### PR TITLE
[BE-5] feat: HttpContentCache처리 #9

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/HttpContentCacheFilter.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/HttpContentCacheFilter.java
@@ -6,6 +6,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
@@ -15,7 +16,9 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 public class HttpContentCacheFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(
-            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            @NotNull HttpServletRequest request,
+            @NotNull HttpServletResponse response,
+            FilterChain chain)
             throws ServletException, IOException {
 
         ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/HttpContentCacheFilter.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/HttpContentCacheFilter.java
@@ -1,0 +1,29 @@
+package com.jnu.ticketapi.config;
+
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+@Component
+public class HttpContentCacheFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappingResponse =
+                new ContentCachingResponseWrapper(response);
+
+        chain.doFilter(wrappingRequest, wrappingResponse);
+
+        wrappingResponse.copyBodyToResponse();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/ServletFilterConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/ServletFilterConfig.java
@@ -1,0 +1,57 @@
+package com.jnu.ticketapi.config;
+
+
+import javax.servlet.Filter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.resource.ResourceUrlEncodingFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@Profile({"prod", "dev", "local"})
+public class ServletFilterConfig implements WebMvcConfigurer {
+
+    private final HttpContentCacheFilter httpContentCacheFilter;
+    private final ForwardedHeaderFilter forwardedHeaderFilter;
+
+    @Bean
+    public FilterRegistrationBean<Filter> securityFilterChain(
+            @Qualifier(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
+                    Filter securityFilter) {
+        FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>(securityFilter);
+        registration.setOrder(Integer.MAX_VALUE - 3);
+        registration.setName(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME);
+        return registration;
+    }
+
+    @Bean
+    public FilterRegistrationBean<Filter> setResourceUrlEncodingFilter() {
+        FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new ResourceUrlEncodingFilter());
+        registrationBean.setOrder(Integer.MAX_VALUE - 2);
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<Filter> setForwardedHeaderFilterOrder() {
+        FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(forwardedHeaderFilter);
+        registrationBean.setOrder(Integer.MAX_VALUE - 1);
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<Filter> setHttpContentCacheFilterOrder() {
+        FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(httpContentCacheFilter);
+        registrationBean.setOrder(Integer.MAX_VALUE);
+        return registrationBean;
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebForwardedHeaderConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebForwardedHeaderConfig.java
@@ -1,0 +1,14 @@
+package com.jnu.ticketapi.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+
+@Configuration
+public class WebForwardedHeaderConfig {
+    @Bean
+    ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
- ContentCache 기능과 X-Forwarded-XXX header를 처리하기 위한 세팅입니다.

## 리뷰어에게...
- ForwardedHeader 의 Bean을 주입시켜주는 레이어를 Application에서 별도의 Config를 만들어서 주입을 해주었습니다.
지금의 Bean 생성방식이 좋아 보이지는 않아서 나중에 Web 별도의 Configuration을 설계하면 그 곳으로 migration하겠습니다.

- 부가 설명 : ForwardedHeader는 사용자 ip를 servlet에 전달받기 위해서 추가하는 겁니다.
https://hwan-shell.tistory.com/381 를 참고해보시길 바랍니다.
## 관련 이슈

closes
- closed #9 
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정