### PR TITLE
[BE-40] bug : 임시저장 / 1차신청

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/controller/CaptchaController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/controller/CaptchaController.java
@@ -4,6 +4,7 @@ package com.jnu.ticketapi.api.captcha.controller;
 import com.jnu.ticketapi.api.captcha.model.response.CaptchaPendingResponse;
 import com.jnu.ticketapi.api.captcha.service.GetCaptchaPendingUseCase;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+@SecurityRequirement(name = "access-token")
 @Controller
 @RequestMapping("/v1")
 @Tag(name = "7. [캡챠]")

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/model/response/CaptchaPendingResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/model/response/CaptchaPendingResponse.java
@@ -4,16 +4,16 @@ package com.jnu.ticketapi.api.captcha.model.response;
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaPending;
 import lombok.Builder;
 
-public record CaptchaPendingResponse(Long captchaId, String captchaImageUrl) {
+public record CaptchaPendingResponse(String captchaPendingCode, String captchaImageUrl) {
     @Builder
     public CaptchaPendingResponse {}
 
     private static final String CLOUD_FRONT_URL = "d21f52knjh246f.cloudfront.net/";
     private static final String IMAGE_POSTFIX = ".png";
 
-    public static CaptchaPendingResponse of(CaptchaPending captchaPending) {
+    public static CaptchaPendingResponse of(String code, CaptchaPending captchaPending) {
         return CaptchaPendingResponse.builder()
-                .captchaId(captchaPending.getCaptcha().getId())
+                .captchaPendingCode(code)
                 .captchaImageUrl(
                         CLOUD_FRONT_URL
                                 + captchaPending.getCaptcha().getImageName()

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaPendingUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaPendingUseCase.java
@@ -2,6 +2,7 @@ package com.jnu.ticketapi.api.captcha.service;
 
 
 import com.jnu.ticketapi.api.captcha.model.response.CaptchaPendingResponse;
+import com.jnu.ticketapi.application.helper.Encryption;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaPendingAdaptor;
@@ -18,11 +19,14 @@ public class GetCaptchaPendingUseCase {
 
     private final CaptchaAdaptor captchaAdaptor;
     private final CaptchaPendingAdaptor captchaPendingAdaptor;
+    private final Encryption encryption;
 
     @Transactional
     public CaptchaPendingResponse execute() {
         Captcha captcha = captchaAdaptor.findByRandom();
         CaptchaPending captchaPending = new CaptchaPending(captcha);
-        return CaptchaPendingResponse.of(captchaPendingAdaptor.save(captchaPending));
+        CaptchaPending jpaCaptchaPending = captchaPendingAdaptor.save(captchaPending);
+        String code = encryption.encrypt(jpaCaptchaPending.getId());
+        return CaptchaPendingResponse.of(code, jpaCaptchaPending);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaPendingUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaPendingUseCase.java
@@ -17,7 +17,7 @@ public class ValidateCaptchaPendingUseCase {
     private final CaptchaPendingAdaptor captchaPendingAdaptor;
 
     @Transactional
-    public void execute(long captchaPendingId, int answer) {
+    public void execute(long captchaPendingId, String answer) {
         CaptchaPending captchaPending = captchaPendingAdaptor.findById(captchaPendingId);
 
         if (captchaPending.validate(answer)) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/controller/RegistrationController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/controller/RegistrationController.java
@@ -3,10 +3,7 @@ package com.jnu.ticketapi.api.registration.controller;
 
 import com.jnu.ticketapi.api.registration.model.request.FinalSaveRequest;
 import com.jnu.ticketapi.api.registration.model.request.TemporarySaveRequest;
-import com.jnu.ticketapi.api.registration.model.response.FinalSaveResponse;
-import com.jnu.ticketapi.api.registration.model.response.GetRegistrationResponse;
-import com.jnu.ticketapi.api.registration.model.response.GetRegistrationsResponse;
-import com.jnu.ticketapi.api.registration.model.response.TemporarySaveResponse;
+import com.jnu.ticketapi.api.registration.model.response.*;
 import com.jnu.ticketapi.api.registration.service.RegistrationUseCase;
 import com.jnu.ticketapi.common.aop.GetEmail;
 import io.swagger.v3.oas.annotations.Operation;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
@@ -13,4 +13,6 @@ public record FinalSaveRequest(
         boolean isLight,
         String phoneNum,
         Long selectSectorId,
-        Optional<Long> registrationId) {}
+        Optional<Long> registrationId,
+        String captchaPendingCode,
+        String captchaAnswer) {}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
@@ -1,9 +1,9 @@
 package com.jnu.ticketapi.api.registration.model.request;
 
 
-import java.util.Optional;
-
+import com.jnu.ticketdomain.domains.coupon.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.User;
 import lombok.Builder;
 
 @Builder
@@ -17,7 +17,7 @@ public record FinalSaveRequest(
         Long selectSectorId,
         String captchaPendingCode,
         String captchaAnswer) {
-         {
+
     public Registration toEntity(
             FinalSaveRequest requestDto, Sector sector, String email, User user) {
         return Registration.builder()

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/response/GetCaptchaResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/response/GetCaptchaResponse.java
@@ -1,0 +1,3 @@
+package com.jnu.ticketapi.api.registration.model.response;
+
+public record GetCaptchaResponse(String code) {}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -13,7 +13,6 @@ import com.jnu.ticketapi.application.helper.Converter;
 import com.jnu.ticketapi.application.helper.Encryption;
 import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
-import com.jnu.ticketcommon.message.ResponseMessage;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
 import com.jnu.ticketdomain.domains.coupon.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.coupon.domain.Sector;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketapi.api.registration.service;
 
 
+import com.jnu.ticketapi.api.captcha.service.ValidateCaptchaPendingUseCase;
 import com.jnu.ticketapi.api.coupon.service.CouponWithDrawUseCase;
 import com.jnu.ticketapi.api.registration.model.request.FinalSaveRequest;
 import com.jnu.ticketapi.api.registration.model.request.TemporarySaveRequest;
@@ -9,9 +10,11 @@ import com.jnu.ticketapi.api.registration.model.response.GetRegistrationResponse
 import com.jnu.ticketapi.api.registration.model.response.GetRegistrationsResponse;
 import com.jnu.ticketapi.api.registration.model.response.TemporarySaveResponse;
 import com.jnu.ticketapi.application.helper.Converter;
+import com.jnu.ticketapi.application.helper.Encryption;
 import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.message.ResponseMessage;
+import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
 import com.jnu.ticketdomain.domains.coupon.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.coupon.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
@@ -30,6 +33,9 @@ public class RegistrationUseCase {
     private final Converter converter;
     private final UserAdaptor userAdaptor;
     private final CouponWithDrawUseCase couponWithDrawUseCase;
+    private final Encryption encryption;
+    private final CaptchaAdaptor captchaAdaptor;
+    private final ValidateCaptchaPendingUseCase validateCaptchaPendingUseCase;
 
     public Registration findByUserId(Long userId) {
         return registrationAdaptor.findByUserId(userId);
@@ -73,6 +79,8 @@ public class RegistrationUseCase {
 
     @Transactional
     public FinalSaveResponse finalSave(FinalSaveRequest requestDto, String email) {
+        Long captchaPendingId = encryption.decrypt(requestDto.captchaPendingCode());
+        validateCaptchaPendingUseCase.execute(captchaPendingId, requestDto.captchaAnswer());
         /*
         임시저장을 했으면 isSave만 true로 변경
          */

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
@@ -1,0 +1,68 @@
+package com.jnu.ticketapi.application.helper;
+
+
+import com.jnu.ticketcommon.annotation.Helper;
+import com.jnu.ticketcommon.exception.DecryptionErrorException;
+import com.jnu.ticketcommon.exception.EncryptionErrorException;
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+
+@Helper
+@Slf4j
+public class Encryption {
+    @Value("${encryption.algorithm}")
+    private String algorithm;
+
+    @Value("${encryption.secret}")
+    private String secret;
+
+    private SecretKeySpec secretKeySpec;
+
+    private SecretKeySpec generateKey() {
+        try {
+            if (secretKeySpec == null) {
+                byte[] keyBytes = secret.getBytes("UTF-8");
+                MessageDigest sha = MessageDigest.getInstance("SHA-256");
+                keyBytes = sha.digest(keyBytes);
+                keyBytes = Arrays.copyOf(keyBytes, 16); // AES-128을 위한 16바이트 키
+                secretKeySpec = new SecretKeySpec(keyBytes, algorithm);
+            }
+            return secretKeySpec;
+        } catch (Exception e) {
+            log.error("Error during generateKey", e);
+            throw EncryptionErrorException.EXCEPTION;
+        }
+    }
+
+    public String encrypt(Long value) {
+        try {
+            Cipher cipher = Cipher.getInstance(algorithm);
+            cipher.init(Cipher.ENCRYPT_MODE, generateKey());
+            byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(value).array();
+            byte[] encrypted = cipher.doFinal(valueBytes);
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            log.error("Error during encryption", e);
+            throw EncryptionErrorException.EXCEPTION;
+        }
+    }
+
+    public Long decrypt(final String encryptedValue) {
+        try {
+            Cipher cipher = Cipher.getInstance(algorithm);
+            cipher.init(Cipher.DECRYPT_MODE, generateKey());
+            byte[] encryptedBytes = Base64.getDecoder().decode(encryptedValue);
+            byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
+            return ByteBuffer.wrap(decryptedBytes).getLong();
+        } catch (Exception e) {
+            log.error("Error during decryption", e);
+            throw DecryptionErrorException.EXCEPTION;
+        }
+    }
+}

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -50,3 +50,6 @@ server:
       charset: UTF-8
       enabled: true
       force: true
+encryption:
+  algorithm: ${ENCRYPTION_ALGORITHM:AES}
+  secret: ${ENCRYPTION_SECRET:jnu-parking-fighting}

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/dto/SuccessResponse.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/dto/SuccessResponse.java
@@ -1,8 +1,6 @@
 package com.jnu.ticketcommon.dto;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.OK_REQUEST;
 
-import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/DecryptionErrorException.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/DecryptionErrorException.java
@@ -1,0 +1,9 @@
+package com.jnu.ticketcommon.exception;
+
+public class DecryptionErrorException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new DecryptionErrorException();
+
+    private DecryptionErrorException() {
+        super(GlobalErrorCode.DECRYPTION_ERROR);
+    }
+}

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/EncryptionErrorException.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/EncryptionErrorException.java
@@ -1,0 +1,9 @@
+package com.jnu.ticketcommon.exception;
+
+public class EncryptionErrorException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new EncryptionErrorException();
+
+    private EncryptionErrorException() {
+        super(GlobalErrorCode.ENCRYPTION_ERROR);
+    }
+}

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/GlobalErrorCode.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/GlobalErrorCode.java
@@ -53,6 +53,10 @@ public enum GlobalErrorCode implements BaseErrorCode {
     ANNOUNCE_NOT_EXIST_ERROR(NOT_FOUND, "ANNOUNCE_404_2", "공지사항이 존재하지 않습니다."),
     @ExplainError("작성된 안내사항이 존재하지 않습니다.")
     NOTICE_NOT_EXIST_ERROR(NOT_FOUND, "NOTICE_404_1", "안내사항이 존재하지 않습니다."),
+    @ExplainError("서버 내에서 PK 암호화에 오류가 생겼을 때 발생하는 오류입니다.")
+    ENCRYPTION_ERROR(INTERNAL_SERVER, "ENCRYPTION_500_1", "암호화도중 오류가 발생했습니다."),
+    @ExplainError("서버 내에서 PK 복호화에 오류가 생겼을 때 발생하는 오류입니다.")
+    DECRYPTION_ERROR(INTERNAL_SERVER, "DECRYPTION_500_1", "복호화도중 오류가 발생했습니다."),
 
     OTHER_SERVER_BAD_REQUEST(BAD_REQUEST, "FEIGN_400_1", "Other server bad request"),
     OTHER_SERVER_UNAUTHORIZED(BAD_REQUEST, "FEIGN_400_2", "Other server unauthorized"),

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/Captcha.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/Captcha.java
@@ -20,13 +20,13 @@ public class Captcha {
     private Long id;
 
     @Column(name = "answer", nullable = false)
-    private Integer answer;
+    private String answer;
 
     @Column(name = "image_name", nullable = false)
     private String imageName;
 
     @Builder
-    public Captcha(Integer answer, String imageName) {
+    public Captcha(String answer, String imageName) {
         this.answer = answer;
         this.imageName = imageName;
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaPending.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketdomain.domains.captcha.domain;
 
 
+import java.util.Objects;
 import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -33,12 +34,8 @@ public class CaptchaPending {
         this.captcha = captcha;
     }
 
-    public boolean validate(int answer) {
-        if (captcha.getAnswer() != answer) {
-            return false;
-        }
-
-        return true;
+    public boolean validate(String answer) {
+        return Objects.equals(captcha.getAnswer(), answer);
     }
 
     public void confirm() {


### PR DESCRIPTION
## 주요 변경
캡챠 pk를 FE한테 그대로 보내주지 않고 AES 알고리즘을 통해 인코딩을 해서 보내준다. (captchaCode 보내줌)
1차 신청에서 인코딩된 캡쳐 코드를 받아 복호화해서 정답이 맞는지 검사
application.yml 환경변수 처리한거는 노션 env 파일에다가 올려놓음
## 리뷰어에게...

## 관련 이슈

closes #83 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정