### PR TITLE
[Hotfix] AWS SES env 값들이 배포서버에서 적용되지 않는 버그를 해결

### DIFF
--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -69,7 +69,11 @@ jib {
                 'MYSQL_DATABASE': System.getenv("MYSQL_DATABASE"),
                 'MYSQL_USERNAME': System.getenv("MYSQL_USERNAME"),
                 'MYSQL_PASSWORD': System.getenv("MYSQL_PASSWORD"),
-                'JWT_SECRET'    : System.getenv("JWT_SECRET")
+                'JWT_SECRET'    : System.getenv("JWT_SECRET"),
+                'AWS_SES_ACCESS_KEY': System.getenv("AWS_SES_ACCESS_KEY"),
+                'AWS_SES_SECRET_KEY': System.getenv("AWS_SES_SECRET_KEY"),
+                'AWS_SES_REGION': System.getenv("AWS_SES_REGION"),
+                'AWS_SES_SEND_MAIL_ADDRESS': System.getenv("AWS_SES_SEND_MAIL_ADDRESS")
         ]
         ports = ['8080']
     }


### PR DESCRIPTION
## 주요 변경사항

build.gradle 단에서 env값을 추가해서 AWS SES env 값들이 배포서버에서 적용되지 않는 버그를 해결

## 리뷰어에게...

마이너한 핫픽스이므로 리뷰없이 바로 머지합니다

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정