### PR TITLE
[BE-117] feat : 이벤트 삭제

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -140,4 +140,13 @@ public class EventController {
         updatePublishStatusUseCase.execute(eventId);
         return new SuccessResponse(PUBLISH_SUCCESS_TRUE_MESSAGE);
     }
+    @Operation(
+            summary = "이벤트 삭제",
+            description = "이벤트를 삭제한다. path variable은 Long타입인 event-id를 받는다."
+    )
+    @DeleteMapping("/events/{event-id}")
+    public SuccessResponse deleteEvent(@PathVariable("event-id") Long eventId) {
+        EventRegisterUseCase.deleteEvent(eventId);
+        return new SuccessResponse(EVENT_SUCCESS_DELETE_MESSAGE);
+    }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -41,6 +41,7 @@ public class EventController {
     private final GetEventsUseCase getEventsUseCase;
     private final GetPublishStatusUseCase getPublishStatusUseCase;
     private final UpdatePublishStatusUseCase updatePublishStatusUseCase;
+    private final EventDeleteUseCase eventDeleteUseCase;
 
     @Operation(summary = "주차권 설정", description = "주차권 행사 세부 설정(시작일, 종료일, 잔고)")
     @ApiErrorExceptionsExample(CreateEventExceptionDocs.class)
@@ -148,7 +149,7 @@ public class EventController {
     @ApiErrorExceptionsExample(DeleteEventExceptionDocs.class)
     @DeleteMapping("/events/{event-id}")
     public SuccessResponse deleteEvent(@PathVariable("event-id") Long eventId) {
-        EventRegisterUseCase.deleteEvent(eventId);
+        eventDeleteUseCase.deleteEvent(eventId);
         return new SuccessResponse(EVENT_SUCCESS_DELETE_MESSAGE);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -3,6 +3,7 @@ package com.jnu.ticketapi.api.event.controller;
 import static com.jnu.ticketcommon.message.ResponseMessage.*;
 
 import com.jnu.ticketapi.api.event.docs.CreateEventExceptionDocs;
+import com.jnu.ticketapi.api.event.docs.DeleteEventExceptionDocs;
 import com.jnu.ticketapi.api.event.docs.ReadEventExceptionDocs;
 import com.jnu.ticketapi.api.event.docs.ReadEventPeriodExceptionDocs;
 import com.jnu.ticketapi.api.event.model.request.EventRegisterRequest;
@@ -144,6 +145,7 @@ public class EventController {
             summary = "이벤트 삭제",
             description = "이벤트를 삭제한다. path variable은 Long타입인 event-id를 받는다."
     )
+    @ApiErrorExceptionsExample(DeleteEventExceptionDocs.class)
     @DeleteMapping("/events/{event-id}")
     public SuccessResponse deleteEvent(@PathVariable("event-id") Long eventId) {
         EventRegisterUseCase.deleteEvent(eventId);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/docs/DeleteEventExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/docs/DeleteEventExceptionDocs.java
@@ -1,0 +1,13 @@
+package com.jnu.ticketapi.api.event.docs;
+
+import com.jnu.ticketcommon.annotation.ExceptionDoc;
+import com.jnu.ticketcommon.annotation.ExplainError;
+import com.jnu.ticketcommon.exception.TicketCodeException;
+import com.jnu.ticketcommon.interfaces.SwaggerExampleExceptions;
+import com.jnu.ticketdomain.domains.events.exception.NotFoundEventException;
+
+@ExceptionDoc
+public class DeleteEventExceptionDocs implements SwaggerExampleExceptions {
+    @ExplainError("삭제할 이벤트가 없는 경우")
+    public TicketCodeException 삭제할_이벤트가_없음 = NotFoundEventException.EXCEPTION;
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -1,0 +1,18 @@
+package com.jnu.ticketapi.api.event.service;
+
+import com.jnu.ticketcommon.annotation.UseCase;
+import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Event;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class EventDeleteUseCase {
+    private final EventAdaptor eventAdaptor;
+    @Transactional
+    public void deleteEvent(Long eventId) {
+        Event event = eventAdaptor.findById(eventId);
+        event.deleteEvent();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
@@ -9,6 +9,7 @@ import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.event.EventCreationEvent;
 import com.jnu.ticketdomain.domains.events.event.EventUpdatedEvent;
+import com.jnu.ticketdomain.domains.events.out.EventRecordPort;
 import io.vavr.control.Option;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -112,5 +113,9 @@ public class EventRegisterUseCase {
                             // 이벤트 상태 변경 Batch 스케줄링 (READY -> OPEN) - 이벤트
                             Events.raise(EventCreationEvent.of(savedEvent));
                         });
+    }
+    @Transactional
+    public void deleteEvent(Long eventId) {
+        eventAdaptor.findById(eventId).deleteEvent();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
@@ -114,8 +114,4 @@ public class EventRegisterUseCase {
                             Events.raise(EventCreationEvent.of(savedEvent));
                         });
     }
-    @Transactional
-    public void deleteEvent(Long eventId) {
-        eventAdaptor.findById(eventId).deleteEvent();
-    }
 }

--- a/Ticket-Api/src/main/resources/db/teardown.sql
+++ b/Ticket-Api/src/main/resources/db/teardown.sql
@@ -37,8 +37,8 @@ update user_tb
 set role = 'COUNCIL'
 where user_id = 1;
 
-insert into event(event_id, event_code, event_status, end_at, start_at)
-values (1, '596575', 'OPEN', TIMESTAMPADD(MINUTE, 30, current_time), TIMESTAMPADD(MINUTE, -30, current_time));
+insert into event(event_id, event_code, event_status, end_at, start_at, is_deleted, publish)
+values (1, '596575', 'OPEN', TIMESTAMPADD(MINUTE, 30, current_time), TIMESTAMPADD(MINUTE, -30, current_time), false, false);
 
 insert into sector(sector_id, issue_amount, name, remaining_amount, reserve, sector_capacity, sector_number, event_id, init_sector_capacity, init_reserve)
 values (1, 40, '사회대 / 농대 / 수의대 / 치전원', 40, 0, 40, '1구간', 1, 0, 0),

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/events/DeleteEventTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/events/DeleteEventTest.java
@@ -1,0 +1,104 @@
+package com.jnu.ticketapi.events;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketapi.RestDocsConfig;
+import com.jnu.ticketapi.security.JwtGenerator;
+import com.jnu.ticketcommon.message.ResponseMessage;
+import com.jnu.ticketdomain.domains.events.exception.EventErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@Slf4j
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@WithMockUser(roles = "ADMIN")
+@Sql("classpath:db/teardown.sql")
+public class DeleteEventTest extends RestDocsConfig {
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    JwtGenerator jwtGenerator;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @Nested
+    class deleteEventTest {
+        @Test
+        @DisplayName("성공 : 이벤트 삭제")
+        void success() throws Exception {
+            // given
+            String email = "admin@jnu.ac.kr";
+            Long eventId = 1L;
+            String accessToken = jwtGenerator.generateAccessToken(email, "ADMIN");
+
+            // when
+            ResultActions resultActions =
+                    mvc.perform(
+                            delete("/v1/events/" + eventId)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .header("Authorization", "Bearer " + accessToken));
+
+            // eye
+            String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+
+            //then
+            resultActions.andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.message").value(ResponseMessage.EVENT_SUCCESS_DELETE_MESSAGE));
+
+            resultActions.andDo(MockMvcResultHandlers.print()).andDo(document);
+            log.info("responseBody : {}", responseBody);
+
+        }
+
+        @Test
+        @DisplayName("실패 : 이벤트 삭제 - 존재하지 않는 이벤트")
+        void fail_not_found_event() throws Exception {
+            //given
+            String email = "admin@jnu.ac.kr";
+            Long eventId = 100L;
+            String accessToken = jwtGenerator.generateAccessToken(email, "ADMIN");
+
+            // when
+            ResultActions resultActions =
+                    mvc.perform(
+                            delete("/v1/events/" + eventId)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .header("Authorization", "Bearer " + accessToken));
+
+            // eye
+            String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+
+            //then
+            resultActions.andExpectAll(
+                    status().isNotFound(),
+                    jsonPath("$.reason").value(EventErrorCode.NOT_FOUND_EVENT.getReason()));
+
+            resultActions.andDo(MockMvcResultHandlers.print()).andDo(document);
+            log.info("responseBody : {}", responseBody);
+
+        }
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -20,11 +20,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Where(clause = "is_deleted = false")
 public class Event {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -53,6 +55,8 @@ public class Event {
     @Column(name = "publish")
     private Boolean publish;
 
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
     @Builder
     public Event(DateTimePeriod dateTimePeriod, List<Sector> sector) {
         this.eventCode = UUID.randomUUID().toString().substring(0, 6);
@@ -60,6 +64,7 @@ public class Event {
         this.sector = sector;
         this.eventStatus = EventStatus.READY;
         this.publish = false;
+        this.isDeleted = false;
     }
 
     @Builder
@@ -70,6 +75,7 @@ public class Event {
         this.title = title;
         this.eventStatus = EventStatus.READY;
         this.publish = false;
+        this.isDeleted = false;
     }
 
     @PostPersist
@@ -134,5 +140,9 @@ public class Event {
 
     public void updateDateTimePeriod(DateTimePeriod dateTimePeriod) {
         this.dateTimePeriod = dateTimePeriod;
+    }
+
+    public void deleteEvent() {
+        this.isDeleted = true;
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -2,19 +2,18 @@ package com.jnu.ticketdomain.domains.events.domain;
 
 
 import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+
+import javax.persistence.*;
+
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -58,6 +57,9 @@ public class Sector {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
+
+    @OneToMany(mappedBy = "sector", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Registration> registrations = new ArrayList<>();
 
     @Builder
     public Sector(String sectorNumber, String name, Integer sectorCapacity, Integer reserve) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -58,11 +58,11 @@ public class Registration {
     @ColumnDefault("false")
     private boolean isDeleted;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sectorId", nullable = false)
     private Sector sector;
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
@@ -2,12 +2,16 @@ package com.jnu.ticketdomain.domains.user.domain;
 
 
 import javax.persistence.*;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -45,6 +49,9 @@ public class User {
     @Column(name = "email_confirmed", nullable = false)
     @ColumnDefault("false")
     private boolean emailConfirmed;
+
+      @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+      private Registration registration;
 
     public void updateRole(UserRole userRole) {
         this.userRole = userRole;


### PR DESCRIPTION
## 주요 변경사항
1. Entity Casecade 수정
  1-1. Sector를 삭제 시 해당 구간에 관련된 Registration을 삭제한다.
  1-2. User를 삭제 시 해당 User가 신청한 Registration을 삭제한다.
 위 와 같은 의도로 
```java
     //Registration Entity
     
    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
    @JoinColumn(name = "user_id")
    private User user;

    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
    @JoinColumn(name = "sectorId", nullable = false)
    private Sector sector;
``` 
이렇게 한 것 같은데 Registration(부모) : Sector(자식) = N : 1 -> cascade는 Remove는 부모가 삭제되면 자식도 삭제된다.
따라서 1-1의 의도와는 정반대(신청 삭제 시 구간 삭제가 되버림)가 되버려서 데이터베이스 무결성 오류가 뜬다.
그래서 양방향 매핑으로 mappedBy로 부모 정하고 Casecade All 적용해줌.

2. Event 삭제 (소프트 딜리트)
3. Event 삭제 통합 테스트
4. Event 삭제 예외 docs
5. DB Event Table에 직접 is_deleted Column 추가
## 리뷰어에게...
2, 3, 4번은 간단한거라 자세한 설명은 건너 뛰었습니다.
## 관련 이슈

closes #243 
- [#243]
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정