### PR TITLE
[BE-78] bug: 메일 전송시 신청 합격 상태가 전부 불합격으로 전송되는 버그 픽스

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -2,9 +2,11 @@ package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
+import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.registration.event.RegistrationCreationEvent;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
@@ -35,6 +37,12 @@ public class EventIssuedEventHandler {
         waitingQueueService.popQueue(REDIS_EVENT_ISSUE_STORE, 1, ChatMessage.class);
     }
 
+    /**
+     * 1차신청에 대한 유저의 신청 결과 상태 정보를 변경하는 로직
+     * 1차신청에 대한 유저 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
+     * @param userId
+     * @author : cookie, blackbean
+     */
     private void processEventData(Long userId) {
         Registration registration = registrationAdaptor.findByUserId(userId);
         Sector sector = registration.getSector();
@@ -49,7 +57,7 @@ public class EventIssuedEventHandler {
         } else {
             user.fail();
         }
-
+        Events.raise(RegistrationCreationEvent.of(registration, user.getStatus()));
         sector.decreaseEventStock();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -121,10 +121,10 @@ public class RegistrationUseCase {
 
     private FinalSaveResponse saveRegistration(
             Registration registration, Long currentUserId, String email) {
+        Registration saveReg = save(registration);
         eventWithDrawUseCase.issueEvent(currentUserId);
-        Events.raise(RegistrationCreationEvent.of(registration));
         redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);
-        return FinalSaveResponse.from(save(registration));
+        return FinalSaveResponse.from(saveReg);
     }
 
     private FinalSaveResponse updateRegistration(
@@ -136,7 +136,6 @@ public class RegistrationUseCase {
         eventWithDrawUseCase.issueEvent(currentUserId);
         temporaryRegistration.update(registration);
         temporaryRegistration.updateIsSaved(true);
-        Events.raise(RegistrationCreationEvent.of(registration));
         redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);
         return FinalSaveResponse.from(temporaryRegistration);
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
@@ -22,4 +22,11 @@ public class RegistrationCreationEvent extends DomainEvent {
                 .status(registration.getUser().getStatus())
                 .build();
     }
+    public static RegistrationCreationEvent of(Registration registration, String status) {
+        return RegistrationCreationEvent.builder()
+                .email(registration.getEmail())
+                .name(registration.getName())
+                .status(status)
+                .build();
+    }
 }


### PR DESCRIPTION
## 주요 변경사항

- NPE 픽스
- 메일링 신청 상태 전송 버그 픽스

## 리뷰어에게...

- 겸사겸사 Registration에 데이터 플로우와 맞지 않는 로직으로 인해 NPE발생하는 부분 픽스했구, 
- 메일링 이벤트를 유저 상태 변경 이벤트 발행 후에 진행되도록 로직 수정했습니다.

## 관련 이슈

closes #163 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정