### PR TITLE
[BE-32] feat: 학생회 회원가입

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/controller/CaptchaController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/controller/CaptchaController.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.captcha.controller;
 
+
 import com.jnu.ticketapi.api.captcha.model.response.CaptchaPendingResponse;
 import com.jnu.ticketapi.api.captcha.service.GetCaptchaPendingUseCase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class CaptchaController {
 
     private final GetCaptchaPendingUseCase getCaptchaPendingUseCase;
-
 
     @GetMapping("/captcha")
     @Operation()

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/model/response/CaptchaPendingResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/model/response/CaptchaPendingResponse.java
@@ -1,12 +1,10 @@
 package com.jnu.ticketapi.api.captcha.model.response;
 
+
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
 import lombok.Builder;
 
-public record CaptchaPendingResponse(
-        Long captchaId,
-        String captchaImageUrl
-) {
+public record CaptchaPendingResponse(Long captchaId, String captchaImageUrl) {
     @Builder
     public CaptchaPendingResponse {}
 
@@ -16,7 +14,10 @@ public record CaptchaPendingResponse(
     public static CaptchaPendingResponse of(CaptchaPending captchaPending) {
         return CaptchaPendingResponse.builder()
                 .captchaId(captchaPending.getCaptcha().getId())
-                .captchaImageUrl(CLOUD_FRONT_URL +  captchaPending.getCaptcha().getImageName() + IMAGE_POSTFIX)
+                .captchaImageUrl(
+                        CLOUD_FRONT_URL
+                                + captchaPending.getCaptcha().getImageName()
+                                + IMAGE_POSTFIX)
                 .build();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaPendingUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaPendingUseCase.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.captcha.service;
 
+
 import com.jnu.ticketapi.api.captcha.model.response.CaptchaPendingResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaPendingUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaPendingUseCase.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.captcha.service;
 
+
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaPendingAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
@@ -20,7 +21,7 @@ public class ValidateCaptchaPendingUseCase {
         CaptchaPending captchaPending = captchaPendingAdaptor.findById(captchaPendingId);
 
         if (captchaPending.validate(answer)) {
-          captchaPending.confirm();
+            captchaPending.confirm();
         } else {
             throw WrongCaptchaAnswerException.EXCEPTION;
         }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/controller/CouncilController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/controller/CouncilController.java
@@ -1,0 +1,32 @@
+package com.jnu.ticketapi.api.council.controller;
+
+
+import com.jnu.ticketapi.api.council.model.request.SignUpCouncilRequest;
+import com.jnu.ticketapi.api.council.model.response.SignUpCouncilResponse;
+import com.jnu.ticketapi.api.council.service.CouncilUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SecurityRequirement(name = "access-token")
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+@Tag(name = "6. [학생회]")
+public class CouncilController {
+    private final CouncilUseCase councilUseCase;
+
+    @Operation(summary = "학생회 회원가입", description = "학생회 회원가입")
+    @PostMapping("/council/signup")
+    public ResponseEntity<SignUpCouncilResponse> signUpCouncil(
+            @RequestBody SignUpCouncilRequest signUpCouncilRequest) {
+        SignUpCouncilResponse responseDto = councilUseCase.signUp(signUpCouncilRequest);
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/model/request/SignUpCouncilRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/model/request/SignUpCouncilRequest.java
@@ -1,0 +1,26 @@
+package com.jnu.ticketapi.api.council.model.request;
+
+
+import com.jnu.ticketdomain.domains.council.domain.Council;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserRole;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public record SignUpCouncilRequest(String email, String pwd, String name, String phoneNum) {
+    public User toUserEntity(SignUpCouncilRequest signUpCouncilRequest) {
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        return User.builder()
+                .email(signUpCouncilRequest.email())
+                .pwd(passwordEncoder.encode(signUpCouncilRequest.pwd()))
+                .userRole(UserRole.USER)
+                .build();
+    }
+
+    public Council toCouncilEntity(SignUpCouncilRequest signUpCouncilRequest, User user) {
+        return Council.builder()
+                .name(signUpCouncilRequest.name())
+                .phoneNum(signUpCouncilRequest.phoneNum())
+                .user(user)
+                .build();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/model/response/SignUpCouncilResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/model/response/SignUpCouncilResponse.java
@@ -1,0 +1,11 @@
+package com.jnu.ticketapi.api.council.model.response;
+
+
+import lombok.Builder;
+
+@Builder
+public record SignUpCouncilResponse(String message) {
+    public static SignUpCouncilResponse of(String message) {
+        return SignUpCouncilResponse.builder().message(message).build();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
@@ -1,0 +1,32 @@
+package com.jnu.ticketapi.api.council.service;
+
+
+import com.jnu.ticketapi.api.council.model.request.SignUpCouncilRequest;
+import com.jnu.ticketapi.api.council.model.response.SignUpCouncilResponse;
+import com.jnu.ticketcommon.annotation.UseCase;
+import com.jnu.ticketcommon.message.ResponseMessage;
+import com.jnu.ticketdomain.domains.council.adaptor.CouncilAdaptor;
+import com.jnu.ticketdomain.domains.council.domain.Council;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class CouncilUseCase {
+    private final CouncilAdaptor councilAdaptor;
+
+    @Transactional(readOnly = true)
+    public User findByEmail(String email) {
+        return councilAdaptor.findByEmail(email);
+    }
+
+    @Transactional
+    public SignUpCouncilResponse signUp(SignUpCouncilRequest signUpCouncilRequest) {
+        User user = signUpCouncilRequest.toUserEntity(signUpCouncilRequest);
+        Council council = signUpCouncilRequest.toCouncilEntity(signUpCouncilRequest, user);
+        councilAdaptor.saveUser(user);
+        councilAdaptor.saveCouncil(council);
+        return SignUpCouncilResponse.of(ResponseMessage.SUCCESS_SIGN_UP);
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/SecurityConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/SecurityConfig.java
@@ -23,7 +23,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtGenerator jwtGenerator;
@@ -102,7 +102,8 @@ public class SecurityConfig {
                         .antMatchers(HttpMethod.OPTIONS, "/v1/notice")
                         .antMatchers(HttpMethod.GET, "/v1/announce/**", "/v1/announce")
                         .antMatchers(HttpMethod.OPTIONS, "/v1/announce/**", "/v1/announce")
-                        .antMatchers("/v1/auth/login")
+                        .antMatchers("/v1/auth/login/**")
+                        .antMatchers("/v1/council/signup")
                         .antMatchers("/error")
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
         //                        .requestMatchers(PathRequest.toH2Console());

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
@@ -12,6 +12,5 @@ public class ResponseMessage {
     public static final String USER_NOT_FOUND_MESSAGE = "유저를 찾을 수 없습니다";
     public static final String SUCCESS_SIGN_UP = "회원가입이 완료 되었습니다.";
 
-    private ResponseMessage() {
-    }
+    private ResponseMessage() {}
 }

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
@@ -10,4 +10,8 @@ public class ResponseMessage {
     public static final String SECTOR_SUCCESS_DELETE_MESSAGE = "성공적으로 구간이 삭제됐습니다";
     public static final String SECTOR_SUCCESS_UPDATE_MESSAGE = "성공적으로 구간이 수정됐습니다";
     public static final String USER_NOT_FOUND_MESSAGE = "유저를 찾을 수 없습니다";
+    public static final String SUCCESS_SIGN_UP = "회원가입이 완료 되었습니다.";
+
+    private ResponseMessage() {
+    }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaAdaptor.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.captcha.adaptor;
 
+
 import com.jnu.ticketcommon.annotation.Adaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.exception.NotFoundCaptchaException;
@@ -14,7 +15,8 @@ public class CaptchaAdaptor implements CaptchaLoadPort {
 
     @Override
     public Captcha findByImageName(String imageName) {
-        return captchaRepository.findByImageName(imageName)
+        return captchaRepository
+                .findByImageName(imageName)
                 .orElseThrow(() -> NotFoundCaptchaException.EXCEPTION);
     }
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaPendingAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaPendingAdaptor.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 public class CaptchaPendingAdaptor implements CaptchaPendingLoadPort, CaptchaPendingRecordPort {
     private final CaptchaPendingRepository captchaPendingRepository;
 
-
     @Override
     public CaptchaPending save(CaptchaPending captchaPending) {
         return captchaPendingRepository.save(captchaPending);
@@ -22,7 +21,8 @@ public class CaptchaPendingAdaptor implements CaptchaPendingLoadPort, CaptchaPen
 
     @Override
     public CaptchaPending findById(Long id) {
-        return captchaPendingRepository.findById(id)
+        return captchaPendingRepository
+                .findById(id)
                 .orElseThrow(() -> NotFoundCaptchaPendingException.EXCEPTION);
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/Captcha.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/Captcha.java
@@ -1,12 +1,12 @@
 package com.jnu.ticketdomain.domains.captcha.domain;
 
+
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import javax.persistence.*;
 
 @Entity
 @Table(name = "captcha_tb")
@@ -15,7 +15,8 @@ import javax.persistence.*;
 @EntityListeners(AuditingEntityListener.class)
 public class Captcha {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "answer", nullable = false)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
@@ -1,13 +1,13 @@
 package com.jnu.ticketdomain.domains.captcha.domain;
 
+
+import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import javax.persistence.*;
 
 @Entity
 @Table(name = "captcha_pending_tb")
@@ -16,7 +16,8 @@ import javax.persistence.*;
 @EntityListeners(AuditingEntityListener.class)
 public class CaptchaPending {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "is_pending", nullable = false)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
@@ -1,16 +1,15 @@
 package com.jnu.ticketdomain.domains.captcha.exception;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.BAD_REQUEST;
+import static com.jnu.ticketcommon.consts.TicketStatic.NOT_FOUND;
+
 import com.jnu.ticketcommon.annotation.ExplainError;
 import com.jnu.ticketcommon.exception.BaseErrorCode;
 import com.jnu.ticketcommon.exception.ErrorReason;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.lang.reflect.Field;
 import java.util.Objects;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.BAD_REQUEST;
-import static com.jnu.ticketcommon.consts.TicketStatic.NOT_FOUND;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @Getter
 @AllArgsConstructor

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/NotFoundCaptchaException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/NotFoundCaptchaException.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.captcha.exception;
 
+
 import com.jnu.ticketcommon.exception.TicketCodeException;
 
 public class NotFoundCaptchaException extends TicketCodeException {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/NotFoundCaptchaPendingException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/NotFoundCaptchaPendingException.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.captcha.exception;
 
+
 import com.jnu.ticketcommon.exception.TicketCodeException;
 
 public class NotFoundCaptchaPendingException extends TicketCodeException {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/WrongCaptchaAnswerException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/WrongCaptchaAnswerException.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.captcha.exception;
 
+
 import com.jnu.ticketcommon.exception.TicketCodeException;
 
 public class WrongCaptchaAnswerException extends TicketCodeException {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaLoadPort.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.captcha.out;
 
+
 import com.jnu.ticketcommon.annotation.Port;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaPendingLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaPendingLoadPort.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.captcha.out;
 
+
 import com.jnu.ticketcommon.annotation.Port;
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaPendingRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaPendingRecordPort.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.captcha.out;
 
+
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
 
 public interface CaptchaPendingRecordPort {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaPendingRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaPendingRepository.java
@@ -1,10 +1,10 @@
 package com.jnu.ticketdomain.domains.captcha.repository;
 
+
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
 
 public interface CaptchaPendingRepository extends JpaRepository<CaptchaPending, Long> {
     @EntityGraph(attributePaths = {"captcha"})

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
@@ -1,10 +1,10 @@
 package com.jnu.ticketdomain.domains.captcha.repository;
 
+
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
-import java.util.Optional;
 
 public interface CaptchaRepository extends JpaRepository<Captcha, Long> {
     Optional<Captcha> findByImageName(String imageName);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/adaptor/CouncilAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/adaptor/CouncilAdaptor.java
@@ -1,0 +1,34 @@
+package com.jnu.ticketdomain.domains.council.adaptor;
+
+
+import com.jnu.ticketcommon.annotation.Adaptor;
+import com.jnu.ticketdomain.domains.council.domain.Council;
+import com.jnu.ticketdomain.domains.council.out.CouncilLoadPort;
+import com.jnu.ticketdomain.domains.council.out.CouncilRecordPort;
+import com.jnu.ticketdomain.domains.council.repository.CouncilRepository;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.exception.NotFoundUserException;
+import com.jnu.ticketdomain.domains.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Adaptor
+@RequiredArgsConstructor
+public class CouncilAdaptor implements CouncilLoadPort, CouncilRecordPort {
+    private final UserRepository userRepository;
+    private final CouncilRepository councilRepository;
+
+    @Override
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(() -> NotFoundUserException.EXCEPTION);
+    }
+
+    @Override
+    public User saveUser(User user) {
+        return userRepository.save(user);
+    }
+
+    @Override
+    public Council saveCouncil(Council council) {
+        return councilRepository.save(council);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/domain/Council.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/domain/Council.java
@@ -1,0 +1,36 @@
+package com.jnu.ticketdomain.domains.council.domain;
+
+
+import com.jnu.ticketdomain.domains.user.domain.User;
+import javax.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Getter
+@Table(name = "council_tb")
+public class Council {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "phone_num", nullable = false)
+    private String phoneNum;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public Council(String name, String phoneNum, User user) {
+        this.name = name;
+        this.phoneNum = phoneNum;
+        this.user = user;
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/out/CouncilLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/out/CouncilLoadPort.java
@@ -1,0 +1,8 @@
+package com.jnu.ticketdomain.domains.council.out;
+
+
+import com.jnu.ticketdomain.domains.user.domain.User;
+
+public interface CouncilLoadPort {
+    User findByEmail(String email);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/out/CouncilRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/out/CouncilRecordPort.java
@@ -1,0 +1,13 @@
+package com.jnu.ticketdomain.domains.council.out;
+
+
+import com.jnu.ticketcommon.annotation.Port;
+import com.jnu.ticketdomain.domains.council.domain.Council;
+import com.jnu.ticketdomain.domains.user.domain.User;
+
+@Port
+public interface CouncilRecordPort {
+    User saveUser(User user);
+
+    Council saveCouncil(Council council);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/repository/CouncilRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/repository/CouncilRepository.java
@@ -1,0 +1,7 @@
+package com.jnu.ticketdomain.domains.council.repository;
+
+
+import com.jnu.ticketdomain.domains.council.domain.Council;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouncilRepository extends JpaRepository<Council, Long> {}


### PR DESCRIPTION
## 주요 변경사항
학생회 회원가입
## 리뷰어에게...
학생회 로그인과 마친가지로
일반 사용자(user)와 학생회(council)은 서로 다른 성질을 지닌 act이고 같은 도메인으로 볼 수 없을 것 같아서 domain쪽도 분리하고 UseCase, Adaptor 도 분리하였습니다.
domain쪽에는 User domain과 중복되는 코드가 있을 겁니다 ex) Port, Adaptor..
코드는 중복되긴 하지만 명확한 책임분리와 유연성이 증가한다는 장점때문에 분리하게 되었습니다.
## 관련 이슈 

closes #68 
- [#68]

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정