### PR TITLE
[BE-113] feat: 이벤트의 PUBLISH 상태 변경 API

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -134,12 +134,9 @@ public class EventController {
 
     @Operation(
             summary = "이벤트의 PUBLISH 상태 변경",
-            description = "이벤트의 PUBLISH 상태를 미게시에서 게시로 변경한다. path variable은 Long타입인 event-id를 받는다."
-    )
+            description = "이벤트의 PUBLISH 상태를 미게시에서 게시로 변경한다. path variable은 Long타입인 event-id를 받는다.")
     @PostMapping("/events/publish/{event-id}")
-    public SuccessResponse setPublish(
-            @PathVariable("event-id") Long eventId
-    ){
+    public SuccessResponse setPublish(@PathVariable("event-id") Long eventId) {
         updatePublishStatusUseCase.execute(eventId);
         return new SuccessResponse(PUBLISH_SUCCESS_TRUE_MESSAGE);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -39,6 +39,7 @@ public class EventController {
     private final GetEventDetailUseCase getEventDetailUseCase;
     private final GetEventsUseCase getEventsUseCase;
     private final GetPublishStatusUseCase getPublishStatusUseCase;
+    private final UpdatePublishStatusUseCase updatePublishStatusUseCase;
 
     @Operation(summary = "주차권 설정", description = "주차권 행사 세부 설정(시작일, 종료일, 잔고)")
     @ApiErrorExceptionsExample(CreateEventExceptionDocs.class)
@@ -129,5 +130,17 @@ public class EventController {
     public ResponseEntity<PublishStatusResponse> getPublish(
             @PathVariable("event-id") Long eventId) {
         return ResponseEntity.ok(getPublishStatusUseCase.execute(eventId));
+    }
+
+    @Operation(
+            summary = "이벤트의 PUBLISH 상태 변경",
+            description = "이벤트의 PUBLISH 상태를 미게시에서 게시로 변경한다. path variable은 Long타입인 event-id를 받는다."
+    )
+    @PostMapping("/events/publish/{event-id}")
+    public SuccessResponse setPublish(
+            @PathVariable("event-id") Long eventId
+    ){
+        updatePublishStatusUseCase.execute(eventId);
+        return new SuccessResponse(PUBLISH_SUCCESS_TRUE_MESSAGE);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/UpdatePublishStatusUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/UpdatePublishStatusUseCase.java
@@ -14,6 +14,6 @@ public class UpdatePublishStatusUseCase {
 
     @Transactional
     public void execute(Long eventId) {
-        eventAdaptor.findById(eventId).updatePublishStatus(true);
+        eventAdaptor.findById(eventId).isPublish(true);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/UpdatePublishStatusUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/UpdatePublishStatusUseCase.java
@@ -1,0 +1,18 @@
+package com.jnu.ticketapi.api.event.service;
+
+import com.jnu.ticketcommon.annotation.UseCase;
+import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdatePublishStatusUseCase {
+
+    private final EventAdaptor eventAdaptor;
+
+    @Transactional
+    public void execute(Long eventId){
+        eventAdaptor.findById(eventId).updatePublishStatus(true);
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/UpdatePublishStatusUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/UpdatePublishStatusUseCase.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.event.service;
 
+
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,7 @@ public class UpdatePublishStatusUseCase {
     private final EventAdaptor eventAdaptor;
 
     @Transactional
-    public void execute(Long eventId){
+    public void execute(Long eventId) {
         eventAdaptor.findById(eventId).updatePublishStatus(true);
     }
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/events/UpdatePublishStatusTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/events/UpdatePublishStatusTest.java
@@ -1,0 +1,84 @@
+package com.jnu.ticketapi.events;
+
+
+import com.jnu.ticketapi.config.BaseIntegrationTest;
+import com.jnu.ticketapi.security.JwtGenerator;
+import com.jnu.ticketdomain.common.vo.DateTimePeriod;
+import com.jnu.ticketdomain.domains.events.domain.Event;
+import com.jnu.ticketdomain.domains.events.repository.EventRepository;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserRole;
+import com.jnu.ticketdomain.domains.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static com.jnu.ticketcommon.message.ResponseMessage.PUBLISH_SUCCESS_TRUE_MESSAGE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Slf4j
+public class UpdatePublishStatusTest extends BaseIntegrationTest {
+
+    @Autowired
+    private EventRepository eventRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private JwtGenerator jwtGenerator;
+
+    @BeforeEach
+    void init() {
+        User user =
+                User.builder()
+                        .email("admin@jnu.ac.kr")
+                        .pwd("asdfasdfasdf")
+                        .userRole(UserRole.ADMIN)
+                        .build();
+        userRepository.saveAndFlush(user);
+
+        Event event =
+                new Event(
+                        DateTimePeriod.builder()
+                                .startAt(LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0)))
+                                .endAt(LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 59)))
+                                .build(),
+                        null,
+                        "테스트 이벤트 제목");
+        eventRepository.saveAndFlush(event);
+    }
+
+    @DisplayName("PUBLISH 상태 변경 성공 테스트")
+    @Test
+    public void update_publish_status_test() throws Exception{
+        // given
+        String accessToken = jwtGenerator.generateAccessToken("admin@jnu.ac.kr", "ADMIN");
+
+        // when
+        ResultActions resultActions =
+                mockMvc.perform(
+                        post("/v1/events/publish/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer " + accessToken)
+                                .characterEncoding(StandardCharsets.UTF_8));
+
+        // stub
+        String responseBody =
+                resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        log.info("responseBody : " + responseBody);
+
+        // then
+
+        resultActions.andExpectAll(status().is2xxSuccessful(), jsonPath("$.message").value(PUBLISH_SUCCESS_TRUE_MESSAGE));
+
+
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/events/UpdatePublishStatusTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/events/UpdatePublishStatusTest.java
@@ -1,5 +1,9 @@
 package com.jnu.ticketapi.events;
 
+import static com.jnu.ticketcommon.message.ResponseMessage.PUBLISH_SUCCESS_TRUE_MESSAGE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jnu.ticketapi.config.BaseIntegrationTest;
 import com.jnu.ticketapi.security.JwtGenerator;
@@ -9,6 +13,10 @@ import com.jnu.ticketdomain.domains.events.repository.EventRepository;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.domain.UserRole;
 import com.jnu.ticketdomain.domains.user.repository.UserRepository;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,21 +25,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-
-import static com.jnu.ticketcommon.message.ResponseMessage.PUBLISH_SUCCESS_TRUE_MESSAGE;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @Slf4j
 public class UpdatePublishStatusTest extends BaseIntegrationTest {
 
-    @Autowired
-    private EventRepository eventRepository;
+    @Autowired private EventRepository eventRepository;
     @Autowired private UserRepository userRepository;
     @Autowired private JwtGenerator jwtGenerator;
 
@@ -58,7 +55,7 @@ public class UpdatePublishStatusTest extends BaseIntegrationTest {
 
     @DisplayName("PUBLISH 상태 변경 성공 테스트")
     @Test
-    public void update_publish_status_test() throws Exception{
+    public void update_publish_status_test() throws Exception {
         // given
         String accessToken = jwtGenerator.generateAccessToken("admin@jnu.ac.kr", "ADMIN");
 
@@ -77,8 +74,8 @@ public class UpdatePublishStatusTest extends BaseIntegrationTest {
 
         // then
 
-        resultActions.andExpectAll(status().is2xxSuccessful(), jsonPath("$.message").value(PUBLISH_SUCCESS_TRUE_MESSAGE));
-
-
+        resultActions.andExpectAll(
+                status().is2xxSuccessful(),
+                jsonPath("$.message").value(PUBLISH_SUCCESS_TRUE_MESSAGE));
     }
 }

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
@@ -15,6 +15,7 @@ public class ResponseMessage {
     public static final String USER_NOT_FOUND_MESSAGE = "유저를 찾을 수 없습니다";
     public static final String SUCCESS_SIGN_UP = "회원가입이 완료 되었습니다.";
     public static final String IS_POSSIBLE_EMAIL = "사용 가능한 이메일 입니다.";
+    public static final String PUBLISH_SUCCESS_TRUE_MESSAGE = "성공적으로 게시 되었습니다.";
 
     private ResponseMessage() {}
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -111,7 +111,7 @@ public class Event {
         Events.raise(EventStatusChangeEvent.of(this));
     }
 
-    public void updatePublishStatus(Boolean publish) {
+    public void isPublish(Boolean publish) {
         this.publish = publish;
     }
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -111,6 +111,10 @@ public class Event {
         Events.raise(EventStatusChangeEvent.of(this));
     }
 
+    public void updatePublishStatus(Boolean publish){
+        this.publish = publish;
+    }
+
     public void open() {
         //        validateOpenStatus();
         updateStatus(OPEN, AlreadyOpenStatusException.EXCEPTION);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -111,7 +111,7 @@ public class Event {
         Events.raise(EventStatusChangeEvent.of(this));
     }
 
-    public void updatePublishStatus(Boolean publish){
+    public void updatePublishStatus(Boolean publish) {
         this.publish = publish;
     }
 


### PR DESCRIPTION
## 주요 변경사항

- 통합테스트
- feat: 이벤트의 PUBLISH 상태 변경 API 

## 리뷰어에게...

## 관련 이슈

closes #235 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정