### PR TITLE
[BE-85] feat: event timePeriod Validation off -> on

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/docs/CheckEmailExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/docs/CheckEmailExceptionDocs.java
@@ -12,6 +12,8 @@ import com.jnu.ticketdomain.domains.council.exception.AlreadyExistEmailException
 public class CheckEmailExceptionDocs implements SwaggerExampleExceptions {
     @ExplainError("이메일이 이미 존재하는 경우")
     public TicketCodeException 이메일이_이미_존재합니다 = AlreadyExistEmailException.EXCEPTION;
+
     @ExplainError("이메일 형식이 올바르지 않는 경우")
-    public TicketCodeException 이메일_형식이_올바르지_않습니다 = new TicketCodeException(GlobalErrorCode.EMAIL_NOT_VALID);
+    public TicketCodeException 이메일_형식이_올바르지_않습니다 =
+            new TicketCodeException(GlobalErrorCode.EMAIL_NOT_VALID);
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/docs/CouncilLoginExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/docs/CouncilLoginExceptionDocs.java
@@ -16,8 +16,12 @@ public class CouncilLoginExceptionDocs implements SwaggerExampleExceptions {
 
     @ExplainError("사용자의 권한이 학생회 이상이 아닐경우")
     public TicketCodeException 권한이_학생회_이상이_아닙나다 = IsNotCouncilException.EXCEPTION;
+
     @ExplainError("이메일 형식이 올바르지 않는 경우")
-    public TicketCodeException 이메일_형식이_올바르지_않습니다 = new TicketCodeException(GlobalErrorCode.EMAIL_NOT_VALID);
+    public TicketCodeException 이메일_형식이_올바르지_않습니다 =
+            new TicketCodeException(GlobalErrorCode.EMAIL_NOT_VALID);
+
     @ExplainError("비밀번호가 정규식에 맞지 않는 경우")
-    public TicketCodeException 비밀번호가_정규식에_맞지_않습니다 = new TicketCodeException(GlobalErrorCode.PASSWORD_NOT_VALID);
+    public TicketCodeException 비밀번호가_정규식에_맞지_않습니다 =
+            new TicketCodeException(GlobalErrorCode.PASSWORD_NOT_VALID);
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/docs/UserLoginExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/docs/UserLoginExceptionDocs.java
@@ -8,14 +8,16 @@ import com.jnu.ticketcommon.exception.GlobalErrorCode;
 import com.jnu.ticketcommon.exception.TicketCodeException;
 import com.jnu.ticketcommon.interfaces.SwaggerExampleExceptions;
 
-
 @ExceptionDoc
 public class UserLoginExceptionDocs implements SwaggerExampleExceptions {
     @ExplainError("로그인 할 때 비밀번호가 일치하지 않는 경우")
     public TicketCodeException 비밀번호가_일치하지_않습니다 = BadCredentialException.EXCEPTION;
-    @ExplainError("이메일 형식이 올바르지 않는 경우")
-    public TicketCodeException 이메일_형식이_올바르지_않습니다 = new TicketCodeException(GlobalErrorCode.EMAIL_NOT_VALID);
-    @ExplainError("비밀번호가 정규식에 맞지 않는 경우")
-    public TicketCodeException 비밀번호가_정규식에_맞지_않습니다 = new TicketCodeException(GlobalErrorCode.PASSWORD_NOT_VALID);
 
+    @ExplainError("이메일 형식이 올바르지 않는 경우")
+    public TicketCodeException 이메일_형식이_올바르지_않습니다 =
+            new TicketCodeException(GlobalErrorCode.EMAIL_NOT_VALID);
+
+    @ExplainError("비밀번호가 정규식에 맞지 않는 경우")
+    public TicketCodeException 비밀번호가_정규식에_맞지_않습니다 =
+            new TicketCodeException(GlobalErrorCode.PASSWORD_NOT_VALID);
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/docs/CouncilSignUpExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/docs/CouncilSignUpExceptionDocs.java
@@ -7,20 +7,29 @@ import com.jnu.ticketcommon.exception.GlobalErrorCode;
 import com.jnu.ticketcommon.exception.TicketCodeException;
 import com.jnu.ticketcommon.interfaces.SwaggerExampleExceptions;
 import com.jnu.ticketdomain.domains.council.exception.AlreadyExistEmailException;
-import com.jnu.ticketdomain.domains.council.exception.CouncilErrorCode;
 
 @ExceptionDoc
 public class CouncilSignUpExceptionDocs implements SwaggerExampleExceptions {
     @ExplainError("이메일이 이미 존재하는 경우")
     public TicketCodeException 이메일이_이미_존재합니다 = AlreadyExistEmailException.EXCEPTION;
+
     @ExplainError("이메일 형식이 올바르지 않는 경우")
-    public TicketCodeException 이메일_형식이_올바르지_않습니다 = new TicketCodeException(GlobalErrorCode.EMAIL_NOT_VALID);
+    public TicketCodeException 이메일_형식이_올바르지_않습니다 =
+            new TicketCodeException(GlobalErrorCode.EMAIL_NOT_VALID);
+
     @ExplainError("비밀번호가 정규식에 맞지 않는 경우")
-    public TicketCodeException 비밀번호가_정규식에_맞지_않습니다 = new TicketCodeException(GlobalErrorCode.PASSWORD_NOT_VALID);
+    public TicketCodeException 비밀번호가_정규식에_맞지_않습니다 =
+            new TicketCodeException(GlobalErrorCode.PASSWORD_NOT_VALID);
+
     @ExplainError("이름에 null 혹은 빈칸인 경우")
-    public TicketCodeException 이름에_null_혹은_빈칸인_경우 = new TicketCodeException(GlobalErrorCode.NAME_MUST_NOT_BLANK);
+    public TicketCodeException 이름에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(GlobalErrorCode.NAME_MUST_NOT_BLANK);
+
     @ExplainError("전화번호 형식이 올바르지 않는 경우")
-    public TicketCodeException 전화번호_형식이_올바르지_않는_경우 = new TicketCodeException(GlobalErrorCode.PHONE_NUMBER_NOT_VALID);
+    public TicketCodeException 전화번호_형식이_올바르지_않는_경우 =
+            new TicketCodeException(GlobalErrorCode.PHONE_NUMBER_NOT_VALID);
+
     @ExplainError("학번에 null 혹은 빈칸인 경우")
-    public TicketCodeException 학번에_null_혹은_빈칸인_경우 = new TicketCodeException(GlobalErrorCode.STUDENT_NUMBER_MUST_NOT_BLANK);
+    public TicketCodeException 학번에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(GlobalErrorCode.STUDENT_NUMBER_MUST_NOT_BLANK);
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -38,8 +38,8 @@ public class EventIssuedEventHandler {
     }
 
     /**
-     * 1차신청에 대한 유저의 신청 결과 상태 정보를 변경하는 로직
-     * 1차신청에 대한 유저 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
+     * 1차신청에 대한 유저의 신청 결과 상태 정보를 변경하는 로직 1차신청에 대한 유저 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
+     *
      * @param userId
      * @author : cookie, blackbean
      */

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/docs/FinalSaveExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/docs/FinalSaveExceptionDocs.java
@@ -42,29 +42,38 @@ public class FinalSaveExceptionDocs implements SwaggerExampleExceptions {
     public TicketCodeException 쿠폰_검증_미발급_쿠폰_조회 = NotFoundEventException.EXCEPTION;
 
     @ExplainError("이름에 null 혹은 빈칸인 경우")
-    public TicketCodeException 이름에_null_혹은_빈칸인_경우 = new TicketCodeException(GlobalErrorCode.NAME_MUST_NOT_BLANK);
+    public TicketCodeException 이름에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(GlobalErrorCode.NAME_MUST_NOT_BLANK);
 
     @ExplainError("학번에 null 혹은 빈칸인 경우")
-    public TicketCodeException 학번에_null_혹은_빈칸인_경우 = new TicketCodeException(GlobalErrorCode.STUDENT_NUMBER_MUST_NOT_BLANK);
+    public TicketCodeException 학번에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(GlobalErrorCode.STUDENT_NUMBER_MUST_NOT_BLANK);
 
     @ExplainError("소속대학에 null 혹은 빈칸인 경우")
-    public TicketCodeException 소속대학에_null_혹은_빈칸인_경우 = new TicketCodeException(RegistrationErrorCode.AFFILIATION_MUST_NOT_BLANK);
+    public TicketCodeException 소속대학에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(RegistrationErrorCode.AFFILIATION_MUST_NOT_BLANK);
 
     @ExplainError("차량번호에 null 혹은 빈칸인 경우")
-    public TicketCodeException 차량번호에_null_혹은_빈칸인_경우 = new TicketCodeException(RegistrationErrorCode.CAR_NUMBER_MUST_NOT_BLANK);
+    public TicketCodeException 차량번호에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(RegistrationErrorCode.CAR_NUMBER_MUST_NOT_BLANK);
 
     @ExplainError("경차여부에 null인 경우")
-    public TicketCodeException 경차여부에_null인_경우 = new TicketCodeException(RegistrationErrorCode.CAR_LIGHT_MUST_NOT_NULL);
+    public TicketCodeException 경차여부에_null인_경우 =
+            new TicketCodeException(RegistrationErrorCode.CAR_LIGHT_MUST_NOT_NULL);
 
     @ExplainError("전화번호 형식이 올바르지 않는 경우")
-    public TicketCodeException 전화번호_형식이_올바르지_않는_경우 = new TicketCodeException(GlobalErrorCode.PHONE_NUMBER_NOT_VALID);
+    public TicketCodeException 전화번호_형식이_올바르지_않는_경우 =
+            new TicketCodeException(GlobalErrorCode.PHONE_NUMBER_NOT_VALID);
 
     @ExplainError("선택 구간 id가 음수인 경우")
-    public TicketCodeException 선택_구간_id가_음수인_경우 = new TicketCodeException(RegistrationErrorCode.SELECT_SECTORID_MUST_POSITIVE_NUMBER);
+    public TicketCodeException 선택_구간_id가_음수인_경우 =
+            new TicketCodeException(RegistrationErrorCode.SELECT_SECTORID_MUST_POSITIVE_NUMBER);
 
     @ExplainError("캡챠코드에 null 혹은 빈칸인 경우")
-    public TicketCodeException 캡챠코드에_null_혹은_빈칸인_경우 = new TicketCodeException(RegistrationErrorCode.CAPTCHA_CODE_MUST_NOT_BLANK);
+    public TicketCodeException 캡챠코드에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(RegistrationErrorCode.CAPTCHA_CODE_MUST_NOT_BLANK);
 
     @ExplainError("캡챠답변에 null 혹은 빈칸인 경우")
-    public TicketCodeException 캡챠답변에_null_혹은_빈칸인_경우 = new TicketCodeException(RegistrationErrorCode.CAPTCHA_ANSWER_MUST_NOT_BLANK);
+    public TicketCodeException 캡챠답변에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(RegistrationErrorCode.CAPTCHA_ANSWER_MUST_NOT_BLANK);
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/docs/FinalSaveExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/docs/FinalSaveExceptionDocs.java
@@ -8,6 +8,7 @@ import com.jnu.ticketcommon.exception.GlobalErrorCode;
 import com.jnu.ticketcommon.exception.TicketCodeException;
 import com.jnu.ticketcommon.interfaces.SwaggerExampleExceptions;
 import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaAnswerException;
+import com.jnu.ticketdomain.domains.events.exception.EventErrorCode;
 import com.jnu.ticketdomain.domains.events.exception.InvalidPeriodEventException;
 import com.jnu.ticketdomain.domains.events.exception.NotFoundEventException;
 import com.jnu.ticketdomain.domains.events.exception.NotFoundSectorException;
@@ -76,4 +77,16 @@ public class FinalSaveExceptionDocs implements SwaggerExampleExceptions {
     @ExplainError("캡챠답변에 null 혹은 빈칸인 경우")
     public TicketCodeException 캡챠답변에_null_혹은_빈칸인_경우 =
             new TicketCodeException(RegistrationErrorCode.CAPTCHA_ANSWER_MUST_NOT_BLANK);
+
+    @ExplainError("Event가 Open 상태가 아닌 경우")
+    public TicketCodeException Event가_Open_상태가_아닌_경우 =
+            new TicketCodeException(EventErrorCode.NOT_EVENT_OPEN_STATUS);
+
+    @ExplainError("Event가 Ready 상태가 아닌 경우")
+    public TicketCodeException Event가_Ready_상태가_아닌_경우 =
+            new TicketCodeException(EventErrorCode.NOT_EVENT_READY_STATUS);
+
+    @ExplainError("Sector 재고가 없는 경우")
+    public TicketCodeException Sector_재고가_없는_경우 =
+            new TicketCodeException(EventErrorCode.NO_EVENT_STOCK_LEFT);
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/docs/TemporarySaveExceptionFDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/docs/TemporarySaveExceptionFDocs.java
@@ -19,24 +19,30 @@ public class TemporarySaveExceptionFDocs implements SwaggerExampleExceptions {
     public TicketCodeException 구간을_찾을_수_없습니다 = NotFoundSectorException.EXCEPTION;
 
     @ExplainError("이름에 null 혹은 빈칸인 경우")
-    public TicketCodeException 이름에_null_혹은_빈칸인_경우 = new TicketCodeException(GlobalErrorCode.NAME_MUST_NOT_BLANK);
+    public TicketCodeException 이름에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(GlobalErrorCode.NAME_MUST_NOT_BLANK);
 
     @ExplainError("학번에 null 혹은 빈칸인 경우")
-    public TicketCodeException 학번에_null_혹은_빈칸인_경우 = new TicketCodeException(GlobalErrorCode.STUDENT_NUMBER_MUST_NOT_BLANK);
+    public TicketCodeException 학번에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(GlobalErrorCode.STUDENT_NUMBER_MUST_NOT_BLANK);
 
     @ExplainError("소속대학에 null 혹은 빈칸인 경우")
-    public TicketCodeException 소속대학에_null_혹은_빈칸인_경우 = new TicketCodeException(RegistrationErrorCode.AFFILIATION_MUST_NOT_BLANK);
+    public TicketCodeException 소속대학에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(RegistrationErrorCode.AFFILIATION_MUST_NOT_BLANK);
 
     @ExplainError("차량번호에 null 혹은 빈칸인 경우")
-    public TicketCodeException 차량번호에_null_혹은_빈칸인_경우 = new TicketCodeException(RegistrationErrorCode.CAR_NUMBER_MUST_NOT_BLANK);
+    public TicketCodeException 차량번호에_null_혹은_빈칸인_경우 =
+            new TicketCodeException(RegistrationErrorCode.CAR_NUMBER_MUST_NOT_BLANK);
 
     @ExplainError("경차여부에 null인 경우")
-    public TicketCodeException 경차여부에_null인_경우 = new TicketCodeException(RegistrationErrorCode.CAR_LIGHT_MUST_NOT_NULL);
+    public TicketCodeException 경차여부에_null인_경우 =
+            new TicketCodeException(RegistrationErrorCode.CAR_LIGHT_MUST_NOT_NULL);
 
     @ExplainError("전화번호 형식이 올바르지 않는 경우")
-    public TicketCodeException 전화번호_형식이_올바르지_않는_경우 = new TicketCodeException(GlobalErrorCode.PHONE_NUMBER_NOT_VALID);
+    public TicketCodeException 전화번호_형식이_올바르지_않는_경우 =
+            new TicketCodeException(GlobalErrorCode.PHONE_NUMBER_NOT_VALID);
 
     @ExplainError("선택 구간 id가 음수인 경우")
-    public TicketCodeException 선택_구간_id가_음수인_경우 = new TicketCodeException(RegistrationErrorCode.SELECT_SECTORID_MUST_POSITIVE_NUMBER);
-
+    public TicketCodeException 선택_구간_id가_음수인_경우 =
+            new TicketCodeException(RegistrationErrorCode.SELECT_SECTORID_MUST_POSITIVE_NUMBER);
 }

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/GlobalErrorCode.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/GlobalErrorCode.java
@@ -1,13 +1,13 @@
 package com.jnu.ticketcommon.exception;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.*;
+
 import com.jnu.ticketcommon.annotation.ExplainError;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import com.jnu.ticketcommon.message.ValidationMessage;
 import java.lang.reflect.Field;
 import java.util.Objects;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 /**
  * 글로벌 관련 예외 코드들이 나온 곳입니다. 인증 , global, aop 종류등 도메인 제외한 exception 코드들이 모이는 곳입니다. 도메인 관련 Exception
@@ -24,7 +24,8 @@ public enum GlobalErrorCode implements BaseErrorCode {
     EMAIL_NOT_VALID(BAD_REQUEST, "BAD_REQUEST", ValidationMessage.IS_NOT_VALID_EMAIL),
     PASSWORD_NOT_VALID(BAD_REQUEST, "BAD_REQUEST", ValidationMessage.IS_NOT_VALID_PASSWORD),
     PHONE_NUMBER_NOT_VALID(BAD_REQUEST, "BAD_REQUEST", ValidationMessage.IS_NOT_VALID_PHONE),
-    STUDENT_NUMBER_MUST_NOT_BLANK(BAD_REQUEST, "BAD_REQUEST", "학번을 " + ValidationMessage.MUST_NOT_BLANK),
+    STUDENT_NUMBER_MUST_NOT_BLANK(
+            BAD_REQUEST, "BAD_REQUEST", "학번을 " + ValidationMessage.MUST_NOT_BLANK),
     NAME_MUST_NOT_BLANK(BAD_REQUEST, "BAD_REQUEST", "이름을 " + ValidationMessage.MUST_NOT_BLANK),
 
     @ExplainError("사용자가 비밀번호를 잘못 입력했을 때 발생하는 오류입니다.")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/aop/redissonLock/RedissonLock.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/aop/redissonLock/RedissonLock.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RedissonLock {
     // 분산락을 걸 파라미터 네임
-    //    String identifier();
+    String identifier();
 
     // 락 이름
     String LockName();

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
@@ -30,6 +30,7 @@ public enum EventErrorCode implements BaseErrorCode {
     NOT_FOUND_EVENT(NOT_FOUND, "EVENT_404_5", "존재하지 않는 이벤트입니다."),
     USE_OTHER_API(BAD_REQUEST, "Event_400_0", "잘못된 접근입니다."),
     NOT_EVENT_READY_STATUS(BAD_REQUEST, "Event_400_14", "이벤트가 READY상태 여야 합니다."),
+    NOT_EVENT_OPEN_STATUS(BAD_REQUEST, "Event_400_15", "이벤트가 OPEN상태가 아닙니다."),
     ;
     private final Integer status;
     private final String code;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/NotOpenEventStatusException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/NotOpenEventStatusException.java
@@ -1,0 +1,12 @@
+package com.jnu.ticketdomain.domains.events.exception;
+
+
+import com.jnu.ticketcommon.exception.TicketCodeException;
+
+public class NotOpenEventStatusException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new NotOpenEventStatusException();
+
+    private NotOpenEventStatusException() {
+        super(EventErrorCode.NOT_EVENT_OPEN_STATUS);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
@@ -22,6 +22,7 @@ public class RegistrationCreationEvent extends DomainEvent {
                 .status(registration.getUser().getStatus())
                 .build();
     }
+
     public static RegistrationCreationEvent of(Registration registration, String status) {
         return RegistrationCreationEvent.builder()
                 .email(registration.getEmail())

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/exception/RegistrationErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/exception/RegistrationErrorCode.java
@@ -5,10 +5,9 @@ import static com.jnu.ticketcommon.consts.TicketStatic.NOT_FOUND;
 import com.jnu.ticketcommon.annotation.ExplainError;
 import com.jnu.ticketcommon.exception.BaseErrorCode;
 import com.jnu.ticketcommon.exception.ErrorReason;
+import com.jnu.ticketcommon.message.ValidationMessage;
 import java.lang.reflect.Field;
 import java.util.Objects;
-
-import com.jnu.ticketcommon.message.ValidationMessage;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -20,10 +19,10 @@ public enum RegistrationErrorCode implements BaseErrorCode {
     AFFILIATION_MUST_NOT_BLANK(400, "BAD_REQUEST", "소속대학을 " + ValidationMessage.MUST_NOT_BLANK),
     CAR_NUMBER_MUST_NOT_BLANK(400, "BAD_REQUEST", "차량번호를 " + ValidationMessage.MUST_NOT_BLANK),
     CAR_LIGHT_MUST_NOT_NULL(400, "BAD_REQUEST", "경차 여부를 " + ValidationMessage.MUST_NOT_NULL),
-    SELECT_SECTORID_MUST_POSITIVE_NUMBER(400, "BAD_REQUEST", "구간 ID는 " + ValidationMessage.MUST_POSITIVE_NUMBER),
+    SELECT_SECTORID_MUST_POSITIVE_NUMBER(
+            400, "BAD_REQUEST", "구간 ID는 " + ValidationMessage.MUST_POSITIVE_NUMBER),
     CAPTCHA_CODE_MUST_NOT_BLANK(400, "BAD_REQUEST", "캡챠 코드를 " + ValidationMessage.MUST_NOT_BLANK),
-    CAPTCHA_ANSWER_MUST_NOT_BLANK(400, "BAD_REQUEST", "캡챠 답변을 " + ValidationMessage.MUST_NOT_BLANK)
-    ;
+    CAPTCHA_ANSWER_MUST_NOT_BLANK(400, "BAD_REQUEST", "캡챠 답변을 " + ValidationMessage.MUST_NOT_BLANK);
     private final Integer status;
     private final String code;
     private final String reason;


### PR DESCRIPTION
+ Redisson parameterize

## 주요 변경사항
기존 validation을 open ready 상태에서 모두 검증할 수 있도록 추가했습니다.

redisson 분산락 유일하게 적용하는 부분에 userId parameter로 추가된 관계로 분산락 로직을 전부 변경했습니다.
identifier기반으로 변경했습니다.

## 리뷰어에게...

## 관련 이슈

closes
- closed #175 
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정