### PR TITLE
[BE-89] feat : Event TimePeriod 과거/과거 시간 수정 허용

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
@@ -8,10 +8,10 @@ import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
-import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.event.EventCreationEvent;
 import com.jnu.ticketdomain.domains.events.event.EventUpdatedEvent;
+import io.vavr.control.Option;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -40,46 +40,74 @@ public class EventRegisterUseCase {
                 });
     }
 
+    /**
+     * 기존 이벤트가 존재한 경우 단, (과거, 과거)는 수정이 불가하다. (과거, 미래) -> (과거, 미래 or 과거)로 수정한 경우 (과거, 미래) -> (과거,
+     * 과거)로 수정한 경우
+     */
     private void saveEventIfPresent(DateTimePeriod dateTimePeriod, Event event) {
         event.validateIssuePeriod();
         LocalDateTime now = LocalDateTime.now();
-        // 과거로 수정한 경우
-        if (dateTimePeriod.getStartAt().isBefore(now)) {
-            if (event.getEventStatus().equals(EventStatus.OPEN)) {
-                event.updateDateTimePeriod(dateTimePeriod);
-            } else {
-                event.open();
-                event.updateDateTimePeriod(dateTimePeriod);
-            }
-        } else {
-            // 과거 -> 미래 로 수정한경우
-            if (event.getEventStatus().equals(EventStatus.OPEN)) {
-                event.ready();
-                event.updateDateTimePeriod(dateTimePeriod);
-            } else {
-                // 미래 -> 미래 로 수정한경우
-                event.updateDateTimePeriod(dateTimePeriod);
-            }
-            Events.raise(EventUpdatedEvent.of(event));
-        }
+        Option.of(dateTimePeriod.getStartAt().isBefore(now))
+                .peek(
+                        b -> {
+                            // (과거, 미래) -> (미래, 미래)로 수정한 경우
+                            if (dateTimePeriod.getStartAt().isAfter(now)
+                                    && dateTimePeriod.getEndAt().isAfter(now)) {
+                                event.ready();
+                            } else {
+                                // (과거, 미래) -> 과거, 미래)로 수정한 경우
+                                if (dateTimePeriod.getEndAt().isAfter(now)) {
+                                    event.open();
+                                } else {
+                                    // (과거, 미래) -> (과거, 과거)로 수정한 경우
+                                    event.close();
+                                }
+                            }
+                        });
+        // (미래, 미래) -> (과거, 미래) 로 수정한경우 or (미래, 미래) -> (미래, 미래)로 수정한 경우 , (미래, 미래) -> (과거, 과거)로 수정한
+        // 경우
+        Option.of(event.getDateTimePeriod().getStartAt().isAfter(now))
+                .filter(b -> dateTimePeriod.getStartAt().isBefore(now))
+                .peek(
+                        b -> {
+                            // (미래, 미래) -> (과거, 과거)로 수정한 경우
+                            if (dateTimePeriod.getEndAt().isBefore(now)) {
+                                event.close();
+                            } else {
+                                // (미래, 미래) -> (과거, 미래)로 수정한 경우
+                                Events.raise(EventUpdatedEvent.of(event));
+                                event.open();
+                            }
+                        })
+                // (미래, 미래) -> (미래, 미래)로 수정한 경우
+                .onEmpty(
+                        () -> {
+                            Events.raise(EventUpdatedEvent.of(event));
+                            event.ready();
+                        });
+        event.updateDateTimePeriod(dateTimePeriod);
     }
 
+    /** 기존 이벤트가 존재하지 않는 경우 단, (과거, 과거)는 생성이 불가하다. (과거, 미래), (미래, 미래)로 생성한 경우 */
     private void firstSaveEvent(DateTimePeriod dateTimePeriod) {
         List<Sector> sectors = sectorAdaptor.findAll();
         Event event = new Event(dateTimePeriod, sectors);
         event.validateIssuePeriod();
         LocalDateTime now = LocalDateTime.now();
-        // 과거로 생성한 경우
-        if (now.isAfter(dateTimePeriod.getStartAt())) {
-            event.open();
-            Event savedEvent = eventAdaptor.save(event);
-            sectors.forEach(sector -> sector.setEvent(savedEvent));
-        }
-        // 미래로 생성한 경우
-        else {
-            Event savedEvent = eventAdaptor.save(event);
-            sectors.forEach(sector -> sector.setEvent(savedEvent));
-            Events.raise(EventCreationEvent.of(savedEvent));
-        }
+        Option.of(dateTimePeriod.getStartAt().isBefore(now))
+                .filter(b -> now.isAfter(dateTimePeriod.getStartAt()))
+                .peek(
+                        b -> {
+                            event.open();
+                            Event savedEvent = eventAdaptor.save(event);
+                            sectors.forEach(sector -> sector.setEvent(savedEvent));
+                        })
+                .onEmpty(
+                        () -> {
+                            Event savedEvent = eventAdaptor.save(event);
+                            sectors.forEach(sector -> sector.setEvent(savedEvent));
+                            // 이벤트 상태 변경 Batch 스케줄링 (READY -> OPEN) - 이벤트
+                            Events.raise(EventCreationEvent.of(savedEvent));
+                        });
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -85,13 +85,13 @@ public class Event {
     }
 
     private void updateStatus(EventStatus status, TicketCodeException exception) {
-        if (this.eventStatus == status) throw exception;
+        //        if (this.eventStatus == status) throw exception;
         this.eventStatus = status;
         Events.raise(EventStatusChangeEvent.of(this));
     }
 
     public void open() {
-        validateOpenStatus();
+        //        validateOpenStatus();
         updateStatus(OPEN, AlreadyOpenStatusException.EXCEPTION);
     }
 


### PR DESCRIPTION
FP style migration

## 주요 변경사항
start = 과거, end = 과거 시간으로 수정할 수 있게 처리했습니다.
(단, 과거, 과거 시간으로 생성하는 것은 불가능합니다.)

## 리뷰어에게...
기존 모든 분기 처리를 Vavr Option을 이용해서 if문을 제거하려 했으나, 내부 람다 처리 내에서 Option분기 처리를 하면 depth처리가 너무 힘들었습니다. 케이스가 4가지 이상으로 많아진다면 Case 를 처리하겠습니다.
FP를 적용하게 되면 공통 로직을 처리하기 위해서 currid함수를 이용해야 하겠지만 고정 변수가 있지 않다 보니 자유롭게 분기 처리하기는 어려운 부분이 있습니다. 

## 관련 이슈

closes
- closed #187 
## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정