### PR TITLE
[BE-27] 캡차 기능 추가

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/controller/CaptchaController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/controller/CaptchaController.java
@@ -1,0 +1,27 @@
+package com.jnu.ticketapi.api.captcha.controller;
+
+import com.jnu.ticketapi.api.captcha.model.response.CaptchaPendingResponse;
+import com.jnu.ticketapi.api.captcha.service.GetCaptchaPendingUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/v1")
+@Tag(name = "7. [캡챠]")
+@RequiredArgsConstructor
+public class CaptchaController {
+
+    private final GetCaptchaPendingUseCase getCaptchaPendingUseCase;
+
+
+    @GetMapping("/captcha")
+    @Operation()
+    public ResponseEntity<CaptchaPendingResponse> getCaptcha() {
+        return ResponseEntity.ok(getCaptchaPendingUseCase.execute());
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/model/response/CaptchaPendingResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/model/response/CaptchaPendingResponse.java
@@ -1,0 +1,22 @@
+package com.jnu.ticketapi.api.captcha.model.response;
+
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
+import lombok.Builder;
+
+public record CaptchaPendingResponse(
+        Long captchaId,
+        String captchaImageUrl
+) {
+    @Builder
+    public CaptchaPendingResponse {}
+
+    private static final String CLOUD_FRONT_URL = "d21f52knjh246f.cloudfront.net/";
+    private static final String IMAGE_POSTFIX = ".png";
+
+    public static CaptchaPendingResponse of(CaptchaPending captchaPending) {
+        return CaptchaPendingResponse.builder()
+                .captchaId(captchaPending.getCaptcha().getId())
+                .captchaImageUrl(CLOUD_FRONT_URL +  captchaPending.getCaptcha().getImageName() + IMAGE_POSTFIX)
+                .build();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaPendingUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaPendingUseCase.java
@@ -1,0 +1,27 @@
+package com.jnu.ticketapi.api.captcha.service;
+
+import com.jnu.ticketapi.api.captcha.model.response.CaptchaPendingResponse;
+import com.jnu.ticketcommon.annotation.UseCase;
+import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
+import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaPendingAdaptor;
+import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class GetCaptchaPendingUseCase {
+
+    private final CaptchaAdaptor captchaAdaptor;
+    private final CaptchaPendingAdaptor captchaPendingAdaptor;
+
+    @Transactional
+    public CaptchaPendingResponse execute() {
+        Captcha captcha = captchaAdaptor.findByRandom();
+        CaptchaPending captchaPending = new CaptchaPending(captcha);
+        return CaptchaPendingResponse.of(captchaPendingAdaptor.save(captchaPending));
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaPendingUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaPendingUseCase.java
@@ -1,0 +1,28 @@
+package com.jnu.ticketapi.api.captcha.service;
+
+import com.jnu.ticketcommon.annotation.UseCase;
+import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaPendingAdaptor;
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
+import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaAnswerException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class ValidateCaptchaPendingUseCase {
+
+    private final CaptchaPendingAdaptor captchaPendingAdaptor;
+
+    @Transactional
+    public void execute(long captchaPendingId, int answer) {
+        CaptchaPending captchaPending = captchaPendingAdaptor.findById(captchaPendingId);
+
+        if (captchaPending.validate(answer)) {
+          captchaPending.confirm();
+        } else {
+            throw WrongCaptchaAnswerException.EXCEPTION;
+        }
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaAdaptor.java
@@ -1,0 +1,20 @@
+package com.jnu.ticketdomain.domains.captcha.adaptor;
+
+import com.jnu.ticketcommon.annotation.Adaptor;
+import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import com.jnu.ticketdomain.domains.captcha.exception.NotFoundCaptchaException;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLoadPort;
+import com.jnu.ticketdomain.domains.captcha.repository.CaptchaRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Adaptor
+public class CaptchaAdaptor implements CaptchaLoadPort {
+    private final CaptchaRepository captchaRepository;
+
+    @Override
+    public Captcha findByImageName(String imageName) {
+        return captchaRepository.findByImageName(imageName)
+                .orElseThrow(() -> NotFoundCaptchaException.EXCEPTION);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaAdaptor.java
@@ -17,4 +17,9 @@ public class CaptchaAdaptor implements CaptchaLoadPort {
         return captchaRepository.findByImageName(imageName)
                 .orElseThrow(() -> NotFoundCaptchaException.EXCEPTION);
     }
+
+    @Override
+    public Captcha findByRandom() {
+        return captchaRepository.findByRandom();
+    }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaPendingAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaPendingAdaptor.java
@@ -1,0 +1,28 @@
+package com.jnu.ticketdomain.domains.captcha.adaptor;
+
+
+import com.jnu.ticketcommon.annotation.Adaptor;
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
+import com.jnu.ticketdomain.domains.captcha.exception.NotFoundCaptchaPendingException;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaPendingLoadPort;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaPendingRecordPort;
+import com.jnu.ticketdomain.domains.captcha.repository.CaptchaPendingRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Adaptor
+public class CaptchaPendingAdaptor implements CaptchaPendingLoadPort, CaptchaPendingRecordPort {
+    private final CaptchaPendingRepository captchaPendingRepository;
+
+
+    @Override
+    public CaptchaPending save(CaptchaPending captchaPending) {
+        return captchaPendingRepository.save(captchaPending);
+    }
+
+    @Override
+    public CaptchaPending findById(Long id) {
+        return captchaPendingRepository.findById(id)
+                .orElseThrow(() -> NotFoundCaptchaPendingException.EXCEPTION);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/Captcha.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/Captcha.java
@@ -1,0 +1,32 @@
+package com.jnu.ticketdomain.domains.captcha.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "captcha_tb")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class Captcha {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "answer", nullable = false)
+    private Integer answer;
+
+    @Column(name = "image_name", nullable = false)
+    private String imageName;
+
+    @Builder
+    public Captcha(Integer answer, String imageName) {
+        this.answer = answer;
+        this.imageName = imageName;
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
@@ -31,4 +31,16 @@ public class CaptchaPending {
     public CaptchaPending(Captcha captcha) {
         this.captcha = captcha;
     }
+
+    public boolean validate(int answer) {
+        if (captcha.getAnswer() != answer) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public void confirm() {
+        isPending = false;
+    }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
@@ -1,0 +1,34 @@
+package com.jnu.ticketdomain.domains.captcha.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "captcha_pending_tb")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class CaptchaPending {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "is_pending", nullable = false)
+    @ColumnDefault("true")
+    private Boolean isPending;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "captcha_id", nullable = false)
+    private Captcha captcha;
+
+    @Builder
+    public CaptchaPending(Captcha captcha) {
+        this.captcha = captcha;
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
@@ -21,7 +21,7 @@ public class CaptchaPending {
 
     @Column(name = "is_pending", nullable = false)
     @ColumnDefault("true")
-    private Boolean isPending;
+    private Boolean isPending = true;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "captcha_id", nullable = false)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
@@ -9,13 +9,15 @@ import lombok.Getter;
 import java.lang.reflect.Field;
 import java.util.Objects;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.BAD_REQUEST;
 import static com.jnu.ticketcommon.consts.TicketStatic.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum CaptchaErrorCode implements BaseErrorCode {
     NOT_FOUND_CAPTCHA(NOT_FOUND, "Captcha_404_1", "존재하지 않는 캡챠입니다."),
-    NOT_FOUND_CAPTCHA_PENDING(NOT_FOUND, "Captcha_404_2", "존재하지 않는 캡챠 인증입니다.");
+    NOT_FOUND_CAPTCHA_PENDING(NOT_FOUND, "Captcha_404_2", "존재하지 않는 캡챠 인증입니다."),
+    WRONG_CAPTCHA_ANSWER(BAD_REQUEST, "Captcha_400_1", "틀린 캡챠 답변입니다.");
 
     private final Integer status;
     private final String code;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
@@ -14,7 +14,8 @@ import static com.jnu.ticketcommon.consts.TicketStatic.NOT_FOUND;
 @Getter
 @AllArgsConstructor
 public enum CaptchaErrorCode implements BaseErrorCode {
-    NOT_FOUND_CAPTCHA(NOT_FOUND, "Captcha_404_1", "존재하지 않는 캡챠입니다.");
+    NOT_FOUND_CAPTCHA(NOT_FOUND, "Captcha_404_1", "존재하지 않는 캡챠입니다."),
+    NOT_FOUND_CAPTCHA_PENDING(NOT_FOUND, "Captcha_404_2", "존재하지 않는 캡챠 인증입니다.");
 
     private final Integer status;
     private final String code;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
@@ -1,0 +1,34 @@
+package com.jnu.ticketdomain.domains.captcha.exception;
+
+import com.jnu.ticketcommon.annotation.ExplainError;
+import com.jnu.ticketcommon.exception.BaseErrorCode;
+import com.jnu.ticketcommon.exception.ErrorReason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum CaptchaErrorCode implements BaseErrorCode {
+    NOT_FOUND_CAPTCHA(NOT_FOUND, "Captcha_404_1", "존재하지 않는 캡챠입니다.");
+
+    private final Integer status;
+    private final String code;
+    private final String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder().reason(reason).code(code).status(status).build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/NotFoundCaptchaException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/NotFoundCaptchaException.java
@@ -1,0 +1,11 @@
+package com.jnu.ticketdomain.domains.captcha.exception;
+
+import com.jnu.ticketcommon.exception.TicketCodeException;
+
+public class NotFoundCaptchaException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new NotFoundCaptchaException();
+
+    private NotFoundCaptchaException() {
+        super(CaptchaErrorCode.NOT_FOUND_CAPTCHA);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/NotFoundCaptchaPendingException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/NotFoundCaptchaPendingException.java
@@ -1,0 +1,11 @@
+package com.jnu.ticketdomain.domains.captcha.exception;
+
+import com.jnu.ticketcommon.exception.TicketCodeException;
+
+public class NotFoundCaptchaPendingException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new NotFoundCaptchaPendingException();
+
+    private NotFoundCaptchaPendingException() {
+        super(CaptchaErrorCode.NOT_FOUND_CAPTCHA_PENDING);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/WrongCaptchaAnswerException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/WrongCaptchaAnswerException.java
@@ -1,0 +1,11 @@
+package com.jnu.ticketdomain.domains.captcha.exception;
+
+import com.jnu.ticketcommon.exception.TicketCodeException;
+
+public class WrongCaptchaAnswerException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new WrongCaptchaAnswerException();
+
+    private WrongCaptchaAnswerException() {
+        super(CaptchaErrorCode.WRONG_CAPTCHA_ANSWER);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaLoadPort.java
@@ -1,0 +1,9 @@
+package com.jnu.ticketdomain.domains.captcha.out;
+
+import com.jnu.ticketcommon.annotation.Port;
+import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+
+@Port
+public interface CaptchaLoadPort {
+    Captcha findByImageName(String imageName);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaLoadPort.java
@@ -6,4 +6,6 @@ import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 @Port
 public interface CaptchaLoadPort {
     Captcha findByImageName(String imageName);
+
+    Captcha findByRandom();
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaPendingLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaPendingLoadPort.java
@@ -1,0 +1,9 @@
+package com.jnu.ticketdomain.domains.captcha.out;
+
+import com.jnu.ticketcommon.annotation.Port;
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
+
+@Port
+public interface CaptchaPendingLoadPort {
+    CaptchaPending findById(Long id);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaPendingRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaPendingRecordPort.java
@@ -1,0 +1,7 @@
+package com.jnu.ticketdomain.domains.captcha.out;
+
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
+
+public interface CaptchaPendingRecordPort {
+    CaptchaPending save(CaptchaPending captchaPending);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaPendingRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaPendingRepository.java
@@ -1,0 +1,12 @@
+package com.jnu.ticketdomain.domains.captcha.repository;
+
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CaptchaPendingRepository extends JpaRepository<CaptchaPending, Long> {
+    @EntityGraph(attributePaths = {"captcha"})
+    Optional<CaptchaPending> findById(Long id);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 public interface CaptchaRepository extends JpaRepository<Captcha, Long> {
     Optional<Captcha> findByImageName(String imageName);
 
-    @Query("select c from Captcha c order by rand() limit 1")
+    @Query("select c from Captcha c order by rand()")
     Captcha findByRandom();
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
@@ -1,0 +1,10 @@
+package com.jnu.ticketdomain.domains.captcha.repository;
+
+import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CaptchaRepository extends JpaRepository<Captcha, Long> {
+    Optional<Captcha> findByImageName(String imageName);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
@@ -2,9 +2,13 @@ package com.jnu.ticketdomain.domains.captcha.repository;
 
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface CaptchaRepository extends JpaRepository<Captcha, Long> {
     Optional<Captcha> findByImageName(String imageName);
+
+    @Query("select c from Captcha c order by rand() limit 1")
+    Captcha findByRandom();
 }

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -71,7 +71,7 @@ spring:
       hibernate:
         default_batch_fetch_size: ${JPA_BATCH_FETCH_SIZE:100}
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL8Dialect
 logging:
   level:
@@ -97,5 +97,5 @@ spring:
       hibernate:
         default_batch_fetch_size: ${JPA_BATCH_FETCH_SIZE:100}
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## 주요 변경사항

- 캡챠 도메인 추가
- 클라이언트가 캡차를 로드하는 API 추가
- 캡챠를 검증하는 ValidateCaptchaUseCase 추가

## 리뷰어에게...

- 클라이언트가 캡차를 로드할 때 마다, CAPTCHA_PENDING 테이블에 기록됩니다. 캡챠를 사용할 주차권 신청 동안 최대한 서버의 부하를 줄이기 위해, 캡챠가 검증되어도 CAPTCHA_PENDING에서 데이터를 지우지는 않고 isPending을 false로 변경합니다.

- @pyg410  @LJH098  주차권 신청 도메인 서비스에서 갭챠 검증 로직 추가해주세요. 비즈니스 코드 내부에서 사용할 것이라고 생각해서 따로 API 만들지 않고 UseCase만 만들었습니다.

- 캡챠 이미지와 디비 정보는 이미 S3와 production DB에 저장했습니다.

- 캡챠 이미지 손실 방시를 위해, ddl-auto도 update로 변경합니다.

- 티켓 번호 (27)이 겹치네요. 이슈 확인하고 티켓 번호 사용해주세요~

## 관련 이슈

closes #62 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정