### PR TITLE
[Hotfix] refactor: 배포 서버의 hibernate ddl-auto을 임시로 create-drop 으로 설정

### DIFF
--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -71,7 +71,7 @@ spring:
       hibernate:
         default_batch_fetch_size: ${JPA_BATCH_FETCH_SIZE:100}
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     database-platform: org.hibernate.dialect.MySQL8Dialect
 logging:
   level:
@@ -97,5 +97,5 @@ spring:
       hibernate:
         default_batch_fetch_size: ${JPA_BATCH_FETCH_SIZE:100}
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create-drop
     database-platform: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## 주요 변경사항

[Hotfix] refactor: 배포 서버의 hibernate ddl-auto을 임시로 create-drop 으로 설정

## 리뷰어에게...

## 관련 이슈

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정