### PR TITLE
[BE-47] refactor: 임시저장 /1차신청

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
@@ -1,6 +1,9 @@
 package com.jnu.ticketapi.api.registration.model.request;
 
 
+import com.jnu.ticketdomain.domains.coupon.domain.Sector;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.User;
 import java.util.Optional;
 import lombok.Builder;
 
@@ -13,4 +16,20 @@ public record FinalSaveRequest(
         boolean isLight,
         String phoneNum,
         Long selectSectorId,
-        Optional<Long> registrationId) {}
+        Optional<Long> registrationId) {
+    public Registration toEntity(
+            FinalSaveRequest requestDto, Sector sector, String email, User user) {
+        return Registration.builder()
+                .email(email)
+                .name(requestDto.name())
+                .studentNum(requestDto.studentNum())
+                .affiliation(requestDto.affiliation())
+                .carNum(requestDto.carNum())
+                .isLight(requestDto.isLight())
+                .phoneNum(requestDto.phoneNum())
+                .sector(sector)
+                .isSaved(true)
+                .user(user)
+                .build();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/TemporarySaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/TemporarySaveRequest.java
@@ -1,6 +1,9 @@
 package com.jnu.ticketapi.api.registration.model.request;
 
 
+import com.jnu.ticketdomain.domains.coupon.domain.Sector;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.User;
 import lombok.Builder;
 
 @Builder
@@ -11,4 +14,20 @@ public record TemporarySaveRequest(
         String carNum,
         boolean isLight,
         String phoneNum,
-        Long selectSectorId) {}
+        Long selectSectorId) {
+    public Registration toEntity(
+            TemporarySaveRequest requestDto, Sector sector, String email, User user) {
+        return Registration.builder()
+                .email(email)
+                .name(requestDto.name())
+                .studentNum(requestDto.studentNum())
+                .affiliation(requestDto.affiliation())
+                .carNum(requestDto.carNum())
+                .isLight(requestDto.isLight())
+                .phoneNum(requestDto.phoneNum())
+                .sector(sector)
+                .isSaved(false)
+                .user(user)
+                .build();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/response/FinalSaveResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/response/FinalSaveResponse.java
@@ -1,7 +1,16 @@
 package com.jnu.ticketapi.api.registration.model.response;
 
 
+import com.jnu.ticketcommon.message.ResponseMessage;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import lombok.Builder;
 
 @Builder
-public record FinalSaveResponse(Long registrationId, String message) {}
+public record FinalSaveResponse(String email, String message) {
+    public static FinalSaveResponse of(Registration registration) {
+        return FinalSaveResponse.builder()
+                .email(registration.getEmail())
+                .message(ResponseMessage.SUCCESS_FINAL_SAVE)
+                .build();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/response/TemporarySaveResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/response/TemporarySaveResponse.java
@@ -1,7 +1,16 @@
 package com.jnu.ticketapi.api.registration.model.response;
 
 
+import com.jnu.ticketcommon.message.ResponseMessage;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import lombok.Builder;
 
 @Builder
-public record TemporarySaveResponse(Long registrationId, String message) {}
+public record TemporarySaveResponse(String email, String message) {
+    public static TemporarySaveResponse of(Registration registration) {
+        return TemporarySaveResponse.builder()
+                .email(registration.getEmail())
+                .message(ResponseMessage.SUCCESS_TEMPORARY_SAVE)
+                .build();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -11,7 +11,6 @@ import com.jnu.ticketapi.api.registration.model.response.TemporarySaveResponse;
 import com.jnu.ticketapi.application.helper.Converter;
 import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
-import com.jnu.ticketcommon.message.ResponseMessage;
 import com.jnu.ticketdomain.domains.coupon.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.coupon.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
@@ -19,6 +18,7 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,12 +31,12 @@ public class RegistrationUseCase {
     private final UserAdaptor userAdaptor;
     private final CouponWithDrawUseCase couponWithDrawUseCase;
 
-    public Registration findByUserId(Long userId) {
-        return registrationAdaptor.findByUserId(userId);
-    }
-
     public Registration save(Registration registration) {
         return registrationAdaptor.save(registration);
+    }
+
+    public Optional<Registration> findByEmail(String email) {
+        return registrationAdaptor.findByEmail(email);
     }
 
     public User findById(Long userId) {
@@ -45,11 +45,10 @@ public class RegistrationUseCase {
 
     @Transactional(readOnly = true)
     public GetRegistrationResponse getRegistration(String email) {
-        Long currentUserId = SecurityUtils.getCurrentUserId();
-        Registration registration = findByUserId(currentUserId);
+        Optional<Registration> registration = findByEmail(email);
         List<Sector> sectorList = sectorAdaptor.findAll();
         // 신청자가 임시저장을 하지 않았을 경우
-        if (registration == null) {
+        if (registration.isEmpty()) {
             return GetRegistrationResponse.builder()
                     .sectors(converter.toSectorDto(sectorList))
                     .email(email)
@@ -57,7 +56,7 @@ public class RegistrationUseCase {
         }
         // 신청자가 임시저장을 했을 경우
         return converter.toGetRegistrationResponseDto(
-                email, registration, converter.toSectorDto(sectorList));
+                email, registration.get(), converter.toSectorDto(sectorList));
     }
 
     @Transactional
@@ -65,10 +64,14 @@ public class RegistrationUseCase {
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
         Sector sector = sectorAdaptor.findById(requestDto.selectSectorId());
-        Registration registration =
-                converter.temporaryToRegistration(requestDto, sector, email, user);
+        Registration registration = requestDto.toEntity(requestDto, sector, email, user);
+        Optional<Registration> temporaryRegistration = findByEmail(email);
+        if (temporaryRegistration.isPresent()) {
+            temporaryRegistration.get().update(registration);
+            return TemporarySaveResponse.of(temporaryRegistration.get());
+        }
         Registration jpaRegistration = save(registration);
-        return converter.toTemporarySaveResponseDto(jpaRegistration);
+        return TemporarySaveResponse.of(jpaRegistration);
     }
 
     @Transactional
@@ -76,22 +79,18 @@ public class RegistrationUseCase {
         /*
         임시저장을 했으면 isSave만 true로 변경
          */
-        Long registrationId = requestDto.registrationId().orElse(null);
-        if (registrationId != null) {
-            Registration registration = registrationAdaptor.findById(registrationId);
-            registration.updateIsSaved(true);
-            return FinalSaveResponse.builder()
-                    .registrationId(registration.getId())
-                    .message(ResponseMessage.SUCCESS_FINAL_SAVE)
-                    .build();
+        Optional<Registration> temporaryRegistration = findByEmail(email);
+        if (temporaryRegistration.isPresent()) {
+            temporaryRegistration.get().updateIsSaved(true);
+            return FinalSaveResponse.of(temporaryRegistration.get());
         }
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
         Sector sector = sectorAdaptor.findById(requestDto.selectSectorId());
-        Registration registration = converter.finalToRegistration(requestDto, sector, email, user);
+        Registration registration = requestDto.toEntity(requestDto, sector, email, user);
         Registration jpaRegistration = save(registration);
         couponWithDrawUseCase.issueCoupon();
-        return converter.toFinalSaveResponseDto(jpaRegistration);
+        return FinalSaveResponse.of(jpaRegistration);
     }
 
     @Transactional(readOnly = true)

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Converter.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Converter.java
@@ -3,17 +3,11 @@ package com.jnu.ticketapi.application.helper;
 
 import com.jnu.ticketapi.api.auth.model.internal.TokenDto;
 import com.jnu.ticketapi.api.auth.model.response.LoginCouncilResponse;
-import com.jnu.ticketapi.api.registration.model.request.FinalSaveRequest;
-import com.jnu.ticketapi.api.registration.model.request.TemporarySaveRequest;
-import com.jnu.ticketapi.api.registration.model.response.FinalSaveResponse;
 import com.jnu.ticketapi.api.registration.model.response.GetRegistrationResponse;
-import com.jnu.ticketapi.api.registration.model.response.TemporarySaveResponse;
 import com.jnu.ticketapi.api.sector.model.internal.SectorDto;
 import com.jnu.ticketcommon.annotation.Helper;
-import com.jnu.ticketcommon.message.ResponseMessage;
 import com.jnu.ticketdomain.domains.coupon.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
-import com.jnu.ticketdomain.domains.user.domain.User;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,52 +37,6 @@ public class Converter {
                 .phoneNum(registration.getPhoneNum())
                 .sectors(sectorDtoList)
                 .selectSectorId(registration.getSector().getId())
-                .build();
-    }
-
-    public Registration temporaryToRegistration(
-            TemporarySaveRequest requestDto, Sector sector, String email, User user) {
-        return Registration.builder()
-                .email(email)
-                .name(requestDto.name())
-                .studentNum(requestDto.studentNum())
-                .affiliation(requestDto.affiliation())
-                .carNum(requestDto.carNum())
-                .isLight(requestDto.isLight())
-                .phoneNum(requestDto.phoneNum())
-                .sector(sector)
-                .isSaved(false)
-                .user(user)
-                .build();
-    }
-
-    public Registration finalToRegistration(
-            FinalSaveRequest requestDto, Sector sector, String email, User user) {
-        return Registration.builder()
-                .email(email)
-                .name(requestDto.name())
-                .studentNum(requestDto.studentNum())
-                .affiliation(requestDto.affiliation())
-                .carNum(requestDto.carNum())
-                .isLight(requestDto.isLight())
-                .phoneNum(requestDto.phoneNum())
-                .sector(sector)
-                .isSaved(true)
-                .user(user)
-                .build();
-    }
-
-    public TemporarySaveResponse toTemporarySaveResponseDto(Registration registration) {
-        return TemporarySaveResponse.builder()
-                .registrationId(registration.getId())
-                .message(ResponseMessage.SUCCESS_TEMPORARY_SAVE)
-                .build();
-    }
-
-    public FinalSaveResponse toFinalSaveResponseDto(Registration registration) {
-        return FinalSaveResponse.builder()
-                .registrationId(registration.getId())
-                .message(ResponseMessage.SUCCESS_FINAL_SAVE)
                 .build();
     }
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -8,6 +8,7 @@ import com.jnu.ticketdomain.domains.registration.out.RegistrationLoadPort;
 import com.jnu.ticketdomain.domains.registration.out.RegistrationRecordPort;
 import com.jnu.ticketdomain.domains.registration.repository.RegistrationRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -35,5 +36,10 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     @Override
     public List<Registration> findAll() {
         return registrationRepository.findAll();
+    }
+
+    @Override
+    public Optional<Registration> findByEmail(String email) {
+        return registrationRepository.findByEmail(email);
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -18,12 +19,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EntityListeners(AuditingEntityListener.class)
+@DynamicUpdate
 public class Registration {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     // 신청자 이메일
-    @Column(name = "email", nullable = false)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
     // 신청자 이름
     @Column(name = "name", nullable = false)
@@ -91,5 +93,16 @@ public class Registration {
 
     public void updateIsSaved(boolean isSaved) {
         this.isSaved = isSaved;
+    }
+
+    public void update(Registration registration) {
+        this.email = registration.getEmail();
+        this.name = registration.getName();
+        this.studentNum = registration.getStudentNum();
+        this.affiliation = registration.getAffiliation();
+        this.carNum = registration.getCarNum();
+        this.isLight = registration.isLight();
+        this.phoneNum = registration.getPhoneNum();
+        this.sector = registration.getSector();
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
@@ -4,6 +4,7 @@ package com.jnu.ticketdomain.domains.registration.out;
 import com.jnu.ticketcommon.annotation.Port;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import java.util.List;
+import java.util.Optional;
 
 @Port
 public interface RegistrationLoadPort {
@@ -12,4 +13,6 @@ public interface RegistrationLoadPort {
     Registration findById(Long id);
 
     List<Registration> findAll();
+
+    Optional<Registration> findByEmail(String email);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -13,4 +13,6 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
     Optional<Registration> findByUserId(@Param("userId") Long userId);
 
     Optional<Registration> findById(Long id);
+
+    Optional<Registration> findByEmail(String email);
 }


### PR DESCRIPTION
## 주요 변경사항
1. 임시저장 / 1차신청의 고유한 email로 registration을 조회
2. 응답으로 registrationId(pk) 대신 고유안 email 보내주기
3. Optional을 사용하여 코드 깔끔하게 짜기
4. converter 대신 Dto에 toEntity, of 메서드 작성해서 사용
5. [#96] 에서 2번 내용 해결
6. registration Entity에 @DynamicUpdate 적용
## 리뷰어에게...

## 관련 이슈

closes #99 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정