### PR TITLE
[BE-90] feat : Event Identifier migration / 이벤트별 섹터 조회 및 섹터 수정 #189

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -8,6 +8,7 @@ import static com.jnu.ticketcommon.message.ResponseMessage.EVENT_SUCCESS_UPDATE_
 import com.jnu.ticketapi.api.event.docs.CreateEventExceptionDocs;
 import com.jnu.ticketapi.api.event.docs.ReadEventExceptionDocs;
 import com.jnu.ticketapi.api.event.docs.ReadEventPeriodExceptionDocs;
+import com.jnu.ticketapi.api.event.model.request.EventRegisterRequest;
 import com.jnu.ticketapi.api.event.model.request.UpdateEventStatusRequest;
 import com.jnu.ticketapi.api.event.service.EventRegisterUseCase;
 import com.jnu.ticketapi.api.event.service.EventWithDrawUseCase;
@@ -46,8 +47,8 @@ public class EventController {
     @Operation(summary = "주차권 설정", description = "주차권 행사 세부 설정(시작일, 종료일, 잔고)")
     @ApiErrorExceptionsExample(CreateEventExceptionDocs.class)
     @PostMapping("/events")
-    public SuccessResponse setEvent(@RequestBody DateTimePeriod dateTimePeriod) {
-        EventRegisterUseCase.registerEvent(dateTimePeriod);
+    public SuccessResponse setEvent(@RequestBody EventRegisterRequest eventRegisterRequest) {
+        EventRegisterUseCase.registerEvent(eventRegisterRequest);
         return new SuccessResponse(EVENT_SUCCESS_REGISTER_MESSAGE);
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/model/request/EventRegisterRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/model/request/EventRegisterRequest.java
@@ -1,13 +1,10 @@
 package com.jnu.ticketapi.api.event.model.request;
 
 
-import com.jnu.ticketapi.api.sector.model.request.SectorRegisterRequest;
 import com.jnu.ticketdomain.common.vo.DateTimePeriod;
-import java.util.List;
 import lombok.Builder;
 
-public record EventRegisterRequest(
-        DateTimePeriod dateTimePeriod, List<SectorRegisterRequest> sectors) {
+public record EventRegisterRequest(DateTimePeriod dateTimePeriod, String title) {
     @Builder
     public EventRegisterRequest {}
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
@@ -1,19 +1,16 @@
 package com.jnu.ticketapi.api.event.service;
 
 
+import com.jnu.ticketapi.api.event.model.request.EventRegisterRequest;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.utils.Result;
 import com.jnu.ticketdomain.common.domainEvent.Events;
-import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
-import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
-import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.event.EventCreationEvent;
 import com.jnu.ticketdomain.domains.events.event.EventUpdatedEvent;
 import io.vavr.control.Option;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,20 +19,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class EventRegisterUseCase {
-
     private final EventAdaptor eventAdaptor;
-    private final SectorAdaptor sectorAdaptor;
 
     @Transactional
-    public void registerEvent(DateTimePeriod dateTimePeriod) {
+    public void registerEvent(EventRegisterRequest eventRegisterRequest) {
         Result<Event, Object> readyEvent = eventAdaptor.findReadyOrOpenEvent();
         readyEvent.fold(
                 event -> {
-                    saveEventIfPresent(dateTimePeriod, event);
+                    saveEventIfPresent(eventRegisterRequest, event);
                     return null;
                 },
                 error -> {
-                    firstSaveEvent(dateTimePeriod);
+                    firstSaveEvent(eventRegisterRequest);
                     return null;
                 });
     }
@@ -44,19 +39,22 @@ public class EventRegisterUseCase {
      * 기존 이벤트가 존재한 경우 단, (과거, 과거)는 수정이 불가하다. (과거, 미래) -> (과거, 미래 or 과거)로 수정한 경우 (과거, 미래) -> (과거,
      * 과거)로 수정한 경우
      */
-    private void saveEventIfPresent(DateTimePeriod dateTimePeriod, Event event) {
+    private void saveEventIfPresent(EventRegisterRequest eventRegisterRequest, Event event) {
         event.validateIssuePeriod();
         LocalDateTime now = LocalDateTime.now();
-        Option.of(dateTimePeriod.getStartAt().isBefore(now))
+        Option.of(eventRegisterRequest.dateTimePeriod().getStartAt().isBefore(now))
                 .peek(
                         b -> {
                             // (과거, 미래) -> (미래, 미래)로 수정한 경우
-                            if (dateTimePeriod.getStartAt().isAfter(now)
-                                    && dateTimePeriod.getEndAt().isAfter(now)) {
+                            if (eventRegisterRequest.dateTimePeriod().getStartAt().isAfter(now)
+                                    && eventRegisterRequest
+                                            .dateTimePeriod()
+                                            .getEndAt()
+                                            .isAfter(now)) {
                                 event.ready();
                             } else {
                                 // (과거, 미래) -> 과거, 미래)로 수정한 경우
-                                if (dateTimePeriod.getEndAt().isAfter(now)) {
+                                if (eventRegisterRequest.dateTimePeriod().getEndAt().isAfter(now)) {
                                     event.open();
                                 } else {
                                     // (과거, 미래) -> (과거, 과거)로 수정한 경우
@@ -67,11 +65,11 @@ public class EventRegisterUseCase {
         // (미래, 미래) -> (과거, 미래) 로 수정한경우 or (미래, 미래) -> (미래, 미래)로 수정한 경우 , (미래, 미래) -> (과거, 과거)로 수정한
         // 경우
         Option.of(event.getDateTimePeriod().getStartAt().isAfter(now))
-                .filter(b -> dateTimePeriod.getStartAt().isBefore(now))
+                .filter(b -> eventRegisterRequest.dateTimePeriod().getStartAt().isBefore(now))
                 .peek(
                         b -> {
                             // (미래, 미래) -> (과거, 과거)로 수정한 경우
-                            if (dateTimePeriod.getEndAt().isBefore(now)) {
+                            if (eventRegisterRequest.dateTimePeriod().getEndAt().isBefore(now)) {
                                 event.close();
                             } else {
                                 // (미래, 미래) -> (과거, 미래)로 수정한 경우
@@ -85,27 +83,31 @@ public class EventRegisterUseCase {
                             Events.raise(EventUpdatedEvent.of(event));
                             event.ready();
                         });
-        event.updateDateTimePeriod(dateTimePeriod);
+        event.updateDateTimePeriod(eventRegisterRequest.dateTimePeriod());
     }
 
     /** 기존 이벤트가 존재하지 않는 경우 단, (과거, 과거)는 생성이 불가하다. (과거, 미래), (미래, 미래)로 생성한 경우 */
-    private void firstSaveEvent(DateTimePeriod dateTimePeriod) {
-        List<Sector> sectors = sectorAdaptor.findAll();
-        Event event = new Event(dateTimePeriod, sectors);
+    private void firstSaveEvent(EventRegisterRequest eventRegisterRequest) {
+        //        List<Sector> sectors = sectorAdaptor.findAll();
+        Event event =
+                new Event(
+                        eventRegisterRequest.dateTimePeriod(), null, eventRegisterRequest.title());
         event.validateIssuePeriod();
         LocalDateTime now = LocalDateTime.now();
-        Option.of(dateTimePeriod.getStartAt().isBefore(now))
-                .filter(b -> now.isAfter(dateTimePeriod.getStartAt()))
+        Option.of(eventRegisterRequest.dateTimePeriod().getStartAt().isBefore(now))
+                .filter(b -> now.isAfter(eventRegisterRequest.dateTimePeriod().getStartAt()))
                 .peek(
                         b -> {
                             event.open();
                             Event savedEvent = eventAdaptor.save(event);
-                            sectors.forEach(sector -> sector.setEvent(savedEvent));
+                            //                            sectors.forEach(sector ->
+                            // sector.setEvent(savedEvent));
                         })
                 .onEmpty(
                         () -> {
                             Event savedEvent = eventAdaptor.save(event);
-                            sectors.forEach(sector -> sector.setEvent(savedEvent));
+                            //                            sectors.forEach(sector ->
+                            // sector.setEvent(savedEvent));
                             // 이벤트 상태 변경 Batch 스케줄링 (READY -> OPEN) - 이벤트
                             Events.raise(EventCreationEvent.of(savedEvent));
                         });

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/controller/SectorController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/controller/SectorController.java
@@ -5,9 +5,11 @@ import static com.jnu.ticketcommon.message.ResponseMessage.SECTOR_SUCCESS_REGIST
 import static com.jnu.ticketcommon.message.ResponseMessage.SECTOR_SUCCESS_UPDATE_MESSAGE;
 
 import com.jnu.ticketapi.api.sector.docs.CreateSectorExceptionDocs;
+import com.jnu.ticketapi.api.sector.docs.ReadSectorExceptionDocs;
 import com.jnu.ticketapi.api.sector.model.request.SectorRegisterRequest;
 import com.jnu.ticketapi.api.sector.model.response.SectorReadResponse;
 import com.jnu.ticketapi.api.sector.service.SectorDeleteUseCase;
+import com.jnu.ticketapi.api.sector.service.SectorReadUseCase;
 import com.jnu.ticketapi.api.sector.service.SectorRegisterUseCase;
 import com.jnu.ticketcommon.annotation.ApiErrorExceptionsExample;
 import com.jnu.ticketcommon.dto.SuccessResponse;
@@ -35,12 +37,31 @@ public class SectorController {
 
     private final SectorRegisterUseCase sectorRegisterUseCase;
     private final SectorDeleteUseCase sectorDeleteUseCase;
+    private final SectorReadUseCase sectorReadUseCase;
 
     @Operation(summary = "구간 조회", description = "구간 조회(구간 번호, 구간 이름, 구간별 수용인원, 잔여 인원))")
-    @ApiErrorExceptionsExample(CreateSectorExceptionDocs.class)
+    @ApiErrorExceptionsExample(ReadSectorExceptionDocs.class)
     @GetMapping("/sectors")
     public List<SectorReadResponse> getEvent() {
-        return sectorRegisterUseCase.findAll();
+        return sectorReadUseCase.findAll();
+    }
+
+    @Operation(
+            summary = "eventId로 구간 조회",
+            description = "eventId로 구간 조회(구간 번호, 구간 이름, 구간별 수용인원, 잔여 인원))")
+    @ApiErrorExceptionsExample(ReadSectorExceptionDocs.class)
+    @GetMapping("/events/{event-id}/sectors")
+    public List<SectorReadResponse> getEvent(@PathVariable("event-id") Long eventId) {
+        return sectorReadUseCase.findByEventId(eventId);
+    }
+
+    @Operation(
+            summary = "최근 활성화된 Sector 조회",
+            description = "최근 활성화된 Sector 조회(구간 번호, 구간 이름, 구간별 수용인원, 잔여 인원))")
+    @ApiErrorExceptionsExample(ReadSectorExceptionDocs.class)
+    @GetMapping("/sectors/recent")
+    public List<SectorReadResponse> getRecentSector() {
+        return sectorReadUseCase.findRecentSector();
     }
 
     @Operation(

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/docs/ReadSectorExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/docs/ReadSectorExceptionDocs.java
@@ -1,0 +1,14 @@
+package com.jnu.ticketapi.api.sector.docs;
+
+
+import com.jnu.ticketcommon.annotation.ExceptionDoc;
+import com.jnu.ticketcommon.annotation.ExplainError;
+import com.jnu.ticketcommon.exception.TicketCodeException;
+import com.jnu.ticketcommon.interfaces.SwaggerExampleExceptions;
+import com.jnu.ticketdomain.domains.events.exception.NotFoundSectorException;
+
+@ExceptionDoc
+public class ReadSectorExceptionDocs implements SwaggerExampleExceptions {
+    @ExplainError("구간을 찾을 수 없습니다.")
+    public TicketCodeException 구간_찾지_못함 = NotFoundSectorException.EXCEPTION;
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/model/response/SectorReadResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/model/response/SectorReadResponse.java
@@ -29,4 +29,14 @@ public record SectorReadResponse(
                                         sector.getInitSectorCapacity() + sector.getInitReserve()))
                 .toList();
     }
+
+    public static SectorReadResponse toSectorReadResponse(Sector sector) {
+        return new SectorReadResponse(
+                sector.getId(),
+                sector.getSectorNumber(),
+                sector.getName(),
+                sector.getInitSectorCapacity(),
+                sector.getInitReserve(),
+                sector.getInitSectorCapacity() + sector.getInitReserve());
+    }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorReadUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorReadUseCase.java
@@ -1,0 +1,34 @@
+package com.jnu.ticketapi.api.sector.service;
+
+
+import com.jnu.ticketapi.api.sector.model.response.SectorReadResponse;
+import com.jnu.ticketcommon.annotation.UseCase;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.events.out.SectorLoadPort;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class SectorReadUseCase {
+    private final SectorLoadPort sectorLoadPort;
+
+    @Transactional(readOnly = true)
+    public List<SectorReadResponse> findAll() {
+        List<Sector> all = sectorLoadPort.findAll();
+        return SectorReadResponse.toSectorReadResponses(all);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SectorReadResponse> findByEventId(Long eventId) {
+        List<Sector> sectors = sectorLoadPort.findByEventId(eventId);
+        return SectorReadResponse.toSectorReadResponses(sectors);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SectorReadResponse> findRecentSector() {
+        List<Sector> sectors = sectorLoadPort.findRecentSector();
+        return SectorReadResponse.toSectorReadResponses(sectors);
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
@@ -2,7 +2,6 @@ package com.jnu.ticketapi.api.sector.service;
 
 
 import com.jnu.ticketapi.api.sector.model.request.SectorRegisterRequest;
-import com.jnu.ticketapi.api.sector.model.response.SectorReadResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.exception.MultiException;
 import com.jnu.ticketcommon.exception.TicketCodeException;
@@ -99,11 +98,5 @@ public class SectorRegisterUseCase {
                                                 sectorRegisterRequest.reserve()))
                         .toList();
         sectorRecordPort.updateAll(prevSector, sectorList);
-    }
-
-    @Transactional(readOnly = true)
-    public List<SectorReadResponse> findAll() {
-        List<Sector> all = sectorLoadPort.findAll();
-        return SectorReadResponse.toSectorReadResponses(all);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
@@ -52,6 +52,7 @@ public class SectorRegisterUseCase {
                                                             sectorRegisterRequest.reserve()))
                                     .toList();
                     sectorList.forEach(sector -> sector.setEvent(recentEvent));
+                    recentEvent.setSector(sectorList);
                     sectorRecordPort.saveAll(sectorList);
                     return null;
                 });

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -2,6 +2,7 @@ package com.jnu.ticketdomain.domains.events.adaptor;
 
 
 import com.jnu.ticketcommon.annotation.Adaptor;
+import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.NotFoundSectorException;
 import com.jnu.ticketdomain.domains.events.out.SectorLoadPort;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
     private final SectorRepository couponRepository;
+    private final EventAdaptor eventAdaptor;
 
     public Sector findById(Long couponId) {
         return couponRepository
@@ -25,6 +27,18 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
     @Override
     public List<Sector> findAll() {
         return couponRepository.findAll();
+    }
+
+    @Override
+    public List<Sector> findByEventId(Long eventId) {
+        return couponRepository.findByEventId(eventId);
+    }
+
+    @Override
+    public List<Sector> findRecentSector() {
+        Event recentEvent = eventAdaptor.findRecentEvent();
+        if (recentEvent == null) throw NotFoundSectorException.EXCEPTION;
+        return couponRepository.findByEventId(recentEvent.getId());
     }
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -37,6 +37,9 @@ public class Event {
     @Column(name = "event_id")
     private Long id;
 
+    @Column(name = "title")
+    private String title;
+
     // 쿠폰 pubsub을 위한 일련번호 -> UUID String 6자리
     @Column(name = "event_code")
     private String eventCode;
@@ -49,7 +52,7 @@ public class Event {
 
     // 구간별 정보
     //    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @OneToMany(mappedBy = "event", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
     //    @JoinColumn(name = "sector_id")
     private List<Sector> sector = new ArrayList<>();
 
@@ -58,6 +61,15 @@ public class Event {
         this.eventCode = UUID.randomUUID().toString().substring(0, 6);
         this.dateTimePeriod = dateTimePeriod;
         this.sector = sector;
+        this.eventStatus = EventStatus.READY;
+    }
+
+    @Builder
+    public Event(DateTimePeriod dateTimePeriod, List<Sector> sector, String title) {
+        this.eventCode = UUID.randomUUID().toString().substring(0, 6);
+        this.dateTimePeriod = dateTimePeriod;
+        this.sector = sector;
+        this.title = title;
         this.eventStatus = EventStatus.READY;
     }
 
@@ -72,6 +84,10 @@ public class Event {
 
     public void validateNotOpenStatus() {
         if (eventStatus != OPEN) throw NotOpenEventPeriodException.EXCEPTION;
+    }
+
+    public void setSector(List<Sector> sector) {
+        this.sector = sector;
     }
 
     public void validateIssuePeriod() {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/EventLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/EventLoadPort.java
@@ -14,4 +14,6 @@ public interface EventLoadPort {
     Event findOpenEvent();
 
     Result<Event, Object> findReadyOrOpenEvent();
+
+    Event findRecentEvent();
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
@@ -10,4 +10,8 @@ public interface SectorLoadPort {
     Sector findById(Long sectorId);
 
     List<Sector> findAll();
+
+    List<Sector> findByEventId(Long eventId);
+
+    List<Sector> findRecentSector();
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/EventRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/EventRepository.java
@@ -6,6 +6,7 @@ import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,4 +20,15 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Query(
             "select e from Event e where e.dateTimePeriod.endAt < :time and e.eventStatus = com.jnu.ticketdomain.domains.events.domain.EventStatus.OPEN")
     List<Event> findByEndAtBeforeAndStatusOpen(@Param("time") LocalDateTime time);
+
+    @Query(
+            "SELECT e FROM Event e "
+                    + "WHERE e.eventStatus = 'CLOSED' AND e.dateTimePeriod.endAt < :time "
+                    + "ORDER BY e.dateTimePeriod.endAt DESC, e.dateTimePeriod.startAt DESC, e.id DESC ")
+    List<Event> findClosestClosedEvent(@Param("time") LocalDateTime time, Pageable pageable);
+    //    @Query("SELECT e FROM Event e " +
+    //        "WHERE e.eventStatus = 'CLOSED' AND e.dateTimePeriod.endAt < :time " +
+    //        "ORDER BY e.dateTimePeriod.endAt ASC ")
+    //    Optional<Event> findClosestClosedEvent(@Param("time") LocalDateTime time);
+
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -2,11 +2,16 @@ package com.jnu.ticketdomain.domains.events.repository;
 
 
 import com.jnu.ticketdomain.domains.events.domain.Sector;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SectorRepository extends JpaRepository<Sector, Long> {
     Optional<Sector> findById(Long sectorId);
+
+    @Query("select s from Sector s where s.event.id = :eventId")
+    List<Sector> findByEventId(Long eventId);
 }


### PR DESCRIPTION
## 주요 변경사항
- 이벤트별 섹터 조회
- 최근 이벤트에 연결된 섹터 조회(READY,OPEN 이벤트이거나, CLOSED밖에 없다면 그중 가장 가까운 Event 제시)
- Event 에 title 칼럼을 추가합니다. ( Event별로 Sector를 관리합니다. )

## 리뷰어에게...


## 관련 이슈

closes
- closed #189 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정