### PR TITLE
[BE-127] feat:이벤트 시간 설정, 수정 validate

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/docs/CreateEventExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/docs/CreateEventExceptionDocs.java
@@ -12,14 +12,14 @@ import com.jnu.ticketdomain.domains.events.exception.NotIssuingEventPeriodExcept
 @ExceptionDoc
 public class CreateEventExceptionDocs implements SwaggerExampleExceptions {
 
-    @ExplainError("설정한 시간이 현재를 포함하고 있을 경우")
-    public TicketCodeException 시작종료시간_현재를_포함 = InvalidPeriodEventException.EXCEPTION;
+    @ExplainError("설정한 시작 시간이 현재시간보다 과거인 경우")
+    public TicketCodeException 시작시간_현재시간보다_과거 = InvalidPeriodEventException.EXCEPTION;
 
-    @ExplainError("설정한 시간이 이미 지났을 때 발급한 경우")
-    public TicketCodeException 종료시간_지남 = NotIssuingEventPeriodException.EXCEPTION;
+    @ExplainError("설정한 종료 시간이 현재시간보다 과거인 경우")
+    public TicketCodeException 종료시간_현재시간보다_과거 = InvalidPeriodEventException.EXCEPTION;
 
-    @ExplainError("시작 시간이 종료 시간보다 늦을 때 발급한 경우")
-    public TicketCodeException 시작시간_종료시간_이후 = NotIssuingEventPeriodException.EXCEPTION;
+    @ExplainError("시작 시간이 종료 시간보다 미래로 설정한 경우")
+    public TicketCodeException 시작시간이_종료시간_이후 = NotIssuingEventPeriodException.EXCEPTION;
 
     @ExplainError("제목이 빈칸인 경우")
     public TicketCodeException 제목이_빈칸일_때 =

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/docs/UpdateEventExceptionDocs.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/docs/UpdateEventExceptionDocs.java
@@ -13,14 +13,14 @@ import com.jnu.ticketdomain.domains.events.exception.NotIssuingEventPeriodExcept
 
 @ExceptionDoc
 public class UpdateEventExceptionDocs implements SwaggerExampleExceptions {
-    @ExplainError("설정한 시간이 현재를 포함하고 있을 경우")
-    public TicketCodeException 시작종료시간_현재를_포함 = InvalidPeriodEventException.EXCEPTION;
+    @ExplainError("설정한 시작 시간이 현재시간보다 과거인 경우")
+    public TicketCodeException 시작시간_현재시간보다_과거 = InvalidPeriodEventException.EXCEPTION;
 
-    @ExplainError("설정한 시간이 이미 지났을 때 발급한 경우")
-    public TicketCodeException 종료시간_지남 = NotIssuingEventPeriodException.EXCEPTION;
+    @ExplainError("설정한 종료 시간이 현재시간보다 과거인 경우")
+    public TicketCodeException 종료시간_현재시간보다_과거 = InvalidPeriodEventException.EXCEPTION;
 
-    @ExplainError("시작 시간이 종료 시간보다 늦을 때 발급한 경우")
-    public TicketCodeException 시작시간_종료시간_이후 = NotIssuingEventPeriodException.EXCEPTION;
+    @ExplainError("시작 시간이 종료 시간보다 미래로 설정한 경우")
+    public TicketCodeException 시작시간이_종료시간_이후 = NotIssuingEventPeriodException.EXCEPTION;
 
     @ExplainError("이벤트가 게시된 경우")
     public TicketCodeException 이벤트가_게시된_경우 = CannotUpdatePublishEventException.EXCEPTION;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventRegisterUseCase.java
@@ -4,6 +4,7 @@ package com.jnu.ticketapi.api.event.service;
 import com.jnu.ticketapi.api.event.model.request.EventRegisterRequest;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.common.domainEvent.Events;
+import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.event.EventCreationEvent;
@@ -22,6 +23,7 @@ public class EventRegisterUseCase {
 
     @Transactional
     public void registerEvent(EventRegisterRequest eventRegisterRequest) {
+        DateTimePeriod.validateEventIssuePeriod(eventRegisterRequest.dateTimePeriod());
         firstSaveEvent(eventRegisterRequest);
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventUpdateUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventUpdateUseCase.java
@@ -4,15 +4,14 @@ package com.jnu.ticketapi.api.event.service;
 import com.jnu.ticketapi.api.event.model.request.EventUpdateRequest;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.exception.TicketCodeException;
+import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.exception.CannotUpdateClosedEventException;
 import com.jnu.ticketdomain.domains.events.exception.CannotUpdatePublishEventException;
-import com.jnu.ticketdomain.domains.events.exception.InvalidPeriodEventException;
 import io.vavr.collection.Seq;
 import io.vavr.control.Validation;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +22,7 @@ public class EventUpdateUseCase {
 
     @Transactional
     public void updateEvent(EventUpdateRequest eventUpdateRequest, Long eventId) {
-        validateEventIssuePeriod(eventUpdateRequest);
+        DateTimePeriod.validateEventIssuePeriod(eventUpdateRequest.dateTimePeriod());
         Event event = eventAdaptor.findById(eventId);
         Validation<Seq<TicketCodeException>, Event> result = validateUpdateEvent(event);
         result.fold(
@@ -50,15 +49,5 @@ public class EventUpdateUseCase {
         if (Boolean.TRUE.equals(event.getPublish()))
             throw CannotUpdatePublishEventException.EXCEPTION;
         return Validation.valid(event);
-    }
-
-    private void validateEventIssuePeriod(EventUpdateRequest request) {
-        LocalDateTime nowTime = LocalDateTime.now();
-        if (request.dateTimePeriod().getEndAt().isBefore(nowTime)
-                || request.dateTimePeriod()
-                        .getEndAt()
-                        .isBefore(request.dateTimePeriod().getStartAt())) {
-            throw InvalidPeriodEventException.EXCEPTION;
-        }
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/vo/DateTimePeriod.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/vo/DateTimePeriod.java
@@ -2,12 +2,10 @@ package com.jnu.ticketdomain.common.vo;
 
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.jnu.ticketdomain.domains.events.exception.InvalidPeriodEventException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import javax.persistence.Embeddable;
-
-import com.jnu.ticketdomain.domains.events.exception.CannotBeModifiedPastTimeException;
-import com.jnu.ticketdomain.domains.events.exception.InvalidPeriodEventException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,11 +34,13 @@ public class DateTimePeriod {
 
     public static void validateEventIssuePeriod(DateTimePeriod dateTimePeriod) {
         LocalDateTime nowTime = LocalDateTime.now();
-        if (dateTimePeriod.getEndAt().isBefore(nowTime) || dateTimePeriod.getStartAt().isBefore(nowTime)
+        if (dateTimePeriod.getEndAt().isBefore(nowTime)
+                || dateTimePeriod.getStartAt().isBefore(nowTime)
                 || dateTimePeriod.getEndAt().isBefore(dateTimePeriod.getStartAt())) {
             throw InvalidPeriodEventException.EXCEPTION;
         }
     }
+
     public boolean contains(LocalDateTime datetime) {
         return (datetime.isAfter(startAt) || datetime.equals(startAt))
                 && (datetime.isBefore(endAt) || datetime.equals(endAt));

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/vo/DateTimePeriod.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/vo/DateTimePeriod.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import javax.persistence.Embeddable;
+
+import com.jnu.ticketdomain.domains.events.exception.CannotBeModifiedPastTimeException;
+import com.jnu.ticketdomain.domains.events.exception.InvalidPeriodEventException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +34,13 @@ public class DateTimePeriod {
         return new DateTimePeriod(startAt, endAt);
     }
 
+    public static void validateEventIssuePeriod(DateTimePeriod dateTimePeriod) {
+        LocalDateTime nowTime = LocalDateTime.now();
+        if (dateTimePeriod.getEndAt().isBefore(nowTime) || dateTimePeriod.getStartAt().isBefore(nowTime)
+                || dateTimePeriod.getEndAt().isBefore(dateTimePeriod.getStartAt())) {
+            throw InvalidPeriodEventException.EXCEPTION;
+        }
+    }
     public boolean contains(LocalDateTime datetime) {
         return (datetime.isAfter(startAt) || datetime.equals(startAt))
                 && (datetime.isBefore(endAt) || datetime.equals(endAt));


### PR DESCRIPTION
## 주요 변경사항
```java
public static void validateEventIssuePeriod(DateTimePeriod dateTimePeriod) {
        LocalDateTime nowTime = LocalDateTime.now();
        if (dateTimePeriod.getEndAt().isBefore(nowTime)
                || dateTimePeriod.getStartAt().isBefore(nowTime)
                || dateTimePeriod.getEndAt().isBefore(dateTimePeriod.getStartAt())) {
            throw InvalidPeriodEventException.EXCEPTION;
        }
    }
``` 
## 리뷰어에게...
DateTimePeriod에 static 메서드로 이벤트 발급 가능 시간을 검증하는 메서드를 추가하였습니다.
이 static메서드로 EventRegisterUseCase, EventUpdateUseCase에서 검증을 하였습니다.
## 관련 이슈

closes #267 
- [#267]

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정