### PR TITLE
[BE-49] feat: 1차신청 메일 기능

### DIFF
--- a/Ticket-Api/src/main/resources/templates/registration.html
+++ b/Ticket-Api/src/main/resources/templates/registration.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <title>합격 여부 안내</title>
+</head>
+<body>
+<h2>안녕하세요, <span th:text="${userName}"></span>님</h2>
+
+<p>전남대 정기 주차권 합격여부 알림 메일입니다.</p>
+
+<p>합격 여부: <span th:text="${pass}"></span></p>
+
+<p>더 많은 정보를 보려면 <a th:href="@{http://jnu-parking.com}">여기</a>를 클릭하세요.</p>
+</body>
+</html>

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/mailService/MailServiceTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/mailService/MailServiceTest.java
@@ -1,0 +1,36 @@
+package com.jnu.ticketapi.mailService;
+
+
+import com.jnu.ticketinfrastructure.service.MailService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class MailServiceTest {
+
+    @Autowired private MailService mailService;
+
+    @DisplayName("성공 : 1차신청 결과 메일링 테스트")
+    @Test
+    @WithMockUser(roles = "USER")
+    public void send_email_test() {
+        // given
+        String email = "pon05114@naver.com";
+        String name = "쿠키팍";
+        String status = "1차합격";
+
+        // when
+        boolean result = mailService.sendRegistrationResultMail(email, name, status);
+
+        // then
+        Assertions.assertTrue(result);
+    }
+}

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/MailTemplate.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/MailTemplate.java
@@ -7,4 +7,10 @@ public class MailTemplate {
     public static final String FIND_PASSWORD_CONTEXT = "resetLink";
 
     public static final String URL = "http://jnu-parking.com/password-reset/";
+
+    public static final String REGISTRATION_SUBJECT = "전남대 주차권 신청결과 발표";
+
+    public static final String REGISTRATION_TEMPLATE = "registration";
+    public static final String REGISTRATION_NAME_CONTEXT = "userName";
+    public static final String REGISTRATION_PASS_CONTEXT = "pass";
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/MailService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/MailService.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketinfrastructure.service;
 
 
+import com.jnu.ticketcommon.consts.MailTemplate;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,5 +59,30 @@ public class MailService {
                 .subject(content)
                 .body(Body.builder().html(builder -> builder.data(html)).build())
                 .build();
+    }
+
+    public boolean sendRegistrationResultMail(String email, String name, String status) {
+        try {
+            Context context = newRegistrationContext(name, status);
+            boolean result =
+                    sendMail(
+                            email,
+                            MailTemplate.REGISTRATION_SUBJECT,
+                            MailTemplate.REGISTRATION_TEMPLATE,
+                            context);
+            log.info("신청 결과 메일 발송. 사용자 이메일 : {}, 결과 : {}", email, result);
+            return result;
+        } catch (Exception e) {
+            log.info("신청 결과 메일 발송 실패. 사용자 이메일 : {}, 에러 로그 : {} ", email, e.getMessage());
+            return false;
+        }
+    }
+
+    public static Context newRegistrationContext(String userName, String pass) {
+        Context context = new Context();
+        context.setVariable(MailTemplate.REGISTRATION_NAME_CONTEXT, userName);
+        context.setVariable(MailTemplate.REGISTRATION_PASS_CONTEXT, pass);
+
+        return context;
     }
 }


### PR DESCRIPTION
## 주요 변경사항

- 1차신청 합격여부 메일 기능
- 1차신청 합격여부 메일 기능 단위 테스트

## 리뷰어에게...

통합테스트는 신청기능 담당자분 부탁해여
메일 실패시 log에 에러메세지랑 실패한 사용자 이메일 띄워놨습니당

## 관련 이슈

closes #106 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정