### PR TITLE
[BE-68] bug : 1차 신청 목록 조회

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -120,7 +120,7 @@ public class RegistrationUseCase {
 
     @Transactional(readOnly = true)
     public GetRegistrationsResponse getRegistrations() {
-        List<Registration> registrations = registrationAdaptor.findAll();
+        List<Registration> registrations = registrationAdaptor.findByIsDeletedFalseAndIsSavedTrue();
         return GetRegistrationsResponse.of(registrations);
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
@@ -5,11 +5,12 @@ import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CaptchaRepository extends JpaRepository<Captcha, Long> {
 
     Optional<Captcha> findById(long id);
 
     @Query(value = "select * from captcha_tb LIMIT 1 OFFSET :offset", nativeQuery = true)
-    Captcha findOneByOffset(long offset);
+    Captcha findOneByOffset(@Param("offset") long offset);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -42,4 +42,9 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     public Optional<Registration> findByEmail(String email) {
         return registrationRepository.findByEmail(email);
     }
+
+    @Override
+    public List<Registration> findByIsDeletedFalseAndIsSavedTrue() {
+        return registrationRepository.findByIsDeletedFalseAndIsSavedTrue();
+    }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -95,6 +95,10 @@ public class Registration {
         this.isSaved = isSaved;
     }
 
+    public void updateIsDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
     public void update(Registration registration) {
         this.email = registration.getEmail();
         this.name = registration.getName();

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
@@ -15,4 +15,6 @@ public interface RegistrationLoadPort {
     List<Registration> findAll();
 
     Optional<Registration> findByEmail(String email);
+
+    List<Registration> findByIsDeletedFalseAndIsSavedTrue();
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -2,6 +2,8 @@ package com.jnu.ticketdomain.domains.registration.repository;
 
 
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +17,5 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
     Optional<Registration> findById(Long id);
 
     Optional<Registration> findByEmail(String email);
+    List<Registration> findByIsDeletedFalseAndIsSavedTrue();
 }


### PR DESCRIPTION
## 주요 변경사항
- Data JPA를 이용하여 isSaved가 true, isDeleted가 false인 것만 조회되도록 수정
- CaptchaRepository의 findOneByOffset에 @param 추가

## 리뷰어에게...
@Kwon770 CaptchaRepository의 findOneByOffset에 @Param 안붙여주니 에러가 떠서 붙여줬습니다. 배포환경에서 왜 잘 되는지 잘 모르겠지만 혹시몰라서 붙여두겠습니다.
## 관련 이슈 

closes #145 
- [#145]
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정