### PR TITLE
[BE-87] bug: 구간 인원 설정

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/model/response/SectorReadResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/model/response/SectorReadResponse.java
@@ -24,9 +24,9 @@ public record SectorReadResponse(
                                         sector.getId(),
                                         sector.getSectorNumber(),
                                         sector.getName(),
-                                        sector.getSectorCapacity(),
-                                        sector.getReserve(),
-                                        sector.getIssueAmount()))
+                                        sector.getInitSectorCapacity(),
+                                        sector.getInitReserve(),
+                                        sector.getInitSectorCapacity() + sector.getInitReserve()))
                 .toList();
     }
 }


### PR DESCRIPTION

## 주요 변경사항
- 구간 인원 설정의 구간 정원, 예비 정원을 초기 설정한 값을 불러오도록 수정

## 리뷰어에게...
- 서현이가 바쁜 관계로 제가 대신 간단하게 수정 하였습니다.

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정