### PR TITLE
[BE-106] bug: sectorNum 구간 이름 중복 검증 로직 수정 #221

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/controller/SectorController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/controller/SectorController.java
@@ -6,6 +6,7 @@ import static com.jnu.ticketcommon.message.ResponseMessage.SECTOR_SUCCESS_UPDATE
 
 import com.jnu.ticketapi.api.sector.docs.CreateSectorExceptionDocs;
 import com.jnu.ticketapi.api.sector.docs.ReadSectorExceptionDocs;
+import com.jnu.ticketapi.api.sector.docs.UpdateSectorExceptionDocs;
 import com.jnu.ticketapi.api.sector.model.request.SectorRegisterRequest;
 import com.jnu.ticketapi.api.sector.model.response.SectorReadResponse;
 import com.jnu.ticketapi.api.sector.service.SectorDeleteUseCase;
@@ -77,8 +78,8 @@ public class SectorController {
 
     @Operation(
             summary = "구간 수정",
-            description = "구간 수정 -> 수정하면 기존 리스트 다 날아가고 새로 생성됩니다 (구간 번호, 구간 이름, 구간별 수용인원, 잔여 인원))")
-    @ApiErrorExceptionsExample(CreateSectorExceptionDocs.class)
+            description = "구간 수정 -> 변경된 구간만 변경이 됩니다. (구간 번호, 구간 이름, 구간별 수용인원, 잔여 인원))")
+    @ApiErrorExceptionsExample(UpdateSectorExceptionDocs.class)
     @PutMapping("/sectors")
     public SuccessResponse updateEvent(@RequestBody List<@Valid SectorRegisterRequest> sectors) {
         sectorRegisterUseCase.update(sectors);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/docs/UpdateSectorExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/docs/UpdateSectorExceptionDocs.java
@@ -1,0 +1,27 @@
+package com.jnu.ticketapi.api.sector.docs;
+
+
+import com.jnu.ticketcommon.annotation.ExceptionDoc;
+import com.jnu.ticketcommon.annotation.ExplainError;
+import com.jnu.ticketcommon.exception.TicketCodeException;
+import com.jnu.ticketcommon.interfaces.SwaggerExampleExceptions;
+import com.jnu.ticketdomain.domains.events.exception.DuplicateSectorNameException;
+import com.jnu.ticketdomain.domains.events.exception.InvalidSectorCapacityAndRemainException;
+import com.jnu.ticketdomain.domains.events.exception.InvalidSizeSectorException;
+import com.jnu.ticketdomain.domains.events.exception.NotFoundSectorException;
+
+@ExceptionDoc
+public class UpdateSectorExceptionDocs implements SwaggerExampleExceptions {
+
+    @ExplainError("구간을 찾을 수 없습니다.")
+    public TicketCodeException 구간_찾지_못함 = NotFoundSectorException.EXCEPTION;
+
+    @ExplainError(
+            "Sector 생성 검증 기준을 만족하지 못합니다. 1) capacity는 0보다 커야합니다. 2) remain은 capacity보다 작거나 같아야합니다.")
+    public TicketCodeException 구간_생성_검증_실패 = InvalidSectorCapacityAndRemainException.EXCEPTION;
+
+    @ExplainError("Sector 생성 검증 기준을 만족하지 못합니다. 2) 구간명(sectorNum)이 중복됩니다.")
+    public TicketCodeException 구간명_중복_생성 = DuplicateSectorNameException.EXCEPTION;
+
+    @ExplainError public TicketCodeException 수정_구간_크기_불일치 = InvalidSizeSectorException.EXCEPTION;
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
@@ -53,8 +53,8 @@ public class SectorRegisterUseCase {
                                                             sectorRegisterRequest.reserve()))
                                     .toList();
                     sectorList.forEach(sector -> sector.setEvent(recentEvent));
-                    recentEvent.setSector(sectorList);
-                    sectorRecordPort.saveAll(sectorList);
+                    List<Sector> savedSectors = sectorRecordPort.saveAll(sectorList);
+                    recentEvent.setSector(savedSectors);
                     return null;
                 });
     }
@@ -88,6 +88,7 @@ public class SectorRegisterUseCase {
     @Transactional
     @EventTypeCheck(eventType = EventStatus.READY)
     public void update(List<SectorRegisterRequest> sectors) {
+        validateRegistrationSector(sectors);
         List<Sector> prevSector = sectorLoadPort.findAll();
         Result<Event, Object> readyOrOpenEvent = eventLoadPort.findReadyOrOpenEvent();
         Event event = readyOrOpenEvent.getOrThrow();

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/InvalidSizeSectorException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/InvalidSizeSectorException.java
@@ -1,0 +1,12 @@
+package com.jnu.ticketdomain.domains.events.exception;
+
+
+import com.jnu.ticketcommon.exception.TicketCodeException;
+
+public class InvalidSizeSectorException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new InvalidSizeSectorException();
+
+    private InvalidSizeSectorException() {
+        super(SectorErrorCode.INVALID_UPDATE_SECTOR_SIZE);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/SectorErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/SectorErrorCode.java
@@ -20,7 +20,9 @@ public enum SectorErrorCode implements BaseErrorCode {
     NOT_FOUND_SECTOR(NOT_FOUND, "Sector_404_2", "존재하지 않는 구간 입니다."),
     NOT_MY_SECTOR(BAD_REQUEST, "Sector_400_7", "내 구간이 아닙니다."),
     DUPLICATE_SECTOR_NUMBER(BAD_REQUEST, "Sector_400_8", "동일한 구간 번호(1구간, 2구간 ..)가 이미 존재합니다."),
-    INVALID_SECTOR_CAPACITY_AND_REMAIN(BAD_REQUEST, "Sector_400_9", "구간의 재고는 0 이상이여야 합니다.");
+    INVALID_SECTOR_CAPACITY_AND_REMAIN(BAD_REQUEST, "Sector_400_9", "구간의 재고는 0 이상이여야 합니다."),
+    INVALID_UPDATE_SECTOR_SIZE(BAD_REQUEST, "Sector_400_10", "구간의 개수가 일치해야 합니다."),
+    ;
     private final Integer status;
     private final String code;
     private final String reason;


### PR DESCRIPTION
## 주요 변경사항
기존 병렬 수정 연산에 Name으로 유니크 검사하는 것을 sectorNum으로 변경했습니다.
또한 2개의 배열을 싱크를 맞추는 과정에서 IntStream으로 인덱스를 맞춰주었습니다.
## 리뷰어에게...

## 관련 이슈

- closes #221 
## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정