### PR TITLE
[BE-67] feat: 학생 상태(합격자, 예비자...) 변경 #144

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -4,6 +4,7 @@ import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
@@ -28,14 +29,14 @@ public class EventIssuedEventHandler {
             classes = EventIssuedEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handle(EventIssuedEvent EventIssuedEvent) {
-        processEventData(EventIssuedEvent.getCurrentUserId());
-        // 재고가 처리되야만 대기열에서 제거
+    public void handle(EventIssuedEvent eventIssuedEvent) {
+        processEventData(eventIssuedEvent.getCurrentUserId());
         waitingQueueService.popQueue(REDIS_EVENT_ISSUE_STORE, 1, ChatMessage.class);
     }
 
     private void processEventData(Long userId) {
-        Sector sector = registrationAdaptor.findByUserId(userId).getSector();
+        Registration registration = registrationAdaptor.findByUserId(userId);
+        Sector sector = registration.getSector();
         sector.decreaseEventStock();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
@@ -1,0 +1,30 @@
+package com.jnu.ticketapi.api.registration.handler;
+
+
+import com.jnu.ticketdomain.domains.registration.event.RegistrationCreationEvent;
+import com.jnu.ticketinfrastructure.service.MailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RegistrationCreationEventHandler {
+    private final MailService mailService;
+
+    @Async
+    @TransactionalEventListener(
+            classes = RegistrationCreationEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(RegistrationCreationEvent event) {
+        mailService.sendRegistrationResultMail(
+                event.getEmail(), event.getName(), event.getStatus());
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -13,11 +13,15 @@ import com.jnu.ticketapi.application.helper.Converter;
 import com.jnu.ticketapi.application.helper.Encryption;
 import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
+import com.jnu.ticketcommon.utils.Result;
+import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.events.exception.NotFoundEventException;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.registration.event.RegistrationCreationEvent;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.service.MailService;
@@ -36,7 +40,7 @@ public class RegistrationUseCase {
     private final SectorAdaptor sectorAdaptor;
     private final Converter converter;
     private final UserAdaptor userAdaptor;
-    private final EventWithDrawUseCase EventWithDrawUseCase;
+    private final EventWithDrawUseCase eventWithDrawUseCase;
     private final Encryption encryption;
     private final CaptchaAdaptor captchaAdaptor;
     private final ValidateCaptchaUseCase validateCaptchaUseCase;
@@ -48,6 +52,13 @@ public class RegistrationUseCase {
 
     public Optional<Registration> findByEmail(String email) {
         return registrationAdaptor.findByEmail(email);
+    }
+
+    public Result<Registration, Object> findResultByEmail(String email) {
+        Optional<Registration> registration = registrationAdaptor.findByEmail(email);
+        return registration
+                .map(Result::success)
+                .orElseGet(() -> Result.failure(NotFoundEventException.EXCEPTION));
     }
 
     public User findById(Long userId) {
@@ -76,46 +87,48 @@ public class RegistrationUseCase {
         User user = findById(currentUserId);
         Sector sector = sectorAdaptor.findById(requestDto.selectSectorId());
         Registration registration = requestDto.toEntity(requestDto, sector, email, user);
-        Optional<Registration> temporaryRegistration = findByEmail(email);
-        if (temporaryRegistration.isPresent()) {
-            temporaryRegistration.get().update(registration);
-            return TemporarySaveResponse.from(temporaryRegistration.get());
-        }
-        Registration jpaRegistration = save(registration);
-        return TemporarySaveResponse.from(jpaRegistration);
+        return findResultByEmail(email)
+                .fold(
+                        tempRegistration -> {
+                            tempRegistration.update(registration);
+                            return TemporarySaveResponse.from(tempRegistration);
+                        },
+                        emptyCase -> {
+                            Registration jpaRegistration = save(registration);
+                            return TemporarySaveResponse.from(jpaRegistration);
+                        });
     }
 
     @Transactional
     public FinalSaveResponse finalSave(FinalSaveRequest requestDto, String email) {
         Long captchaId = encryption.decrypt(requestDto.captchaCode());
         validateCaptchaUseCase.execute(captchaId, requestDto.captchaAnswer());
-        /*
-        임시저장을 했으면 isSave만 true로 변경
-         */
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
 
         Sector sector = sectorAdaptor.findById(requestDto.selectSectorId());
         Registration registration = requestDto.toEntity(requestDto, sector, email, user);
-        Optional<Registration> temporaryRegistration = findByEmail(email);
-        if (temporaryRegistration.isPresent()) {
-            temporaryRegistration.get().update(registration);
-            temporaryRegistration.get().updateIsSaved(true);
-            mailService.sendRegistrationResultMail(
-                    registration.getEmail(),
-                    registration.getName(),
-                    registration.getUser().getStatus());
-            return FinalSaveResponse.from(temporaryRegistration.get());
-        }
-        Registration jpaRegistration = save(registration);
-        EventWithDrawUseCase.issueEvent(currentUserId);
+        return findResultByEmail(email)
+                .fold(
+                        tempRegistration ->
+                                updateRegistration(tempRegistration, registration, currentUserId),
+                        emptyCase -> saveRegistration(registration, currentUserId));
+    }
 
-        mailService.sendRegistrationResultMail(
-                registration.getEmail(),
-                registration.getName(),
-                registration.getUser().getStatus());
+    private FinalSaveResponse saveRegistration(Registration registration, Long currentUserId) {
+        eventWithDrawUseCase.issueEvent(currentUserId);
+        Events.raise(RegistrationCreationEvent.of(registration));
+        return FinalSaveResponse.from(save(registration));
+    }
 
-        return FinalSaveResponse.from(jpaRegistration);
+    private FinalSaveResponse updateRegistration(
+            Registration temporaryRegistration, Registration registration, Long currentUserId) {
+        // update
+        eventWithDrawUseCase.issueEvent(currentUserId);
+        temporaryRegistration.update(registration);
+        temporaryRegistration.updateIsSaved(true);
+        Events.raise(RegistrationCreationEvent.of(registration));
+        return FinalSaveResponse.from(temporaryRegistration);
     }
 
     @Transactional(readOnly = true)

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -101,8 +101,8 @@ public class RegistrationUseCase {
 
     @Transactional
     public FinalSaveResponse finalSave(FinalSaveRequest requestDto, String email) {
-        Long captchaId = encryption.decrypt(requestDto.captchaCode());
-        validateCaptchaUseCase.execute(captchaId, requestDto.captchaAnswer());
+        //        Long captchaId = encryption.decrypt(requestDto.captchaCode());
+        //        validateCaptchaUseCase.execute(captchaId, requestDto.captchaAnswer());
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -63,15 +63,32 @@ public class Sector {
         this.remainingAmount = this.issueAmount;
     }
 
-    public void checkEventLeft() {
-        if (remainingAmount < 1) { // 재고 없을 경우 에러 처리
+    public void decreaseEventStock() {
+        checkEventLeft();
+
+        if (sectorCapacity > 0) {
+            decreaseCapacity();
+        } else if (reserve > 0) {
+            decreaseReserve();
+        } else {
             throw NoEventStockLeftException.EXCEPTION;
         }
     }
 
-    public void decreaseEventStock() {
-        checkEventLeft();
-        this.remainingAmount = remainingAmount - 1;
+    private void decreaseCapacity() {
+        sectorCapacity--;
+        remainingAmount--;
+    }
+
+    private void decreaseReserve() {
+        reserve--;
+        remainingAmount--;
+    }
+
+    public void checkEventLeft() {
+        if (remainingAmount < 1) { // 재고 없을 경우 에러 처리
+            throw NoEventStockLeftException.EXCEPTION;
+        }
     }
 
     public void update(Sector sector) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -65,10 +65,9 @@ public class Sector {
 
     public void decreaseEventStock() {
         checkEventLeft();
-
-        if (sectorCapacity > 0) {
+        if (isSectorRemaining()) {
             decreaseCapacity();
-        } else if (reserve > 0) {
+        } else if (isSectorReserveRemaining()) {
             decreaseReserve();
         } else {
             throw NoEventStockLeftException.EXCEPTION;
@@ -89,6 +88,14 @@ public class Sector {
         if (remainingAmount < 1) { // 재고 없을 경우 에러 처리
             throw NoEventStockLeftException.EXCEPTION;
         }
+    }
+
+    public boolean isSectorRemaining() {
+        return remainingAmount > 0;
+    }
+
+    public boolean isSectorReserveRemaining() {
+        return reserve > 0;
     }
 
     public void update(Sector sector) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
@@ -1,0 +1,25 @@
+package com.jnu.ticketdomain.domains.registration.event;
+
+
+import com.jnu.ticketdomain.common.domainEvent.DomainEvent;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class RegistrationCreationEvent extends DomainEvent {
+    private final String email;
+    private final String name;
+    private final String status;
+
+    public static RegistrationCreationEvent of(Registration registration) {
+        return RegistrationCreationEvent.builder()
+                .email(registration.getEmail())
+                .name(registration.getName())
+                .status(registration.getUser().getStatus())
+                .build();
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
@@ -60,7 +60,7 @@ public class User {
         this.sequence = -1;
     }
 
-    public void fail(String status, int sequence) {
+    public void fail() {
         this.status = "불합격";
         this.sequence = -2;
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
@@ -55,6 +55,21 @@ public class User {
         this.pwd = password;
     }
 
+    public void success() {
+        this.status = "합격";
+        this.sequence = -1;
+    }
+
+    public void fail(String status, int sequence) {
+        this.status = "불합격";
+        this.sequence = -2;
+    }
+
+    public void prepare(int sequence) {
+        this.status = "예비";
+        this.sequence = sequence;
+    }
+
     @Builder
     public User(String pwd, String email, UserRole userRole) {
         this.pwd = pwd;


### PR DESCRIPTION
## 주요 변경사항
기존 모든 로직을 FP스럽게 Result로 변경했습니다.
기존 구간별 event 재고 감소 로직에 전체 재고를 함꼐 줄일 수 있게 개선했습니다.
재고 감소에 따라 사용자의 상태가 합격인지 불합격인지 예비번호인지 추가하는 기능을 추가했습니다.
- 예비 번호 검증은 추 후 Issueing 처리하겠습니다.
- 기존 모든 로직의 처리를 Event 기반으로 분리해서 로직 분리 했습니다.

## 리뷰어에게...
- 이렇게 분기처리를 fold 로 처리하는 로직은 어때보이시나요?

## 관련 이슈

closes
- closed #144 
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정