### PR TITLE
[BE-61] feat: CustomEnumDeserializer #128

### DIFF
--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/annotation/EnumClass.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/annotation/EnumClass.java
@@ -2,6 +2,8 @@ package com.jnu.ticketcommon.annotation;
 
 
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.jnu.ticketcommon.deserializer.CustomEnumDeserializer;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -10,5 +12,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @JacksonAnnotationsInside
-// @JsonDeserialize(using = CustomEnumDeserializer.class)
+ @JsonDeserialize(using = CustomEnumDeserializer.class)
 public @interface EnumClass {}

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/deserializer/CustomEnumDeserializer.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/deserializer/CustomEnumDeserializer.java
@@ -1,0 +1,44 @@
+package com.jnu.ticketcommon.deserializer;
+
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class CustomEnumDeserializer extends StdDeserializer<Enum<?>>
+        implements ContextualDeserializer {
+
+    public CustomEnumDeserializer() {
+        this(null);
+    }
+
+    protected CustomEnumDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Enum<?> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        final JsonNode jsonNode = jp.getCodec().readTree(jp);
+        final String text = jsonNode.asText();
+        final Class<? extends Enum> enumType = (Class<? extends Enum>) this._valueClass;
+        if (enumType == null) return null;
+        return Arrays.stream(enumType.getEnumConstants())
+                .filter(value -> value.name().equals(text))
+                .findAny()
+                .orElse(null);
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property)
+            throws JsonMappingException {
+        return new CustomEnumDeserializer(property.getType().getRawClass());
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
- 기존 Enum을 JacksonMessageConverter를 통해 역직렬화를 통해 사용했는데 이때문에 EnumValidator AOP가 걸리지 않았습니다.
때문에  별도로 Deserializer를 걸어서 적용시켰습니다.

```java
    @Override
    public Enum<?> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
        final JsonNode jsonNode = jp.getCodec().readTree(jp);
        final String text = jsonNode.asText();
        final Class<? extends Enum> enumType = (Class<? extends Enum>) this._valueClass;
        if (enumType == null) return null;
        return Arrays.stream(enumType.getEnumConstants())
                .filter(value -> value.name().equals(text))
                .findAny()
                .orElse(null);
    }

```
json 을 Text로 변환시켜  name에 value와 일치시키는지 검증하여 deserializer를 걸어주니 IllegalArgumentException이 발생하지 않아 정상 흐름으로 동작합니다.

## 리뷰어에게...

## 관련 이슈

closes
- closed #128 
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정