### PR TITLE
[BE-63] bug: 토큰 재발급

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/controller/AuthController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import com.jnu.ticketapi.api.auth.model.request.LoginUserRequest;
 import com.jnu.ticketapi.api.auth.model.request.ReissueTokenRequest;
 import com.jnu.ticketapi.api.auth.model.response.*;
 import com.jnu.ticketapi.api.auth.service.AuthUseCase;
+import com.jnu.ticketapi.common.aop.GetEmail;
 import com.jnu.ticketcommon.annotation.ApiErrorExceptionsExample;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -43,10 +44,11 @@ public class AuthController {
     @ApiErrorExceptionsExample(TokenReissueExceptionDocs.class)
     public ResponseEntity<ReissueTokenResponse> reIssue(
             @RequestBody ReissueTokenRequest requestDto,
-            @RequestHeader("Authorization") String bearerToken) {
+            @RequestHeader("Authorization") String bearerToken,
+            @GetEmail String email) {
         String accessToken = authUseCase.extractToken(bearerToken);
         ReissueTokenResponse responseDto =
-                authUseCase.reissue(accessToken, requestDto.refreshToken());
+                authUseCase.reissue(accessToken, requestDto.refreshToken(), email);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/common/aop/EmailMethodArgumentResolver.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/common/aop/EmailMethodArgumentResolver.java
@@ -2,6 +2,7 @@ package com.jnu.ticketapi.common.aop;
 
 
 import com.jnu.ticketapi.security.JwtResolver;
+import com.jnu.ticketcommon.consts.TicketStatic;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -15,7 +16,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class EmailMethodArgumentResolver implements HandlerMethodArgumentResolver {
     private final JwtResolver jwtResolver;
-    private static final String EMAIL_KEY = "Email";
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -34,6 +34,6 @@ public class EmailMethodArgumentResolver implements HandlerMethodArgumentResolve
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String requestAccessTokenInHeader = request.getHeader("Authorization");
         String requestAccessToken = jwtResolver.extractToken(requestAccessTokenInHeader);
-        return jwtResolver.parseClaims(requestAccessToken).get(EMAIL_KEY).toString();
+        return jwtResolver.parseClaims(requestAccessToken).get(TicketStatic.EMAIL_KEY).toString();
     }
 }

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
@@ -8,6 +8,8 @@ public class TicketStatic {
     public static final String TOKEN_ISSUER = "Ticket";
     public static final String ACCESS_TOKEN = "ACCESS_TOKEN";
     public static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+    public static final String SERVER = "Server";
+    public static final String EMAIL_KEY = "Email";
     public static final String CONSTRAINT_VIOLATION_SEPARATOR = "\\.";
     public static final Integer DEVELOPER_COLUMNS_ID = 1;
     public static final Integer DESIGNER_COLUMNS_ID = 2;


### PR DESCRIPTION

## 주요 변경사항
- access, refresh의 principal을 비교하여 같으면 재발급 하는 로직에서 토큰의 claim에있는 email을 비교하여 같으면 재발급 되도록 로직 수정
## 리뷰어에게...
토큰 재발급 테스트 코드를 짜고있었던 중이라 바로 머지하겠습니다.
테스트 코드를 짜던 중 잘 안되서 디버그 찍다가 발견한 오류인데 ... 다시한번 테스트 코드의 중요성을 깨닫고 갑니다.. ㅜㅜ
## 관련 이슈

closes #132 
- [#132]

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정