### PR TITLE
[BE-131] feat: 이벤트 상태가 CLOSED 될 시 redis 비우고 관련 sector, registration 삭제

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -5,9 +5,11 @@ import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.consts.TicketStatic;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.event.EventDeletedEvent;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventDeleteUseCase {
     private final EventAdaptor eventAdaptor;
     private final RedisRepository redisRepository;
+    private final SectorAdaptor sectorAdaptor;
+    private final RegistrationAdaptor registrationAdaptor;
 
     @Transactional
     public void deleteEvent(Long eventId) {
@@ -25,5 +29,7 @@ public class EventDeleteUseCase {
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
         redisRepository.sRem(TicketStatic.REDIS_EVENT_ISSUE_STORE);
+        sectorAdaptor.deleteByEvent(eventId);
+        registrationAdaptor.deleteByEvent(eventId);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -2,10 +2,13 @@ package com.jnu.ticketapi.api.event.service;
 
 
 import com.jnu.ticketcommon.annotation.UseCase;
+import com.jnu.ticketcommon.consts.TicketStatic;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
+import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.event.EventDeletedEvent;
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,11 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EventDeleteUseCase {
     private final EventAdaptor eventAdaptor;
+    private final RedisRepository redisRepository;
 
     @Transactional
     public void deleteEvent(Long eventId) {
         Event event = eventAdaptor.findById(eventId);
         Events.raise(EventDeletedEvent.of(event));
         event.deleteEvent();
+        event.updateStatus(EventStatus.CLOSED, null);
+        redisRepository.sRem(TicketStatic.REDIS_EVENT_ISSUE_STORE);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -143,7 +143,7 @@ public class RegistrationUseCase {
     private void reFinalRegisterProcess(
             Registration tempRegistration, Registration registration, User user, String email) {
         tempRegistration.update(registration);
-        tempRegistration.updateIsSaved(false);
+        tempRegistration.updateIsSaved(true);
         eventWithDrawUseCase.issueEvent(user.getId());
         redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/controller/SectorController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/controller/SectorController.java
@@ -1,8 +1,6 @@
 package com.jnu.ticketapi.api.sector.controller;
 
-import static com.jnu.ticketcommon.message.ResponseMessage.SECTOR_SUCCESS_DELETE_MESSAGE;
-import static com.jnu.ticketcommon.message.ResponseMessage.SECTOR_SUCCESS_REGISTER_MESSAGE;
-import static com.jnu.ticketcommon.message.ResponseMessage.SECTOR_SUCCESS_UPDATE_MESSAGE;
+import static com.jnu.ticketcommon.message.ResponseMessage.*;
 
 import com.jnu.ticketapi.api.sector.docs.CreateSectorExceptionDocs;
 import com.jnu.ticketapi.api.sector.docs.ReadSectorExceptionDocs;
@@ -20,14 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Tag(name = "3. [구간]")

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/sector/service/SectorDeleteUseCase.java
@@ -25,7 +25,7 @@ public class SectorDeleteUseCase {
         Sector sector = sectorLoadPort.findById(sectorId);
         if (Boolean.TRUE.equals(sector.getEvent().getPublish()))
             throw CannotUpdatePublishEventException.EXCEPTION;
-        registrationRecordPort.deleteBySector(sector);
-        sectorRecordPort.delete(sector);
+        registrationRecordPort.deleteBySector(sectorId);
+        sectorRecordPort.delete(sectorId);
     }
 }

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/EventDeletedEventHandler.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/EventDeletedEventHandler.java
@@ -4,7 +4,7 @@ package com.jnu.ticketbatch;
 import com.jnu.ticketbatch.job.EventRegisterJob;
 import com.jnu.ticketbatch.job.EventUpdateJob;
 import com.jnu.ticketdomain.domains.events.domain.Event;
-import com.jnu.ticketdomain.domains.events.event.EventCreationEvent;
+import com.jnu.ticketdomain.domains.events.event.EventDeletedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -25,12 +25,12 @@ public class EventDeletedEventHandler {
     @SneakyThrows
     @Async
     @TransactionalEventListener(
-            classes = EventCreationEvent.class,
+            classes = EventDeletedEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handle(EventCreationEvent eventCreationEvent) {
+    public void handle(EventDeletedEvent eventDeletedEvent) {
         // 예약 스케줄링
-        Event event = eventCreationEvent.getEvent();
+        Event event = eventDeletedEvent.getEvent();
         try {
             eventUpdateJob.cancelScheduledJob(event.getId());
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/EventDeletedEventHandler.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/EventDeletedEventHandler.java
@@ -35,7 +35,7 @@ public class EventDeletedEventHandler {
             eventUpdateJob.cancelScheduledJob(event.getId());
         } catch (Exception e) {
             log.info("스케줄링 실패 : " + e.getMessage());
-            throw
+            throw e;
         }
     }
 }

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
@@ -64,7 +64,7 @@ public class EventRegisterJob implements Job {
         jobDataMap.put("eventId", eventId);
         JobDetail reserveEventQuartzJob =
                 newJob(QuartzJobLauncher.class)
-                        .withIdentity("RESERVATION_JOB" + eventId, "group1")
+                        .withIdentity("RESERVATION_JOB", "group1")
                         .usingJobData("eventId", eventId) // Pass eventId as job data
                         .setJobData(jobDataMap)
                         .build();
@@ -96,7 +96,7 @@ public class EventRegisterJob implements Job {
         jobDataMap.put("jobLauncher", jobLauncher);
         JobDetail expiredEventQuartzJob =
                 newJob(BatchQuartzJob.class)
-                        .withIdentity("EXPIRED_JOB" + eventId, "group1")
+                        .withIdentity("EXPIRED_JOB", "group1")
                         .usingJobData("eventId", eventId)
                         //                .usingJobData("endAt", endAt.toString())
                         .setJobData(jobDataMap)

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventUpdateJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventUpdateJob.java
@@ -57,9 +57,9 @@ public class EventUpdateJob implements Job {
             Scheduler sched = schedFact.getScheduler();
 
             // JobKey 생성
-            JobKey jobKey1 = JobKey.jobKey("RESERVATION_JOB" + eventId, "group1");
+            JobKey jobKey1 = JobKey.jobKey("RESERVATION_JOB", "group1");
             log.info(">>>>> 예약 생성 작업 스케줄러에서 삭제");
-            JobKey jobKey2 = JobKey.jobKey("EXPIRED_JOB" + eventId, "group1");
+            JobKey jobKey2 = JobKey.jobKey("EXPIRED_JOB", "group1");
             log.info(">>>>> 만료 작업 스케줄러에서 삭제");
             // 스케줄러에서 작업 삭제
             if (sched.checkExists(jobKey1)) { // 해당 JobKey로 등록된 작업이 존재하는지 확인
@@ -85,7 +85,7 @@ public class EventUpdateJob implements Job {
 
         JobDetail reserveEventQuartzJob =
                 newJob(QuartzJobLauncher.class)
-                        .withIdentity("RESERVATION_JOB" + eventId, "group1")
+                        .withIdentity("RESERVATION_JOB", "group1")
                         .usingJobData("eventId", eventId) // Pass eventId as job data
                         .setJobData(jobDataMap)
                         .build();

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -119,7 +119,12 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
     //    }
 
     @Override
-    public void delete(Sector sector) {
-        couponRepository.delete(sector);
+    public void delete(Long sectorId) {
+        couponRepository.delete(sectorId);
+    }
+
+    @Override
+    public void deleteByEvent(Long eventId) {
+        couponRepository.deleteByEventId(eventId);
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -112,7 +112,7 @@ public class Event {
         }
     }
 
-    private void updateStatus(EventStatus status, TicketCodeException exception) {
+    public void updateStatus(EventStatus status, TicketCodeException exception) {
         //        if (this.eventStatus == status) throw exception;
         this.eventStatus = status;
         Events.raise(EventStatusChangeEvent.of(this));

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -11,12 +11,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Getter
+@Where(clause = "is_deleted = false")
 public class Sector {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,6 +53,9 @@ public class Sector {
     @Column(name = "remaining_amount")
     private Integer remainingAmount;
 
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
@@ -68,6 +73,7 @@ public class Sector {
         this.initReserve = reserve;
         this.issueAmount = sectorCapacity + reserve;
         this.remainingAmount = this.issueAmount;
+        this.isDeleted = false;
     }
 
     public void resetAmount() {
@@ -120,6 +126,7 @@ public class Sector {
         this.initReserve = sector.reserve;
         this.initSectorCapacity = sector.sectorCapacity;
         this.remainingAmount = issueAmount;
+        this.isDeleted = sector.isDeleted;
     }
 
     public void setEvent(Event savedEvent) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorRecordPort.java
@@ -2,7 +2,6 @@ package com.jnu.ticketdomain.domains.events.out;
 
 
 import com.jnu.ticketcommon.annotation.Port;
-import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import java.util.List;
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorRecordPort.java
@@ -2,6 +2,7 @@ package com.jnu.ticketdomain.domains.events.out;
 
 
 import com.jnu.ticketcommon.annotation.Port;
+import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import java.util.List;
 
@@ -13,5 +14,7 @@ public interface SectorRecordPort {
 
     void updateAll(List<Sector> prevSector, List<Sector> sectorList);
 
-    void delete(Sector sector);
+    void delete(Long sectorId);
+
+    void deleteByEvent(Long eventId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -2,12 +2,13 @@ package com.jnu.ticketdomain.domains.events.repository;
 
 
 import com.jnu.ticketdomain.domains.events.domain.Sector;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SectorRepository extends JpaRepository<Sector, Long> {
@@ -22,4 +23,9 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
 
     @Query("select s from Sector s where s.id = :sectorId and s.event.publish = false")
     Optional<Sector> findByIdWhereEventPublishIdFalse(Long sectorId);
+    @Query("update Sector s SET s.isDeleted = true where s.event.id = :eventId")
+    void deleteByEventId(Long eventId);
+
+    @Query("update Sector s SET s.isDeleted = true where s.id = :sectorId")
+    void delete(Long sectorId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -2,13 +2,12 @@ package com.jnu.ticketdomain.domains.events.repository;
 
 
 import com.jnu.ticketdomain.domains.events.domain.Sector;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface SectorRepository extends JpaRepository<Sector, Long> {
@@ -23,6 +22,7 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
 
     @Query("select s from Sector s where s.id = :sectorId and s.event.publish = false")
     Optional<Sector> findByIdWhereEventPublishIdFalse(Long sectorId);
+
     @Query("update Sector s SET s.isDeleted = true where s.event.id = :eventId")
     void deleteByEventId(Long eventId);
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -33,8 +33,13 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     }
 
     @Override
-    public void deleteBySector(Sector sector) {
-        registrationRepository.deleteBySectorId(sector.getId());
+    public void deleteBySector(Long sectorId) {
+        registrationRepository.deleteBySectorId(sectorId);
+    }
+
+    @Override
+    public void deleteByEvent(Long eventId) {
+        registrationRepository.deleteByEventId(eventId);
     }
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -2,7 +2,6 @@ package com.jnu.ticketdomain.domains.registration.adaptor;
 
 
 import com.jnu.ticketcommon.annotation.Adaptor;
-import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.NotFoundRegistrationException;
 import com.jnu.ticketdomain.domains.registration.out.RegistrationLoadPort;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationRecordPort.java
@@ -9,5 +9,7 @@ public interface RegistrationRecordPort {
 
     void delete(Registration registration);
 
-    void deleteBySector(Sector sector);
+    void deleteBySector(Long sectorId);
+
+    void deleteByEvent(Long eventId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationRecordPort.java
@@ -1,7 +1,6 @@
 package com.jnu.ticketdomain.domains.registration.out;
 
 
-import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 
 public interface RegistrationRecordPort {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -22,11 +22,12 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
             "select r from Registration r where r.isDeleted = false and r.isSaved = true and r.sector.event.id = :eventId")
     List<Registration> findByIsDeletedFalseAndIsSavedTrue(@Param("eventId") Long eventId);
 
-    @Query("DELETE FROM Registration r WHERE r.sector.id = :id")
-    @Modifying
-    void deleteBySectorId(Long id);
+    @Query("UPDATE Registration r SET r.isDeleted = true WHERE r.sector.id = :sectorId")
+    void deleteBySectorId(Long sectorId);
 
     Boolean existsByEmailAndIsSavedTrue(String email);
 
     Boolean existsByStudentNumAndIsSavedTrue(String studentNum);
+    @Query("update Registration r SET  r.isDeleted = true where r.sector.event.id = :eventId")
+    void deleteByEventId(Long eventId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -5,7 +5,6 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -28,6 +27,7 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
     Boolean existsByEmailAndIsSavedTrue(String email);
 
     Boolean existsByStudentNumAndIsSavedTrue(String studentNum);
+
     @Query("update Registration r SET  r.isDeleted = true where r.sector.event.id = :eventId")
     void deleteByEventId(Long eventId);
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -72,8 +72,8 @@ public class RedisRepository {
         return redisTemplate.opsForSet().add(key, value);
     }
 
-    public Long sRem(String key, Object value) {
-        return redisTemplate.opsForSet().remove(key, value);
+    public Long sRem(String key) {
+        return redisTemplate.opsForSet().remove(key);
     }
 
     public Long sCard(String key) {


### PR DESCRIPTION
## 주요 변경사항
1. 이벤트 삭제시 이벤트의 status를 CLOSED로 바꾸고 is_deleted를 true로 update한다.
2. 이벤트 삭제, 이벤트의 시간이 다 지나서 CLOSED시 redis 비우고 관련 sector, registration 삭제
3. Sector Entity에 isDeleted 추가
  - DB에 직접 컬럼 추가 완료
4. Quartz withIdentity에서 eventId 제거
5. 구간 삭제 시 구간과 연관된 신청(registration)을 모두 소프트 딜리트
6. reFinalRegisterProcess에서 isSaved를 true로 업데이트 하도록 수정
## 리뷰어에게...
1. EventDeletedEventHandler에서 `@SneakyThrows`를 사용했던데 이T 어노테이션은 checked exception을 마치 unchecked exception처럼 취급하게 해주는 어노테이션인 걸로 알고있다. 
`@SneakyThrows`를 메소드에 적용하고 던질 주체 없이 throw 만 하고있던데 이게 가능한건지? 아니면 잘못 작성한건지 궁금하다. (일단 저는 컴파일 에러가 떳습니다.)

2. 이벤트 삭제 시 redis를 비워야하는데 redis에 정확히 무엇을 어떻게 저장하고있는지 파악하지 못하여 `REDIS_EVENT_ISSUE_STORE` 를 Key로 가지는 것을 지우는 것으로 했는데 옳바르게 한 것인지?
3. reFinalRegisterProcess은 finalSave 작업이므로 isSaved를 true로 변경하는게 맞지 않나?
## 관련 이슈

closes #274 
- [#274 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정