### PR TITLE
[BE-81] style: 엑세스 토큰이 비어있는 경우 예외 메세지 수정

### DIFF
--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/GlobalErrorCode.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/GlobalErrorCode.java
@@ -27,7 +27,7 @@ public enum GlobalErrorCode implements BaseErrorCode {
     @ExplainError("accessToken 만료시 발생하는 오류입니다.")
     ACCESS_TOKEN_EXPIRED(UNAUTHORIZED, "AUTH_401_1", "인증 시간이 만료되었습니다. 인증토큰을 재 발급 해주세요"),
     @ExplainError("인증되지 않은 사용자가 인증이 필요한 URL에 접근하려고 할 때 발생하는 오류입니다.")
-    AUTHENTICATION_NOT_VALID(UNAUTHORIZED, "AUTH_401_2", "인증되지 않은 사용자입니다."),
+    AUTHENTICATION_NOT_VALID(UNAUTHORIZED, "AUTH_401_2", "인증되지 않은 사용자입니다 재 로그인 해주세요."),
     @ExplainError("refreshToken 만료시 발생하는 오류입니다.")
     REFRESH_TOKEN_EXPIRED(FORBIDDEN, "AUTH_403_1", "인증 시간이 만료되었습니다. 재 로그인 해주세요."),
     @ExplainError("헤더에 올바른 accessToken을 담지않았을 때 발생하는 오류(형식 불일치 등)")


### PR DESCRIPTION
## 주요 변경사항
- AUTHENTICATION_NOT_VALID reason 변경
## 리뷰어에게...

## 관련 이슈

closes #166 
- [#166]

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정