### PR TITLE
[BE-122] fix: 하드코딩된 Captcha Cloudfront url을 env로 변경

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/model/response/CaptchaResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/model/response/CaptchaResponse.java
@@ -4,6 +4,7 @@ package com.jnu.ticketapi.api.captcha.model.response;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import org.springframework.beans.factory.annotation.Value;
 
 @Schema(description = "캡챠 요청 응답")
 public record CaptchaResponse(
@@ -12,13 +13,14 @@ public record CaptchaResponse(
     @Builder
     public CaptchaResponse {}
 
-    private static final String CLOUD_FRONT_URL = "d21f52knjh246f.cloudfront.net/";
+    @Value("${aws.cloudfront.url}")
+    private static String couldFrontUrl;
     private static final String IMAGE_POSTFIX = ".png";
 
     public static CaptchaResponse of(String code, Captcha captcha) {
         return CaptchaResponse.builder()
                 .captchaCode(code)
-                .captchaImageUrl(CLOUD_FRONT_URL + captcha.getImageName() + IMAGE_POSTFIX)
+                .captchaImageUrl(couldFrontUrl + "/" + captcha.getImageName() + IMAGE_POSTFIX)
                 .build();
     }
 }

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -53,3 +53,6 @@ server:
 encryption:
   algorithm: ${ENCRYPTION_ALGORITHM:AES}
   secret: ${ENCRYPTION_SECRET:jnu-parking-fighting}
+aws:
+  cloudfront:
+    url: ${CLOUD_FRONT_URL}


### PR DESCRIPTION
## 주요 변경사항
Captcha Cloudfront url이 하드코딩되어 있어 기존 인프라로 연결되어 있는 것을 고치기 위해 env로 추출하고 swarmpit에 적용합니다.

## 리뷰어에게...
핫픽스 오네가이

## 관련 이슈

closes

## 체크리스트

- [x] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정