### PR TITLE
[BE-27] : hotfix: SecurityConfig 수정

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/SecurityConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/SecurityConfig.java
@@ -11,7 +11,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -94,8 +93,8 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) ->
                 web.ignoring()
-                        .antMatchers(HttpMethod.POST, "/v1/auth/login")
-                        .antMatchers(HttpMethod.GET, "/error")
+                        .antMatchers("/v1/auth/login")
+                        .antMatchers("/error")
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                         .requestMatchers(PathRequest.toH2Console());
     }


### PR DESCRIPTION
## 주요 변경사항
- /v1/auth/login 요청을 post뿐만 아니라 다른 HttpMethod도 filter 안거치게 수정
## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정