### PR TITLE
[BE-125] refactor: 구간 삭제 에러케이스 세분화

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/docs/CreateSectorExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/docs/CreateSectorExceptionDocs.java
@@ -5,6 +5,7 @@ import com.jnu.ticketcommon.annotation.ExceptionDoc;
 import com.jnu.ticketcommon.annotation.ExplainError;
 import com.jnu.ticketcommon.exception.TicketCodeException;
 import com.jnu.ticketcommon.interfaces.SwaggerExampleExceptions;
+import com.jnu.ticketdomain.domains.events.exception.CannotUpdatePublishEventException;
 import com.jnu.ticketdomain.domains.events.exception.DuplicateSectorNameException;
 import com.jnu.ticketdomain.domains.events.exception.InvalidSectorCapacityAndRemainException;
 import com.jnu.ticketdomain.domains.events.exception.NotFoundSectorException;
@@ -21,4 +22,7 @@ public class CreateSectorExceptionDocs implements SwaggerExampleExceptions {
 
     @ExplainError("Sector 생성 검증 기준을 만족하지 못합니다. 2) 구간명이 중복됩니다.")
     public TicketCodeException 구간명_중복_생성 = DuplicateSectorNameException.EXCEPTION;
+
+    @ExplainError("이벤트가 게시된 경우")
+    public TicketCodeException 이벤트가_게시된_경우 = CannotUpdatePublishEventException.EXCEPTION;
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
@@ -23,7 +23,7 @@ public class SectorDeleteUseCase {
     public void execute(Long sectorId) {
         // to Sector List
         Sector sector = sectorLoadPort.findById(sectorId);
-        if(Boolean.TRUE.equals(sector.getEvent().getPublish()))
+        if (Boolean.TRUE.equals(sector.getEvent().getPublish()))
             throw CannotUpdatePublishEventException.EXCEPTION;
         registrationRecordPort.deleteBySector(sector);
         sectorRecordPort.delete(sector);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
@@ -3,6 +3,7 @@ package com.jnu.ticketapi.api.sector.service;
 
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.events.exception.CannotUpdatePublishEventException;
 import com.jnu.ticketdomain.domains.events.out.SectorLoadPort;
 import com.jnu.ticketdomain.domains.events.out.SectorRecordPort;
 import com.jnu.ticketdomain.domains.registration.out.RegistrationRecordPort;
@@ -21,7 +22,9 @@ public class SectorDeleteUseCase {
     @Transactional
     public void execute(Long sectorId) {
         // to Sector List
-        Sector sector = sectorLoadPort.findByIdAndPublishIsFalse(sectorId);
+        Sector sector = sectorLoadPort.findById(sectorId);
+        if(Boolean.TRUE.equals(sector.getEvent().getPublish()))
+            throw CannotUpdatePublishEventException.EXCEPTION;
         registrationRecordPort.deleteBySector(sector);
         sectorRecordPort.delete(sector);
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -26,7 +26,6 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
                 .orElseThrow(() -> NotFoundSectorException.EXCEPTION);
     }
 
-
     @Override
     public List<Sector> findAll() {
         return couponRepository.findAll();

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -26,12 +26,6 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
                 .orElseThrow(() -> NotFoundSectorException.EXCEPTION);
     }
 
-    @Override
-    public Sector findByIdAndPublishIsFalse(Long sectorId) {
-        return couponRepository
-                .findByIdWhereEventPublishIdFalse(sectorId)
-                .orElseThrow(() -> NotFoundSectorException.EXCEPTION);
-    }
 
     @Override
     public List<Sector> findAll() {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
@@ -16,6 +16,4 @@ public interface SectorLoadPort {
     List<Sector> findRecentSector();
 
     List<Sector> findAllByEventStatusAndPublishAndIsDeleted();
-
-    Sector findByIdAndPublishIsFalse(Long sectorId);
 }


### PR DESCRIPTION
## 주요 변경사항

## 리뷰어에게...
구간을 삭제 할 때 클라이언트에게 보여지는 에러를 세분화 할 필요가 있어보여서 에러케이스를 세분화 하였습니다.
ex) 이벤트가 publish되서 구간 추가, 수정,삭제가 안되는건데 에러 문구는 `존재하지 않은 구간입니다` 라는 문구가 떠서 클라이언트를 혼란스럽게 한다.
## 관련 이슈

closes #263 
- [#263]

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정