### PR TITLE
[BE-124] fix : 구간 목록 조회

### DIFF
--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -9,10 +9,11 @@ import com.jnu.ticketdomain.domains.events.exception.NotFoundSectorException;
 import com.jnu.ticketdomain.domains.events.out.SectorLoadPort;
 import com.jnu.ticketdomain.domains.events.out.SectorRecordPort;
 import com.jnu.ticketdomain.domains.events.repository.SectorRepository;
+import lombok.RequiredArgsConstructor;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
-import lombok.RequiredArgsConstructor;
 
 @Adaptor
 @RequiredArgsConstructor
@@ -52,7 +53,10 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
 
     @Override
     public List<Sector> findAllByEventStatusAndPublishAndIsDeleted() {
-        return couponRepository.findAllByEventStatusAndPublishTrueAndIsDeletedFalse();
+        List<Sector> sectors = couponRepository.findAllByEventStatus();
+        return sectors.stream()
+                .filter(sector -> sector.getEvent().getPublish() && !sector.getEvent().isDeleted())
+                .toList();
     }
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -9,11 +9,10 @@ import com.jnu.ticketdomain.domains.events.exception.NotFoundSectorException;
 import com.jnu.ticketdomain.domains.events.out.SectorLoadPort;
 import com.jnu.ticketdomain.domains.events.out.SectorRecordPort;
 import com.jnu.ticketdomain.domains.events.repository.SectorRepository;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
 
 @Adaptor
 @RequiredArgsConstructor

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -17,9 +17,8 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
     List<Sector> findByEventId(@Param("eventId") Long eventId);
 
     @Query(
-            "select s from Sector s join fetch s.event where s.event.eventStatus = 'OPEN' or s.event.eventStatus = 'READY' "
-                    + "and s.event.publish = true and s.event.isDeleted = false")
-    List<Sector> findAllByEventStatusAndPublishTrueAndIsDeletedFalse();
+            "select s from Sector s join fetch s.event where s.event.eventStatus = 'OPEN' or s.event.eventStatus = 'READY'")
+    List<Sector> findAllByEventStatus();
 
     @Query("select s from Sector s where s.id = :sectorId and s.event.publish = false")
     Optional<Sector> findByIdWhereEventPublishIdFalse(Long sectorId);


### PR DESCRIPTION
## 주요 변경사항
```java
public List<Sector> findAllByEventStatusAndPublishAndIsDeleted() {
        List<Sector> sectors = couponRepository.findAllByEventStatus();
        return sectors.stream()
                .filter(sector -> sector.getEvent().getPublish() && !sector.getEvent().isDeleted())
                .toList();
    }
``` 
## 리뷰어에게...
이벤트 상태가 OPEN 이거나 READY인 것을 가져와서 서비스 레이어에서 filter링 하는 것으로 바꿧다.
## 관련 이슈

closes #261 
- [#261]
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정