### PR TITLE
[BE-119] feat : 이벤트 목록 조회

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/model/response/EventsInfoResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/model/response/EventsInfoResponse.java
@@ -9,7 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 
 public record EventsInfoResponse(
-        Long eventId, String eventTitle, String eventStatus, String dateTimePeriod) {
+        Long eventId, String eventTitle, String eventStatus, String dateTimePeriod, boolean publish) {
 
     @Builder(access = AccessLevel.PACKAGE)
     public EventsInfoResponse {}
@@ -20,6 +20,7 @@ public record EventsInfoResponse(
                 .eventTitle(event.getTitle())
                 .eventStatus(event.getEventStatus().toString())
                 .dateTimePeriod(EventsInfoResponse.toString(event.getDateTimePeriod()))
+                .publish(event.getPublish())
                 .build();
     }
 


### PR DESCRIPTION
## 주요 변경사항
- 응답에 이벤트의 publish 상태 정보 추가
## 리뷰어에게...
코드 한줄 수정한거라 바로 merge 하겠습니다.
## 관련 이슈

closes #250 
- [#250]
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정