### PR TITLE
[BE-114] feat: 이벤트 PUBLISH 상태에 따라 시간/구간 설정 변경가능하게 로직 수정

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/docs/CreateEventExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/docs/CreateEventExceptionDocs.java
@@ -7,6 +7,7 @@ import com.jnu.ticketcommon.exception.TicketCodeException;
 import com.jnu.ticketcommon.interfaces.SwaggerExampleExceptions;
 import com.jnu.ticketdomain.domains.events.exception.InvalidPeriodEventException;
 import com.jnu.ticketdomain.domains.events.exception.NotIssuingEventPeriodException;
+import com.jnu.ticketdomain.domains.events.exception.PublishStatusTrueException;
 
 @ExceptionDoc
 public class CreateEventExceptionDocs implements SwaggerExampleExceptions {
@@ -19,4 +20,7 @@ public class CreateEventExceptionDocs implements SwaggerExampleExceptions {
 
     @ExplainError("시작 시간이 종료 시간보다 늦을 때 발급한 경우")
     public TicketCodeException 시작시간_종료시간_이후 = NotIssuingEventPeriodException.EXCEPTION;
+
+    @ExplainError("수정할 이벤트가 이미 PUBLISH된 경우")
+    public TicketCodeException 이벤트가_PUBLISH_TURE_상태 = PublishStatusTrueException.EXCEPTION;
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
@@ -36,10 +36,12 @@ public class EventRegisterUseCase {
     }
 
     /**
+     * 이벤트의 PUBLISH 상태가 TRUE인 경우는 수정이 불가능하다.
      * 기존 이벤트가 존재한 경우 단, (과거, 과거)는 수정이 불가하다. (과거, 미래) -> (과거, 미래 or 과거)로 수정한 경우 (과거, 미래) -> (과거,
      * 과거)로 수정한 경우
      */
     private void saveEventIfPresent(EventRegisterRequest eventRegisterRequest, Event event) {
+        event.validationPublishStatus();
         event.validateIssuePeriod();
         LocalDateTime now = LocalDateTime.now();
         Option.of(eventRegisterRequest.dateTimePeriod().getStartAt().isBefore(now))

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
@@ -36,9 +36,8 @@ public class EventRegisterUseCase {
     }
 
     /**
-     * 이벤트의 PUBLISH 상태가 TRUE인 경우는 수정이 불가능하다.
-     * 기존 이벤트가 존재한 경우 단, (과거, 과거)는 수정이 불가하다. (과거, 미래) -> (과거, 미래 or 과거)로 수정한 경우 (과거, 미래) -> (과거,
-     * 과거)로 수정한 경우
+     * 이벤트의 PUBLISH 상태가 TRUE인 경우는 수정이 불가능하다. 기존 이벤트가 존재한 경우 단, (과거, 과거)는 수정이 불가하다. (과거, 미래) -> (과거,
+     * 미래 or 과거)로 수정한 경우 (과거, 미래) -> (과거, 과거)로 수정한 경우
      */
     private void saveEventIfPresent(EventRegisterRequest eventRegisterRequest, Event event) {
         event.validationPublishStatus();

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
@@ -21,7 +21,7 @@ public class SectorDeleteUseCase {
     @Transactional
     public void execute(Long sectorId) {
         // to Sector List
-        Sector sector = sectorLoadPort.findById(sectorId);
+        Sector sector = sectorLoadPort.findByIdWherePublishIsFalse(sectorId);
         registrationRecordPort.deleteBySector(sector);
         sectorRecordPort.delete(sector);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
@@ -21,7 +21,7 @@ public class SectorDeleteUseCase {
     @Transactional
     public void execute(Long sectorId) {
         // to Sector List
-        Sector sector = sectorLoadPort.findByIdWherePublishIsFalse(sectorId);
+        Sector sector = sectorLoadPort.findByIdAndPublishIsFalse(sectorId);
         registrationRecordPort.deleteBySector(sector);
         sectorRecordPort.delete(sector);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
@@ -168,7 +168,8 @@ public class SectorRegisterUseCase {
                 },
                 validSectors -> {
                     List<Sector> prevSector = sectorLoadPort.findAll();
-                    Result<Event, Object> readyOrOpenEvent = eventLoadPort.findReadyOrOpenAndNotPublishEvent();
+                    Result<Event, Object> readyOrOpenEvent =
+                            eventLoadPort.findReadyOrOpenAndNotPublishEvent();
                     Event event = readyOrOpenEvent.getOrThrow();
                     List<Sector> sectorStream =
                             prevSector.stream()

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorRegisterUseCase.java
@@ -168,7 +168,7 @@ public class SectorRegisterUseCase {
                 },
                 validSectors -> {
                     List<Sector> prevSector = sectorLoadPort.findAll();
-                    Result<Event, Object> readyOrOpenEvent = eventLoadPort.findReadyOrOpenEvent();
+                    Result<Event, Object> readyOrOpenEvent = eventLoadPort.findReadyOrOpenAndNotPublishEvent();
                     Event event = readyOrOpenEvent.getOrThrow();
                     List<Sector> sectorStream =
                             prevSector.stream()

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
@@ -52,7 +52,7 @@ public class EventAdaptor implements EventRecordPort, EventLoadPort {
     public Result<Event, Object> findReadyOrOpenAndNotPublishEvent() {
         // READY 상태의 이벤트가 없으면 OPEN 상태의 이벤트를 가져온다.
         Optional<Event> event = eventRepository.findByEventStatus(EventStatus.READY);
-        if (event.isPresent() & !event.get().getPublish()) return Result.success(event.get());
+        if (event.isPresent() && !event.get().getPublish()) return Result.success(event.get());
         event = eventRepository.findByEventStatus(EventStatus.OPEN);
         return event.filter(e -> !e.getPublish())
                 .map(Result::success)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
@@ -48,6 +48,14 @@ public class EventAdaptor implements EventRecordPort, EventLoadPort {
                 .orElseGet(() -> Result.failure(NotFoundEventException.EXCEPTION));
     }
 
+    /**
+     * 이벤트가 존재하면서, 이벤트의 Publish상태가 false라면 이벤트를 반환한다.
+     * 위의 조건을 만족하지 못한다면, OPEN인 상태이면서 Publish상태가 false인 이벤트를 불러와 반환한다.
+     *
+     * @author Cookie
+     * @return {@link Result} 타입의 결과 반환. Result 객체는 Event와 예외타입을 담는다.
+     * @throws {@link NotFoundEventException} 이벤트를 찾지 못한 경우 발생하는 예외이다.
+     */
     @Override
     public Result<Event, Object> findReadyOrOpenAndNotPublishEvent() {
         // READY 상태의 이벤트가 없으면 OPEN 상태의 이벤트를 가져온다.

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
@@ -49,7 +49,7 @@ public class EventAdaptor implements EventRecordPort, EventLoadPort {
     }
 
     @Override
-    public Result<Event, Object> findReadyOrOpenAndNotPublishEvent(){
+    public Result<Event, Object> findReadyOrOpenAndNotPublishEvent() {
         // READY 상태의 이벤트가 없으면 OPEN 상태의 이벤트를 가져온다.
         Optional<Event> event = eventRepository.findByEventStatus(EventStatus.READY);
         if (event.isPresent() & !event.get().getPublish()) return Result.success(event.get());

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -27,6 +27,13 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
     }
 
     @Override
+    public Sector findByIdWherePublishIsFalse(Long sectorId){
+        return couponRepository
+                .findByIdWhereEventPublishIdFalse(sectorId)
+                .orElseThrow(() -> NotFoundSectorException.EXCEPTION);
+    }
+
+    @Override
     public List<Sector> findAll() {
         return couponRepository.findAll();
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -27,7 +27,7 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
     }
 
     @Override
-    public Sector findByIdWherePublishIsFalse(Long sectorId) {
+    public Sector findByIdAndPublishIsFalse(Long sectorId) {
         return couponRepository
                 .findByIdWhereEventPublishIdFalse(sectorId)
                 .orElseThrow(() -> NotFoundSectorException.EXCEPTION);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -27,7 +27,7 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
     }
 
     @Override
-    public Sector findByIdWherePublishIsFalse(Long sectorId){
+    public Sector findByIdWherePublishIsFalse(Long sectorId) {
         return couponRepository
                 .findByIdWhereEventPublishIdFalse(sectorId)
                 .orElseThrow(() -> NotFoundSectorException.EXCEPTION);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -11,7 +11,6 @@ import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.events.event.CouponExpiredEvent;
 import com.jnu.ticketdomain.domains.events.event.EventStatusChangeEvent;
 import com.jnu.ticketdomain.domains.events.exception.*;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,8 +99,8 @@ public class Event {
         }
     }
 
-    public void validationPublishStatus(){
-        if(this.publish){
+    public void validationPublishStatus() {
+        if (this.publish) {
             throw PublishStatusTrueException.EXCEPTION;
         }
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -10,13 +10,8 @@ import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.events.event.CouponExpiredEvent;
 import com.jnu.ticketdomain.domains.events.event.EventStatusChangeEvent;
-import com.jnu.ticketdomain.domains.events.exception.AlreadyCalculatingStatusException;
-import com.jnu.ticketdomain.domains.events.exception.AlreadyCloseStatusException;
-import com.jnu.ticketdomain.domains.events.exception.AlreadyOpenStatusException;
-import com.jnu.ticketdomain.domains.events.exception.AlreadyReadyStatusException;
-import com.jnu.ticketdomain.domains.events.exception.CannotModifyOpenEventException;
-import com.jnu.ticketdomain.domains.events.exception.InvalidPeriodEventException;
-import com.jnu.ticketdomain.domains.events.exception.NotOpenEventPeriodException;
+import com.jnu.ticketdomain.domains.events.exception.*;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -102,6 +97,12 @@ public class Event {
         if (dateTimePeriod.getEndAt().isBefore(nowTime)
                 || dateTimePeriod.getEndAt().isBefore(dateTimePeriod.getStartAt())) {
             throw InvalidPeriodEventException.EXCEPTION;
+        }
+    }
+
+    public void validationPublishStatus(){
+        if(this.publish){
+            throw PublishStatusTrueException.EXCEPTION;
         }
     }
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
@@ -31,6 +31,7 @@ public enum EventErrorCode implements BaseErrorCode {
     USE_OTHER_API(BAD_REQUEST, "Event_400_0", "잘못된 접근입니다."),
     NOT_EVENT_READY_STATUS(BAD_REQUEST, "Event_400_14", "이벤트가 READY상태 여야 합니다."),
     NOT_EVENT_OPEN_STATUS(BAD_REQUEST, "Event_400_15", "신청기간이 아닙니다."),
+    NOT_PUBLISH_FALSE_STATUS(BAD_REQUEST, "EVENT_400_16", "게시된 이벤트는 수정할 수 없습니다."),
     ;
     private final Integer status;
     private final String code;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/PublishStatusTrueException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/PublishStatusTrueException.java
@@ -1,0 +1,11 @@
+package com.jnu.ticketdomain.domains.events.exception;
+
+import com.jnu.ticketcommon.exception.TicketCodeException;
+
+public class PublishStatusTrueException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new PublishStatusTrueException();
+
+    private PublishStatusTrueException() {
+        super(EventErrorCode.NOT_PUBLISH_FALSE_STATUS);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/PublishStatusTrueException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/PublishStatusTrueException.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.events.exception;
 
+
 import com.jnu.ticketcommon.exception.TicketCodeException;
 
 public class PublishStatusTrueException extends TicketCodeException {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/EventLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/EventLoadPort.java
@@ -20,4 +20,6 @@ public interface EventLoadPort {
     Event findRecentEvent();
 
     Page<Event> findAllByOrderByIdDesc(Pageable pageable);
+
+    Result<Event, Object> findReadyOrOpenAndNotPublishEvent();
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
@@ -16,4 +16,6 @@ public interface SectorLoadPort {
     List<Sector> findRecentSector();
 
     List<Sector> findAllByEventStatus();
+
+    Sector findByIdWherePublishIsFalse(Long sectorId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
@@ -17,5 +17,5 @@ public interface SectorLoadPort {
 
     List<Sector> findAllByEventStatus();
 
-    Sector findByIdWherePublishIsFalse(Long sectorId);
+    Sector findByIdAndPublishIsFalse(Long sectorId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -19,4 +19,7 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
     @Query(
             "select s from Sector s join fetch s.event where s.event.eventStatus = 'OPEN' or s.event.eventStatus = 'READY'")
     List<Sector> findAllByEventStatus();
+
+    @Query("select s from Sector s where s.id = :sectorId and s.event.publish = false")
+    Optional<Sector> findByIdWhereEventPublishIdFalse(Long sectorId);
 }


### PR DESCRIPTION
## 주요 변경사항

- spotless
- 이벤트 PUBLISH가 TRUE인 경우 구간/시간 설정 불가능하게 변경
- EXCEPTION 추가

## 리뷰어에게...
- 생각보다 서현이 코드를 손댈 일이 거의 없더라구요(다행)
- 추가적으로 수정해야할 부분이 있을까요?

## 관련 이슈

closes #238 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정