### PR TITLE
[BE-132] bug: 이전에 신청한 사람은 다음에 신청 할 수 없는 버그

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -9,6 +9,7 @@ import com.jnu.ticketapi.api.event.model.request.UpdateEventPublishRequest;
 import com.jnu.ticketapi.api.event.model.request.UpdateEventStatusRequest;
 import com.jnu.ticketapi.api.event.model.response.EventDetailResponse;
 import com.jnu.ticketapi.api.event.model.response.EventsPagingResponse;
+import com.jnu.ticketapi.api.event.model.response.GetEventPeriodResponse;
 import com.jnu.ticketapi.api.event.model.response.PublishStatusResponse;
 import com.jnu.ticketapi.api.event.service.*;
 import com.jnu.ticketcommon.annotation.ApiErrorExceptionsExample;
@@ -103,7 +104,7 @@ public class EventController {
     @Operation(summary = "주차권 신청 기간 조회", description = "주차권 신청 기간 조회")
     @ApiErrorExceptionsExample(ReadEventPeriodExceptionDocs.class)
     @GetMapping("/events/period")
-    public ResponseEntity<DateTimePeriod> getEventPeriod() {
+    public ResponseEntity<GetEventPeriodResponse> getEventPeriod() {
         return ResponseEntity.ok(EventWithDrawUseCase.getEventPeriod());
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/model/response/GetEventPeriodResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/model/response/GetEventPeriodResponse.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.event.model.response;
 
+
 import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import lombok.Builder;
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/model/response/GetEventPeriodResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/model/response/GetEventPeriodResponse.java
@@ -1,0 +1,15 @@
+package com.jnu.ticketapi.api.event.model.response;
+
+import com.jnu.ticketdomain.common.vo.DateTimePeriod;
+import lombok.Builder;
+
+@Builder
+public record GetEventPeriodResponse(DateTimePeriod dateTimePeriod, Long eventId) {
+
+    public static GetEventPeriodResponse of(DateTimePeriod dateTimePeriod, Long eventId) {
+        return GetEventPeriodResponse.builder()
+                .dateTimePeriod(dateTimePeriod)
+                .eventId(eventId)
+                .build();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -8,14 +8,11 @@ import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
-import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.event.EventDeletedEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -8,11 +8,14 @@ import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.event.EventDeletedEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
@@ -25,10 +28,11 @@ public class EventDeleteUseCase {
     @Transactional
     public void deleteEvent(Long eventId) {
         Event event = eventAdaptor.findById(eventId);
+        List<Sector> sector = event.getSector();
         Events.raise(EventDeletedEvent.of(event));
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
-        redisRepository.sRem(TicketStatic.REDIS_EVENT_ISSUE_STORE);
+        redisRepository.delete(TicketStatic.REDIS_EVENT_ISSUE_STORE);
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -28,7 +28,6 @@ public class EventDeleteUseCase {
     @Transactional
     public void deleteEvent(Long eventId) {
         Event event = eventAdaptor.findById(eventId);
-        List<Sector> sector = event.getSector();
         Events.raise(EventDeletedEvent.of(event));
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -2,6 +2,7 @@ package com.jnu.ticketapi.api.event.service;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
+import com.jnu.ticketapi.api.event.model.response.GetEventPeriodResponse;
 import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.utils.Result;
@@ -57,12 +58,12 @@ public class EventWithDrawUseCase {
         return waitingQueueService.getWaitingOrder(REDIS_EVENT_ISSUE_STORE, currentUserId);
     }
 
-    public DateTimePeriod getEventPeriod() {
+    public GetEventPeriodResponse getEventPeriod() {
         Result<Event, Object> readyEvent = eventAdaptor.findReadyOrOpenEvent();
         return readyEvent.fold(
                 (event) -> {
                     if (event.getPublish().equals(false)) throw NotPublishEventException.EXCEPTION;
-                    return event.getDateTimePeriod();
+                    return GetEventPeriodResponse.of(event.getDateTimePeriod(), event.getId());
                 },
                 (error) -> {
                     throw AlreadyCloseStatusException.EXCEPTION;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/controller/RegistrationController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/controller/RegistrationController.java
@@ -32,27 +32,27 @@ public class RegistrationController {
     @Operation(
             summary = "임시 저장 조회",
             description = "임시 저장 했던 정보를 조회(임시 저장을 하지 않은 유저는 Email, Sector 빼고 null 반환)")
-    @GetMapping("/registration")
-    public ResponseEntity<GetRegistrationResponse> getRegistration(@GetEmail String email) {
-        GetRegistrationResponse responseDto = registrationUseCase.getRegistration(email);
+    @GetMapping("/registration/{event-id}")
+    public ResponseEntity<GetRegistrationResponse> getRegistration(@GetEmail String email, @PathVariable("event-id") Long eventId) {
+        GetRegistrationResponse responseDto = registrationUseCase.getRegistration(email, eventId);
         return ResponseEntity.ok(responseDto);
     }
 
     @Operation(summary = "주차권 임시 저장", description = "주차권 임시 저장(주차권 신청시 잔고 감소)")
-    @PostMapping("/registration/temporary")
+    @PostMapping("/registration/temporary/{event-id}")
     @ApiErrorExceptionsExample(TemporarySaveExceptionFDocs.class)
     public ResponseEntity<TemporarySaveResponse> temporarySave(
-            @RequestBody @Valid TemporarySaveRequest requestDto, @GetEmail String email) {
-        TemporarySaveResponse responseDto = registrationUseCase.temporarySave(requestDto, email);
+            @RequestBody @Valid TemporarySaveRequest requestDto, @GetEmail String email, @PathVariable("event-id") Long eventId) {
+        TemporarySaveResponse responseDto = registrationUseCase.temporarySave(requestDto, email, eventId);
         return ResponseEntity.ok(responseDto);
     }
 
     @Operation(summary = "1차 신청", description = "1차 신청")
-    @PostMapping("/registration")
+    @PostMapping("/registration/{event-id}")
     @ApiErrorExceptionsExample(FinalSaveExceptionDocs.class)
     public ResponseEntity<FinalSaveResponse> finalSave(
-            @RequestBody @Valid FinalSaveRequest requestDto, @GetEmail String email) {
-        FinalSaveResponse responseDto = registrationUseCase.finalSave(requestDto, email);
+            @RequestBody @Valid FinalSaveRequest requestDto, @GetEmail String email, @PathVariable("event-id") Long eventId) {
+        FinalSaveResponse responseDto = registrationUseCase.finalSave(requestDto, email, eventId);
         return ResponseEntity.ok(responseDto);
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/controller/RegistrationController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/controller/RegistrationController.java
@@ -33,7 +33,8 @@ public class RegistrationController {
             summary = "임시 저장 조회",
             description = "임시 저장 했던 정보를 조회(임시 저장을 하지 않은 유저는 Email, Sector 빼고 null 반환)")
     @GetMapping("/registration/{event-id}")
-    public ResponseEntity<GetRegistrationResponse> getRegistration(@GetEmail String email, @PathVariable("event-id") Long eventId) {
+    public ResponseEntity<GetRegistrationResponse> getRegistration(
+            @GetEmail String email, @PathVariable("event-id") Long eventId) {
         GetRegistrationResponse responseDto = registrationUseCase.getRegistration(email, eventId);
         return ResponseEntity.ok(responseDto);
     }
@@ -42,8 +43,11 @@ public class RegistrationController {
     @PostMapping("/registration/temporary/{event-id}")
     @ApiErrorExceptionsExample(TemporarySaveExceptionFDocs.class)
     public ResponseEntity<TemporarySaveResponse> temporarySave(
-            @RequestBody @Valid TemporarySaveRequest requestDto, @GetEmail String email, @PathVariable("event-id") Long eventId) {
-        TemporarySaveResponse responseDto = registrationUseCase.temporarySave(requestDto, email, eventId);
+            @RequestBody @Valid TemporarySaveRequest requestDto,
+            @GetEmail String email,
+            @PathVariable("event-id") Long eventId) {
+        TemporarySaveResponse responseDto =
+                registrationUseCase.temporarySave(requestDto, email, eventId);
         return ResponseEntity.ok(responseDto);
     }
 
@@ -51,7 +55,9 @@ public class RegistrationController {
     @PostMapping("/registration/{event-id}")
     @ApiErrorExceptionsExample(FinalSaveExceptionDocs.class)
     public ResponseEntity<FinalSaveResponse> finalSave(
-            @RequestBody @Valid FinalSaveRequest requestDto, @GetEmail String email, @PathVariable("event-id") Long eventId) {
+            @RequestBody @Valid FinalSaveRequest requestDto,
+            @GetEmail String email,
+            @PathVariable("event-id") Long eventId) {
         FinalSaveResponse responseDto = registrationUseCase.finalSave(requestDto, email, eventId);
         return ResponseEntity.ok(responseDto);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -108,7 +108,8 @@ public class RegistrationUseCase {
         validateEventPublish(sector);
         validateEventStatusIsClosed(sector);
         if (registrationAdaptor.existsByEmailAndIsSavedTrue(email, eventId)
-                || registrationAdaptor.existsByStudentNumAndIsSavedTrue(requestDto.studentNum(), eventId)) {
+                || registrationAdaptor.existsByStudentNumAndIsSavedTrue(
+                        requestDto.studentNum(), eventId)) {
             throw AlreadyExistRegistrationException.EXCEPTION;
         }
         Long captchaId = encryption.decrypt(requestDto.captchaCode());

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -55,6 +55,7 @@ public class RegistrationUseCase {
         Optional<Registration> registration =
                 registrationAdaptor.findByEmailAndIsSaved(email, flag, eventId);
         return registration
+                .filter(r -> r.getSector().getEvent().getId().equals(eventId))
                 .map(Result::success)
                 .orElseGet(() -> Result.failure(NotFoundRegistrationException.EXCEPTION));
     }
@@ -106,8 +107,8 @@ public class RegistrationUseCase {
         Sector sector = sectorAdaptor.findById(requestDto.selectSectorId());
         validateEventPublish(sector);
         validateEventStatusIsClosed(sector);
-        if (registrationAdaptor.existsByEmailAndIsSavedTrue(email)
-                || registrationAdaptor.existsByStudentNumAndIsSavedTrue(requestDto.studentNum())) {
+        if (registrationAdaptor.existsByEmailAndIsSavedTrue(email, eventId)
+                || registrationAdaptor.existsByStudentNumAndIsSavedTrue(requestDto.studentNum(), eventId)) {
             throw AlreadyExistRegistrationException.EXCEPTION;
         }
         Long captchaId = encryption.decrypt(requestDto.captchaCode());

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -50,9 +50,10 @@ public class RegistrationUseCase {
         return registrationAdaptor.save(registration);
     }
 
-
-    public Result<Registration, Object> findResultByEmail(String email, boolean flag, Long eventId) {
-        Optional<Registration> registration = registrationAdaptor.findByEmailAndIsSaved(email,flag,eventId);
+    public Result<Registration, Object> findResultByEmail(
+            String email, boolean flag, Long eventId) {
+        Optional<Registration> registration =
+                registrationAdaptor.findByEmailAndIsSaved(email, flag, eventId);
         return registration
                 .map(Result::success)
                 .orElseGet(() -> Result.failure(NotFoundRegistrationException.EXCEPTION));
@@ -64,7 +65,8 @@ public class RegistrationUseCase {
 
     @Transactional(readOnly = true)
     public GetRegistrationResponse getRegistration(String email, Long eventId) {
-        Optional<Registration> registration = registrationAdaptor.findByEmailAndIsSaved(email,false,eventId);
+        Optional<Registration> registration =
+                registrationAdaptor.findByEmailAndIsSaved(email, false, eventId);
         List<Sector> sectorList = sectorAdaptor.findAllByEventStatusAndPublishAndIsDeleted();
         // 신청자가 임시저장을 하지 않았을 경우
         if (registration.isEmpty()) {
@@ -79,14 +81,15 @@ public class RegistrationUseCase {
     }
 
     @Transactional
-    public TemporarySaveResponse temporarySave(TemporarySaveRequest requestDto, String email, Long eventId) {
+    public TemporarySaveResponse temporarySave(
+            TemporarySaveRequest requestDto, String email, Long eventId) {
         Sector sector = sectorAdaptor.findById(requestDto.selectSectorId());
         validateEventPublish(sector);
         validateEventStatusIsClosed(sector);
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
         Registration registration = requestDto.toEntity(requestDto, sector, email, user);
-        return findResultByEmail(email, false,eventId)
+        return findResultByEmail(email, false, eventId)
                 .fold(
                         tempRegistration -> {
                             tempRegistration.update(registration);
@@ -113,7 +116,7 @@ public class RegistrationUseCase {
         User user = findById(currentUserId);
 
         Registration registration = requestDto.toEntity(requestDto, sector, email, user);
-        return findResultByEmail(email,false,eventId)
+        return findResultByEmail(email, false, eventId)
                 .fold(
                         tempRegistration ->
                                 reFinalRegister(

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -43,7 +43,7 @@ public class BatchQuartzJob extends QuartzJobBean {
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
         event.deleteEvent();
-        redisRepository.sRem(TicketStatic.REDIS_EVENT_ISSUE_STORE);
+        redisRepository.delete(TicketStatic.REDIS_EVENT_ISSUE_STORE);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 
         JobParameters jobParameters =

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -42,7 +42,6 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
-        event.deleteEvent();
         redisRepository.delete(TicketStatic.REDIS_EVENT_ISSUE_STORE);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 

--- a/Ticket-Domain/build.gradle
+++ b/Ticket-Domain/build.gradle
@@ -1,5 +1,20 @@
+
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
+
+plugins {
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+}
+
+
 bootJar { enabled = false }
 jar { enabled = true }
+
+
 
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -8,24 +23,26 @@ dependencies {
     implementation project(':Ticket-Common')
     implementation project(':Ticket-Infrastructure')
     //queryDsl 설정 부분
-//    api ("com.querydsl:querydsl-core") // querydsl
-//    api ("com.querydsl:querydsl-jpa") // querydsl
-//    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa" // querydsl JPAAnnotationProcessor 사용 지정
-    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
-    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     //for @Nullable  https://velog.io/@saintho/javaxannotationmetawhennotfound
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
 }
-//https://jojoldu.tistory.com/372
-def generated='src/main/generated'
+// (4) queryDSL 추가 : QueryDSL 빌드 옵션
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
 sourceSets {
-    main.java.srcDirs += [ generated ]
+    main.java.srcDir querydslDir
 }
-
-tasks.withType(JavaCompile) {
-    options.annotationProcessorGeneratedSourcesDirectory = file(generated)
+configurations {
+    querydsl.extendsFrom compileClasspath
 }
-
-clean.doLast {
-    file(generated).deleteDir()
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/common/vo/QDateTimePeriod.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/common/vo/QDateTimePeriod.java
@@ -1,0 +1,39 @@
+package com.jnu.ticketdomain.common.vo;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QDateTimePeriod is a Querydsl query type for DateTimePeriod
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QDateTimePeriod extends BeanPath<DateTimePeriod> {
+
+    private static final long serialVersionUID = -1547613022L;
+
+    public static final QDateTimePeriod dateTimePeriod = new QDateTimePeriod("dateTimePeriod");
+
+    public final DateTimePath<java.time.LocalDateTime> endAt = createDateTime("endAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> startAt = createDateTime("startAt", java.time.LocalDateTime.class);
+
+    public QDateTimePeriod(String variable) {
+        super(DateTimePeriod.class, forVariable(variable));
+    }
+
+    public QDateTimePeriod(Path<? extends DateTimePeriod> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QDateTimePeriod(PathMetadata metadata) {
+        super(DateTimePeriod.class, metadata);
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/common/vo/QDateTimePeriod.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/common/vo/QDateTimePeriod.java
@@ -2,16 +2,12 @@ package com.jnu.ticketdomain.common.vo;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QDateTimePeriod is a Querydsl query type for DateTimePeriod
- */
+/** QDateTimePeriod is a Querydsl query type for DateTimePeriod */
 @Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
 public class QDateTimePeriod extends BeanPath<DateTimePeriod> {
 
@@ -19,9 +15,11 @@ public class QDateTimePeriod extends BeanPath<DateTimePeriod> {
 
     public static final QDateTimePeriod dateTimePeriod = new QDateTimePeriod("dateTimePeriod");
 
-    public final DateTimePath<java.time.LocalDateTime> endAt = createDateTime("endAt", java.time.LocalDateTime.class);
+    public final DateTimePath<java.time.LocalDateTime> endAt =
+            createDateTime("endAt", java.time.LocalDateTime.class);
 
-    public final DateTimePath<java.time.LocalDateTime> startAt = createDateTime("startAt", java.time.LocalDateTime.class);
+    public final DateTimePath<java.time.LocalDateTime> startAt =
+            createDateTime("startAt", java.time.LocalDateTime.class);
 
     public QDateTimePeriod(String variable) {
         super(DateTimePeriod.class, forVariable(variable));
@@ -34,6 +32,4 @@ public class QDateTimePeriod extends BeanPath<DateTimePeriod> {
     public QDateTimePeriod(PathMetadata metadata) {
         super(DateTimePeriod.class, metadata);
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/common/vo/QPhoneNumberVo.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/common/vo/QPhoneNumberVo.java
@@ -2,16 +2,12 @@ package com.jnu.ticketdomain.common.vo;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QPhoneNumberVo is a Querydsl query type for PhoneNumberVo
- */
+/** QPhoneNumberVo is a Querydsl query type for PhoneNumberVo */
 @Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
 public class QPhoneNumberVo extends BeanPath<PhoneNumberVo> {
 
@@ -38,6 +34,4 @@ public class QPhoneNumberVo extends BeanPath<PhoneNumberVo> {
     public QPhoneNumberVo(PathMetadata metadata) {
         super(PhoneNumberVo.class, metadata);
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/common/vo/QPhoneNumberVo.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/common/vo/QPhoneNumberVo.java
@@ -1,0 +1,43 @@
+package com.jnu.ticketdomain.common.vo;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QPhoneNumberVo is a Querydsl query type for PhoneNumberVo
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QPhoneNumberVo extends BeanPath<PhoneNumberVo> {
+
+    private static final long serialVersionUID = 614755146L;
+
+    public static final QPhoneNumberVo phoneNumberVo = new QPhoneNumberVo("phoneNumberVo");
+
+    public final StringPath internationalFormat = createString("internationalFormat");
+
+    public final StringPath nationalFormat = createString("nationalFormat");
+
+    public final StringPath naverSmsToNumber = createString("naverSmsToNumber");
+
+    public final StringPath phoneNumber = createString("phoneNumber");
+
+    public QPhoneNumberVo(String variable) {
+        super(PhoneNumberVo.class, forVariable(variable));
+    }
+
+    public QPhoneNumberVo(Path<? extends PhoneNumberVo> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QPhoneNumberVo(PathMetadata metadata) {
+        super(PhoneNumberVo.class, metadata);
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/CredentialCode/domain/QCredentialCode.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/CredentialCode/domain/QCredentialCode.java
@@ -2,16 +2,12 @@ package com.jnu.ticketdomain.domains.CredentialCode.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QCredentialCode is a Querydsl query type for CredentialCode
- */
+/** QCredentialCode is a Querydsl query type for CredentialCode */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QCredentialCode extends EntityPathBase<CredentialCode> {
 
@@ -36,6 +32,4 @@ public class QCredentialCode extends EntityPathBase<CredentialCode> {
     public QCredentialCode(PathMetadata metadata) {
         super(CredentialCode.class, metadata);
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/CredentialCode/domain/QCredentialCode.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/CredentialCode/domain/QCredentialCode.java
@@ -1,0 +1,41 @@
+package com.jnu.ticketdomain.domains.CredentialCode.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QCredentialCode is a Querydsl query type for CredentialCode
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCredentialCode extends EntityPathBase<CredentialCode> {
+
+    private static final long serialVersionUID = -394953961L;
+
+    public static final QCredentialCode credentialCode = new QCredentialCode("credentialCode");
+
+    public final StringPath code = createString("code");
+
+    public final NumberPath<Long> credentialCodeId = createNumber("credentialCodeId", Long.class);
+
+    public final StringPath email = createString("email");
+
+    public QCredentialCode(String variable) {
+        super(CredentialCode.class, forVariable(variable));
+    }
+
+    public QCredentialCode(Path<? extends CredentialCode> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCredentialCode(PathMetadata metadata) {
+        super(CredentialCode.class, metadata);
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/announce/domain/QAnnounce.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/announce/domain/QAnnounce.java
@@ -1,0 +1,43 @@
+package com.jnu.ticketdomain.domains.announce.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAnnounce is a Querydsl query type for Announce
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QAnnounce extends EntityPathBase<Announce> {
+
+    private static final long serialVersionUID = -1199637375L;
+
+    public static final QAnnounce announce = new QAnnounce("announce");
+
+    public final StringPath announceContent = createString("announceContent");
+
+    public final NumberPath<Long> announceId = createNumber("announceId", Long.class);
+
+    public final StringPath announceTitle = createString("announceTitle");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public QAnnounce(String variable) {
+        super(Announce.class, forVariable(variable));
+    }
+
+    public QAnnounce(Path<? extends Announce> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAnnounce(PathMetadata metadata) {
+        super(Announce.class, metadata);
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/announce/domain/QAnnounce.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/announce/domain/QAnnounce.java
@@ -2,16 +2,12 @@ package com.jnu.ticketdomain.domains.announce.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QAnnounce is a Querydsl query type for Announce
- */
+/** QAnnounce is a Querydsl query type for Announce */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QAnnounce extends EntityPathBase<Announce> {
 
@@ -25,7 +21,8 @@ public class QAnnounce extends EntityPathBase<Announce> {
 
     public final StringPath announceTitle = createString("announceTitle");
 
-    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+    public final DateTimePath<java.time.LocalDateTime> createdAt =
+            createDateTime("createdAt", java.time.LocalDateTime.class);
 
     public QAnnounce(String variable) {
         super(Announce.class, forVariable(variable));
@@ -38,6 +35,4 @@ public class QAnnounce extends EntityPathBase<Announce> {
     public QAnnounce(PathMetadata metadata) {
         super(Announce.class, metadata);
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/captcha/domain/QCaptcha.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/captcha/domain/QCaptcha.java
@@ -2,16 +2,12 @@ package com.jnu.ticketdomain.domains.captcha.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QCaptcha is a Querydsl query type for Captcha
- */
+/** QCaptcha is a Querydsl query type for Captcha */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QCaptcha extends EntityPathBase<Captcha> {
 
@@ -36,6 +32,4 @@ public class QCaptcha extends EntityPathBase<Captcha> {
     public QCaptcha(PathMetadata metadata) {
         super(Captcha.class, metadata);
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/captcha/domain/QCaptcha.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/captcha/domain/QCaptcha.java
@@ -1,0 +1,41 @@
+package com.jnu.ticketdomain.domains.captcha.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QCaptcha is a Querydsl query type for Captcha
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCaptcha extends EntityPathBase<Captcha> {
+
+    private static final long serialVersionUID = -704274569L;
+
+    public static final QCaptcha captcha = new QCaptcha("captcha");
+
+    public final StringPath answer = createString("answer");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath imageName = createString("imageName");
+
+    public QCaptcha(String variable) {
+        super(Captcha.class, forVariable(variable));
+    }
+
+    public QCaptcha(Path<? extends Captcha> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCaptcha(PathMetadata metadata) {
+        super(Captcha.class, metadata);
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/council/domain/QCouncil.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/council/domain/QCouncil.java
@@ -1,0 +1,57 @@
+package com.jnu.ticketdomain.domains.council.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCouncil is a Querydsl query type for Council
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCouncil extends EntityPathBase<Council> {
+
+    private static final long serialVersionUID = 1420029079L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCouncil council = new QCouncil("council");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final StringPath phoneNum = createString("phoneNum");
+
+    public final StringPath studentNum = createString("studentNum");
+
+    public final com.jnu.ticketdomain.domains.user.domain.QUser user;
+
+    public QCouncil(String variable) {
+        this(Council.class, forVariable(variable), INITS);
+    }
+
+    public QCouncil(Path<? extends Council> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCouncil(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCouncil(PathMetadata metadata, PathInits inits) {
+        this(Council.class, metadata, inits);
+    }
+
+    public QCouncil(Class<? extends Council> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.jnu.ticketdomain.domains.user.domain.QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/council/domain/QCouncil.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/council/domain/QCouncil.java
@@ -2,17 +2,13 @@ package com.jnu.ticketdomain.domains.council.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.dsl.PathInits;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QCouncil is a Querydsl query type for Council
- */
+/** QCouncil is a Querydsl query type for Council */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QCouncil extends EntityPathBase<Council> {
 
@@ -50,8 +46,10 @@ public class QCouncil extends EntityPathBase<Council> {
 
     public QCouncil(Class<? extends Council> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.user = inits.isInitialized("user") ? new com.jnu.ticketdomain.domains.user.domain.QUser(forProperty("user"), inits.get("user")) : null;
+        this.user =
+                inits.isInitialized("user")
+                        ? new com.jnu.ticketdomain.domains.user.domain.QUser(
+                                forProperty("user"), inits.get("user"))
+                        : null;
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/events/domain/QEvent.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/events/domain/QEvent.java
@@ -1,0 +1,63 @@
+package com.jnu.ticketdomain.domains.events.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QEvent is a Querydsl query type for Event
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QEvent extends EntityPathBase<Event> {
+
+    private static final long serialVersionUID = 935002642L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QEvent event = new QEvent("event");
+
+    public final com.jnu.ticketdomain.common.vo.QDateTimePeriod dateTimePeriod;
+
+    public final StringPath eventCode = createString("eventCode");
+
+    public final EnumPath<EventStatus> eventStatus = createEnum("eventStatus", EventStatus.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isDeleted = createBoolean("isDeleted");
+
+    public final BooleanPath publish = createBoolean("publish");
+
+    public final ListPath<Sector, QSector> sector = this.<Sector, QSector>createList("sector", Sector.class, QSector.class, PathInits.DIRECT2);
+
+    public final StringPath title = createString("title");
+
+    public QEvent(String variable) {
+        this(Event.class, forVariable(variable), INITS);
+    }
+
+    public QEvent(Path<? extends Event> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QEvent(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QEvent(PathMetadata metadata, PathInits inits) {
+        this(Event.class, metadata, inits);
+    }
+
+    public QEvent(Class<? extends Event> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.dateTimePeriod = inits.isInitialized("dateTimePeriod") ? new com.jnu.ticketdomain.common.vo.QDateTimePeriod(forProperty("dateTimePeriod")) : null;
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/events/domain/QEvent.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/events/domain/QEvent.java
@@ -2,17 +2,13 @@ package com.jnu.ticketdomain.domains.events.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.dsl.PathInits;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QEvent is a Querydsl query type for Event
- */
+/** QEvent is a Querydsl query type for Event */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QEvent extends EntityPathBase<Event> {
 
@@ -34,7 +30,9 @@ public class QEvent extends EntityPathBase<Event> {
 
     public final BooleanPath publish = createBoolean("publish");
 
-    public final ListPath<Sector, QSector> sector = this.<Sector, QSector>createList("sector", Sector.class, QSector.class, PathInits.DIRECT2);
+    public final ListPath<Sector, QSector> sector =
+            this.<Sector, QSector>createList(
+                    "sector", Sector.class, QSector.class, PathInits.DIRECT2);
 
     public final StringPath title = createString("title");
 
@@ -56,8 +54,10 @@ public class QEvent extends EntityPathBase<Event> {
 
     public QEvent(Class<? extends Event> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.dateTimePeriod = inits.isInitialized("dateTimePeriod") ? new com.jnu.ticketdomain.common.vo.QDateTimePeriod(forProperty("dateTimePeriod")) : null;
+        this.dateTimePeriod =
+                inits.isInitialized("dateTimePeriod")
+                        ? new com.jnu.ticketdomain.common.vo.QDateTimePeriod(
+                                forProperty("dateTimePeriod"))
+                        : null;
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/events/domain/QSector.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/events/domain/QSector.java
@@ -1,0 +1,71 @@
+package com.jnu.ticketdomain.domains.events.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSector is a Querydsl query type for Sector
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSector extends EntityPathBase<Sector> {
+
+    private static final long serialVersionUID = -694634770L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSector sector = new QSector("sector");
+
+    public final QEvent event;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> initReserve = createNumber("initReserve", Integer.class);
+
+    public final NumberPath<Integer> initSectorCapacity = createNumber("initSectorCapacity", Integer.class);
+
+    public final BooleanPath isDeleted = createBoolean("isDeleted");
+
+    public final NumberPath<Integer> issueAmount = createNumber("issueAmount", Integer.class);
+
+    public final StringPath name = createString("name");
+
+    public final ListPath<com.jnu.ticketdomain.domains.registration.domain.Registration, com.jnu.ticketdomain.domains.registration.domain.QRegistration> registrations = this.<com.jnu.ticketdomain.domains.registration.domain.Registration, com.jnu.ticketdomain.domains.registration.domain.QRegistration>createList("registrations", com.jnu.ticketdomain.domains.registration.domain.Registration.class, com.jnu.ticketdomain.domains.registration.domain.QRegistration.class, PathInits.DIRECT2);
+
+    public final NumberPath<Integer> remainingAmount = createNumber("remainingAmount", Integer.class);
+
+    public final NumberPath<Integer> reserve = createNumber("reserve", Integer.class);
+
+    public final NumberPath<Integer> sectorCapacity = createNumber("sectorCapacity", Integer.class);
+
+    public final StringPath sectorNumber = createString("sectorNumber");
+
+    public QSector(String variable) {
+        this(Sector.class, forVariable(variable), INITS);
+    }
+
+    public QSector(Path<? extends Sector> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSector(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSector(PathMetadata metadata, PathInits inits) {
+        this(Sector.class, metadata, inits);
+    }
+
+    public QSector(Class<? extends Sector> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.event = inits.isInitialized("event") ? new QEvent(forProperty("event"), inits.get("event")) : null;
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/events/domain/QSector.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/events/domain/QSector.java
@@ -2,17 +2,13 @@ package com.jnu.ticketdomain.domains.events.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.dsl.PathInits;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QSector is a Querydsl query type for Sector
- */
+/** QSector is a Querydsl query type for Sector */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QSector extends EntityPathBase<Sector> {
 
@@ -28,7 +24,8 @@ public class QSector extends EntityPathBase<Sector> {
 
     public final NumberPath<Integer> initReserve = createNumber("initReserve", Integer.class);
 
-    public final NumberPath<Integer> initSectorCapacity = createNumber("initSectorCapacity", Integer.class);
+    public final NumberPath<Integer> initSectorCapacity =
+            createNumber("initSectorCapacity", Integer.class);
 
     public final BooleanPath isDeleted = createBoolean("isDeleted");
 
@@ -36,9 +33,23 @@ public class QSector extends EntityPathBase<Sector> {
 
     public final StringPath name = createString("name");
 
-    public final ListPath<com.jnu.ticketdomain.domains.registration.domain.Registration, com.jnu.ticketdomain.domains.registration.domain.QRegistration> registrations = this.<com.jnu.ticketdomain.domains.registration.domain.Registration, com.jnu.ticketdomain.domains.registration.domain.QRegistration>createList("registrations", com.jnu.ticketdomain.domains.registration.domain.Registration.class, com.jnu.ticketdomain.domains.registration.domain.QRegistration.class, PathInits.DIRECT2);
+    public final ListPath<
+                    com.jnu.ticketdomain.domains.registration.domain.Registration,
+                    com.jnu.ticketdomain.domains.registration.domain.QRegistration>
+            registrations =
+                    this
+                            .<com.jnu.ticketdomain.domains.registration.domain.Registration,
+                                    com.jnu.ticketdomain.domains.registration.domain.QRegistration>
+                                    createList(
+                                            "registrations",
+                                            com.jnu.ticketdomain.domains.registration.domain
+                                                    .Registration.class,
+                                            com.jnu.ticketdomain.domains.registration.domain
+                                                    .QRegistration.class,
+                                            PathInits.DIRECT2);
 
-    public final NumberPath<Integer> remainingAmount = createNumber("remainingAmount", Integer.class);
+    public final NumberPath<Integer> remainingAmount =
+            createNumber("remainingAmount", Integer.class);
 
     public final NumberPath<Integer> reserve = createNumber("reserve", Integer.class);
 
@@ -64,8 +75,9 @@ public class QSector extends EntityPathBase<Sector> {
 
     public QSector(Class<? extends Sector> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.event = inits.isInitialized("event") ? new QEvent(forProperty("event"), inits.get("event")) : null;
+        this.event =
+                inits.isInitialized("event")
+                        ? new QEvent(forProperty("event"), inits.get("event"))
+                        : null;
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/notice/domain/QNotice.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/notice/domain/QNotice.java
@@ -1,0 +1,43 @@
+package com.jnu.ticketdomain.domains.notice.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QNotice is a Querydsl query type for Notice
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotice extends EntityPathBase<Notice> {
+
+    private static final long serialVersionUID = 1614295519L;
+
+    public static final QNotice notice = new QNotice("notice");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public final StringPath noticeContent = createString("noticeContent");
+
+    public final NumberPath<Long> noticeId = createNumber("noticeId", Long.class);
+
+    public QNotice(String variable) {
+        super(Notice.class, forVariable(variable));
+    }
+
+    public QNotice(Path<? extends Notice> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QNotice(PathMetadata metadata) {
+        super(Notice.class, metadata);
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/notice/domain/QNotice.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/notice/domain/QNotice.java
@@ -2,16 +2,12 @@ package com.jnu.ticketdomain.domains.notice.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QNotice is a Querydsl query type for Notice
- */
+/** QNotice is a Querydsl query type for Notice */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QNotice extends EntityPathBase<Notice> {
 
@@ -19,9 +15,11 @@ public class QNotice extends EntityPathBase<Notice> {
 
     public static final QNotice notice = new QNotice("notice");
 
-    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+    public final DateTimePath<java.time.LocalDateTime> createdAt =
+            createDateTime("createdAt", java.time.LocalDateTime.class);
 
-    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt =
+            createDateTime("modifiedAt", java.time.LocalDateTime.class);
 
     public final StringPath noticeContent = createString("noticeContent");
 
@@ -38,6 +36,4 @@ public class QNotice extends EntityPathBase<Notice> {
     public QNotice(PathMetadata metadata) {
         super(Notice.class, metadata);
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/registration/domain/QRegistration.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/registration/domain/QRegistration.java
@@ -1,0 +1,74 @@
+package com.jnu.ticketdomain.domains.registration.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QRegistration is a Querydsl query type for Registration
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRegistration extends EntityPathBase<Registration> {
+
+    private static final long serialVersionUID = 1138249633L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QRegistration registration = new QRegistration("registration");
+
+    public final StringPath affiliation = createString("affiliation");
+
+    public final StringPath carNum = createString("carNum");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isDeleted = createBoolean("isDeleted");
+
+    public final BooleanPath isLight = createBoolean("isLight");
+
+    public final BooleanPath isSaved = createBoolean("isSaved");
+
+    public final StringPath name = createString("name");
+
+    public final StringPath phoneNum = createString("phoneNum");
+
+    public final com.jnu.ticketdomain.domains.events.domain.QSector sector;
+
+    public final StringPath studentNum = createString("studentNum");
+
+    public final com.jnu.ticketdomain.domains.user.domain.QUser user;
+
+    public QRegistration(String variable) {
+        this(Registration.class, forVariable(variable), INITS);
+    }
+
+    public QRegistration(Path<? extends Registration> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QRegistration(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QRegistration(PathMetadata metadata, PathInits inits) {
+        this(Registration.class, metadata, inits);
+    }
+
+    public QRegistration(Class<? extends Registration> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.sector = inits.isInitialized("sector") ? new com.jnu.ticketdomain.domains.events.domain.QSector(forProperty("sector"), inits.get("sector")) : null;
+        this.user = inits.isInitialized("user") ? new com.jnu.ticketdomain.domains.user.domain.QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/registration/domain/QRegistration.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/registration/domain/QRegistration.java
@@ -2,17 +2,13 @@ package com.jnu.ticketdomain.domains.registration.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.dsl.PathInits;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QRegistration is a Querydsl query type for Registration
- */
+/** QRegistration is a Querydsl query type for Registration */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QRegistration extends EntityPathBase<Registration> {
 
@@ -26,7 +22,8 @@ public class QRegistration extends EntityPathBase<Registration> {
 
     public final StringPath carNum = createString("carNum");
 
-    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+    public final DateTimePath<java.time.LocalDateTime> createdAt =
+            createDateTime("createdAt", java.time.LocalDateTime.class);
 
     public final StringPath email = createString("email");
 
@@ -64,11 +61,18 @@ public class QRegistration extends EntityPathBase<Registration> {
         this(Registration.class, metadata, inits);
     }
 
-    public QRegistration(Class<? extends Registration> type, PathMetadata metadata, PathInits inits) {
+    public QRegistration(
+            Class<? extends Registration> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.sector = inits.isInitialized("sector") ? new com.jnu.ticketdomain.domains.events.domain.QSector(forProperty("sector"), inits.get("sector")) : null;
-        this.user = inits.isInitialized("user") ? new com.jnu.ticketdomain.domains.user.domain.QUser(forProperty("user"), inits.get("user")) : null;
+        this.sector =
+                inits.isInitialized("sector")
+                        ? new com.jnu.ticketdomain.domains.events.domain.QSector(
+                                forProperty("sector"), inits.get("sector"))
+                        : null;
+        this.user =
+                inits.isInitialized("user")
+                        ? new com.jnu.ticketdomain.domains.user.domain.QUser(
+                                forProperty("user"), inits.get("user"))
+                        : null;
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/user/domain/QUser.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/user/domain/QUser.java
@@ -2,17 +2,13 @@ package com.jnu.ticketdomain.domains.user.domain;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
-import com.querydsl.core.types.dsl.*;
-
-import com.querydsl.core.types.PathMetadata;
-import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.dsl.PathInits;
+import javax.annotation.processing.Generated;
 
-
-/**
- * QUser is a Querydsl query type for User
- */
+/** QUser is a Querydsl query type for User */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QUser extends EntityPathBase<User> {
 
@@ -56,8 +52,10 @@ public class QUser extends EntityPathBase<User> {
 
     public QUser(Class<? extends User> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.registration = inits.isInitialized("registration") ? new com.jnu.ticketdomain.domains.registration.domain.QRegistration(forProperty("registration"), inits.get("registration")) : null;
+        this.registration =
+                inits.isInitialized("registration")
+                        ? new com.jnu.ticketdomain.domains.registration.domain.QRegistration(
+                                forProperty("registration"), inits.get("registration"))
+                        : null;
     }
-
 }
-

--- a/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/user/domain/QUser.java
+++ b/Ticket-Domain/src/main/generated/com/jnu/ticketdomain/domains/user/domain/QUser.java
@@ -1,0 +1,63 @@
+package com.jnu.ticketdomain.domains.user.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = -424544827L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUser user = new QUser("user");
+
+    public final StringPath email = createString("email");
+
+    public final BooleanPath emailConfirmed = createBoolean("emailConfirmed");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath pwd = createString("pwd");
+
+    public final com.jnu.ticketdomain.domains.registration.domain.QRegistration registration;
+
+    public final NumberPath<Integer> sequence = createNumber("sequence", Integer.class);
+
+    public final StringPath status = createString("status");
+
+    public final EnumPath<UserRole> userRole = createEnum("userRole", UserRole.class);
+
+    public QUser(String variable) {
+        this(User.class, forVariable(variable), INITS);
+    }
+
+    public QUser(Path<? extends User> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUser(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUser(PathMetadata metadata, PathInits inits) {
+        this(User.class, metadata, inits);
+    }
+
+    public QUser(Class<? extends User> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.registration = inits.isInitialized("registration") ? new com.jnu.ticketdomain.domains.registration.domain.QRegistration(forProperty("registration"), inits.get("registration")) : null;
+    }
+
+}
+

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/TicketDomainApplication.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/TicketDomainApplication.java
@@ -1,9 +1,13 @@
 package com.jnu.ticketdomain;
 
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import javax.persistence.EntityManager;
 
 @SpringBootApplication
 @EnableJpaAuditing
@@ -11,5 +15,10 @@ public class TicketDomainApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(TicketDomainApplication.class, args);
+    }
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/TicketDomainApplication.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/TicketDomainApplication.java
@@ -2,12 +2,11 @@ package com.jnu.ticketdomain;
 
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-import javax.persistence.EntityManager;
 
 @SpringBootApplication
 @EnableJpaAuditing

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
@@ -69,20 +69,7 @@ public class EventAdaptor implements EventRecordPort, EventLoadPort {
 
     @Override
     public Event findRecentEvent() {
-        Event event =
-                findReadyOrOpenAndNotPublishEvent()
-                        .fold(
-                                Result::success,
-                                error -> {
-                                    Pageable pageRequest = PageRequest.of(0, 1);
-                                    Event event1 =
-                                            eventRepository
-                                                    .findClosestClosedEvent(
-                                                            LocalDateTime.now(), pageRequest)
-                                                    .get(0);
-                                    return Result.success(event1);
-                                })
-                        .getOrThrow();
+        Event event = findReadyOrOpenAndNotPublishEvent().getOrThrow();
 
         if (event == null) {
             throw NotFoundEventException.EXCEPTION;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 @Adaptor

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -48,8 +48,7 @@ public class Event {
 
     // 구간별 정보
     //    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @OneToMany(fetch = FetchType.EAGER)
-    //    @JoinColumn(name = "sector_id")
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Sector> sector = new ArrayList<>();
 
     @Column(name = "publish")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -48,7 +48,10 @@ public class Event {
 
     // 구간별 정보
     //    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(
+            fetch = FetchType.LAZY,
+            mappedBy = "event",
+            cascade = CascadeType.ALL)
     private List<Sector> sector = new ArrayList<>();
 
     @Column(name = "publish")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -48,7 +48,7 @@ public class Event {
 
     // 구간별 정보
     //    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.EAGER)
     //    @JoinColumn(name = "sector_id")
     private List<Sector> sector = new ArrayList<>();
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -48,10 +48,7 @@ public class Event {
 
     // 구간별 정보
     //    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @OneToMany(
-            fetch = FetchType.LAZY,
-            mappedBy = "event",
-            cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "event", cascade = CascadeType.ALL)
     private List<Sector> sector = new ArrayList<>();
 
     @Column(name = "publish")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -56,7 +56,7 @@ public class Sector {
     @Column(name = "is_deleted")
     private boolean isDeleted;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id")
     private Event event;
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -56,7 +56,7 @@ public class Sector {
     @Column(name = "is_deleted")
     private boolean isDeleted;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "event_id")
     private Event event;
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -60,7 +60,7 @@ public class Sector {
     @JoinColumn(name = "event_id")
     private Event event;
 
-    @OneToMany(mappedBy = "sector", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "sector", cascade = CascadeType.ALL)
     private List<Registration> registrations = new ArrayList<>();
 
     @Builder

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -24,11 +24,11 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
     @Query("select s from Sector s where s.id = :sectorId and s.event.publish = false")
     Optional<Sector> findByIdWhereEventPublishIdFalse(Long sectorId);
 
-    @Query("UPDATE Sector s SET s.isDeleted = true WHERE s.event.id = ?1")
-    @Modifying(clearAutomatically = true)
-    void deleteByEventId(Long eventId);
+    @Query("UPDATE Sector s SET s.isDeleted = true WHERE s.event.id = :eventId")
+    @Modifying()
+    void deleteByEventId(@Param("eventId") Long eventId);
 
     @Query("update Sector s SET s.isDeleted = true where s.id = :sectorId")
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     void delete(Long sectorId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -5,6 +5,7 @@ import com.jnu.ticketdomain.domains.events.domain.Sector;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -23,9 +24,11 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
     @Query("select s from Sector s where s.id = :sectorId and s.event.publish = false")
     Optional<Sector> findByIdWhereEventPublishIdFalse(Long sectorId);
 
-    @Query("update Sector s SET s.isDeleted = true where s.event.id = :eventId")
+    @Query("UPDATE Sector s SET s.isDeleted = true WHERE s.event.id = ?1")
+    @Modifying(clearAutomatically = true)
     void deleteByEventId(Long eventId);
 
     @Query("update Sector s SET s.isDeleted = true where s.id = :sectorId")
+    @Modifying(clearAutomatically = true)
     void delete(Long sectorId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -59,6 +59,11 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     }
 
     @Override
+    public Optional<Registration> findByEmailAndIsSaved(String email, boolean flag, Long eventId) {
+        return registrationRepository.findByEmailAndIsSaved(email, flag).filter(r -> r.getSector().getEvent().getId().equals(eventId));
+    }
+
+    @Override
     public List<Registration> findByIsDeletedFalseAndIsSavedTrue(Long eventId) {
         return registrationRepository.findByIsDeletedFalseAndIsSavedTrue(eventId);
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -7,9 +7,10 @@ import com.jnu.ticketdomain.domains.registration.exception.NotFoundRegistrationE
 import com.jnu.ticketdomain.domains.registration.out.RegistrationLoadPort;
 import com.jnu.ticketdomain.domains.registration.out.RegistrationRecordPort;
 import com.jnu.ticketdomain.domains.registration.repository.RegistrationRepository;
+import lombok.RequiredArgsConstructor;
+
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Adaptor
@@ -60,9 +61,8 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
 
     @Override
     public Optional<Registration> findByEmailAndIsSaved(String email, boolean flag, Long eventId) {
-        return registrationRepository
-                .findByEmailAndIsSaved(email, flag)
-                .filter(r -> r.getSector().getEvent().getId().equals(eventId));
+        Optional<Registration> registration = registrationRepository.findByEmailAndIsSaved(email, flag);
+        return registration;
     }
 
     @Override
@@ -71,12 +71,12 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     }
 
     @Override
-    public Boolean existsByEmailAndIsSavedTrue(String email) {
-        return registrationRepository.existsByEmailAndIsSavedTrue(email);
+    public Boolean existsByEmailAndIsSavedTrue(String email, Long eventId) {
+        return registrationRepository.existsByEmailAndIsSavedTrueAndEvent(email, eventId);
     }
 
     @Override
-    public Boolean existsByStudentNumAndIsSavedTrue(String studentNum) {
-        return registrationRepository.existsByStudentNumAndIsSavedTrue(studentNum);
+    public Boolean existsByStudentNumAndIsSavedTrue(String studentNum, Long eventId) {
+        return registrationRepository.existsByStudentNumAndIsSavedTrue(studentNum, eventId);
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -7,10 +7,9 @@ import com.jnu.ticketdomain.domains.registration.exception.NotFoundRegistrationE
 import com.jnu.ticketdomain.domains.registration.out.RegistrationLoadPort;
 import com.jnu.ticketdomain.domains.registration.out.RegistrationRecordPort;
 import com.jnu.ticketdomain.domains.registration.repository.RegistrationRepository;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Adaptor
@@ -61,7 +60,8 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
 
     @Override
     public Optional<Registration> findByEmailAndIsSaved(String email, boolean flag, Long eventId) {
-        Optional<Registration> registration = registrationRepository.findByEmailAndIsSaved(email, flag);
+        Optional<Registration> registration =
+                registrationRepository.findByEmailAndIsSaved(email, flag);
         return registration;
     }
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -60,7 +60,9 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
 
     @Override
     public Optional<Registration> findByEmailAndIsSaved(String email, boolean flag, Long eventId) {
-        return registrationRepository.findByEmailAndIsSaved(email, flag).filter(r -> r.getSector().getEvent().getId().equals(eventId));
+        return registrationRepository
+                .findByEmailAndIsSaved(email, flag)
+                .filter(r -> r.getSector().getEvent().getId().equals(eventId));
     }
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -25,7 +25,7 @@ public class Registration {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     // 신청자 이메일
-    @Column(name = "email", nullable = false, unique = true)
+    @Column(name = "email", nullable = false)
     private String email;
     // 신청자 이름
     @Column(name = "name", nullable = false)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -20,6 +21,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @DynamicUpdate
+@Where(clause = "is_deleted = false")
 public class Registration {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,7 +60,7 @@ public class Registration {
     @ColumnDefault("false")
     private boolean isDeleted;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
@@ -18,9 +18,9 @@ public interface RegistrationLoadPort {
 
     List<Registration> findByIsDeletedFalseAndIsSavedTrue(Long eventId);
 
-    Boolean existsByEmailAndIsSavedTrue(String email);
+    Boolean existsByEmailAndIsSavedTrue(String email, Long eventId);
 
-    Boolean existsByStudentNumAndIsSavedTrue(String studentNum);
+    Boolean existsByStudentNumAndIsSavedTrue(String studentNum, Long eventId);
 
     Optional<Registration> findByEmailAndIsSaved(String email, boolean flag, Long eventId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
@@ -21,4 +21,6 @@ public interface RegistrationLoadPort {
     Boolean existsByEmailAndIsSavedTrue(String email);
 
     Boolean existsByStudentNumAndIsSavedTrue(String studentNum);
+
+    Optional<Registration> findByEmailAndIsSaved(String email, boolean flag, Long eventId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface RegistrationRepository extends JpaRepository<Registration, Long> {
+public interface RegistrationRepository
+        extends JpaRepository<Registration, Long>, RegistrationRepositoryCustom {
     // 신청, 구간 한꺼번에 조회
     @Query("SELECT r FROM Registration r  join fetch r.sector WHERE r.user.id = :userId")
     Optional<Registration> findByUserId(@Param("userId") Long userId);
@@ -26,14 +27,16 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
     @Modifying(clearAutomatically = true)
     void deleteBySectorId(@Param("sectorId") Long sectorId);
 
-    Boolean existsByEmailAndIsSavedTrue(String email) ;
 
-    Boolean existsByStudentNumAndIsSavedTrue(String studentNum);
-
-    @Query(value = "update registration_tb r join sector s on r.sector_id = s.sector_id set r.is_deleted = 1" +
-            " where s.event_id = :eventId",nativeQuery = true)
-    @Modifying(clearAutomatically = true)
+    @Query(
+            value =
+                    "update registration_tb r join sector s on r.sector_id = s.sector_id set r.is_deleted = 1"
+                            + " where s.event_id = :eventId",
+            nativeQuery = true)
+    @Modifying()
     void deleteByEventId(@Param("eventId") Long eventId);
+
     @Query("select r from Registration r where r.isSaved = :flag and r.email = :email")
-    Optional<Registration> findByEmailAndIsSaved(@Param("email") String email, @Param("flag") boolean flag);
+    Optional<Registration> findByEmailAndIsSaved(
+            @Param("email") String email, @Param("flag") boolean flag);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -30,7 +30,8 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
 
     Boolean existsByStudentNumAndIsSavedTrue(String studentNum);
 
-    @Query("update Registration r SET  r.isDeleted = true where r.sector.event.id = :eventId")
+    @Query(value = "update registration_tb r join sector s on r.sector_id = s.sector_id set r.is_deleted = 1" +
+            " where s.event_id = :eventId",nativeQuery = true)
     @Modifying(clearAutomatically = true)
     void deleteByEventId(@Param("eventId") Long eventId);
     @Query("select r from Registration r where r.isSaved = :flag and r.email = :email")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -5,6 +5,7 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,12 +23,16 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
     List<Registration> findByIsDeletedFalseAndIsSavedTrue(@Param("eventId") Long eventId);
 
     @Query("UPDATE Registration r SET r.isDeleted = true WHERE r.sector.id = :sectorId")
-    void deleteBySectorId(Long sectorId);
+    @Modifying(clearAutomatically = true)
+    void deleteBySectorId(@Param("sectorId") Long sectorId);
 
-    Boolean existsByEmailAndIsSavedTrue(String email);
+    Boolean existsByEmailAndIsSavedTrue(String email) ;
 
     Boolean existsByStudentNumAndIsSavedTrue(String studentNum);
 
     @Query("update Registration r SET  r.isDeleted = true where r.sector.event.id = :eventId")
-    void deleteByEventId(Long eventId);
+    @Modifying(clearAutomatically = true)
+    void deleteByEventId(@Param("eventId") Long eventId);
+    @Query("select r from Registration r where r.isSaved = :flag and r.email = :email")
+    Optional<Registration> findByEmailAndIsSaved(@Param("email") String email, @Param("flag") boolean flag);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -27,7 +27,6 @@ public interface RegistrationRepository
     @Modifying(clearAutomatically = true)
     void deleteBySectorId(@Param("sectorId") Long sectorId);
 
-
     @Query(
             value =
                     "update registration_tb r join sector s on r.sector_id = s.sector_id set r.is_deleted = 1"

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustom.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.jnu.ticketdomain.domains.registration.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RegistrationRepositoryCustom {
+    Boolean existsByEmailAndIsSavedTrueAndEvent(String email, Long eventId);
+    Boolean existsByStudentNumAndIsSavedTrue(String studentNum, Long eventId);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustom.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustom.java
@@ -1,9 +1,11 @@
 package com.jnu.ticketdomain.domains.registration.repository;
 
+
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RegistrationRepositoryCustom {
     Boolean existsByEmailAndIsSavedTrueAndEvent(String email, Long eventId);
+
     Boolean existsByStudentNumAndIsSavedTrue(String studentNum, Long eventId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
@@ -1,15 +1,13 @@
 package com.jnu.ticketdomain.domains.registration.repository;
 
+import static com.jnu.ticketdomain.domains.registration.domain.QRegistration.registration;
 
 import com.jnu.ticketdomain.domains.registration.domain.QRegistration;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import javax.persistence.EntityManager;
-
-import static com.jnu.ticketdomain.domains.registration.domain.QRegistration.registration;
 
 @Repository
 @RequiredArgsConstructor
@@ -19,20 +17,30 @@ public class RegistrationRepositoryCustomImpl implements RegistrationRepositoryC
 
     @Override
     public Boolean existsByEmailAndIsSavedTrueAndEvent(String email, Long eventId) {
-        return queryFactory.selectOne()
-                .from(registration)
-                .where(registration.email.eq(email)
-                        .and(isSavedAndEqEvent(registration, eventId)))
-                .fetchFirst() != null;
+        return queryFactory
+                        .selectOne()
+                        .from(registration)
+                        .where(
+                                registration
+                                        .email
+                                        .eq(email)
+                                        .and(isSavedAndEqEvent(registration, eventId)))
+                        .fetchFirst()
+                != null;
     }
 
     @Override
     public Boolean existsByStudentNumAndIsSavedTrue(String studentNum, Long eventId) {
-        return queryFactory.selectOne()
-                .from(registration)
-                .where(registration.studentNum.eq(studentNum)
-                        .and(isSavedAndEqEvent(registration, eventId)))
-                .fetchFirst() != null;
+        return queryFactory
+                        .selectOne()
+                        .from(registration)
+                        .where(
+                                registration
+                                        .studentNum
+                                        .eq(studentNum)
+                                        .and(isSavedAndEqEvent(registration, eventId)))
+                        .fetchFirst()
+                != null;
     }
 
     private BooleanExpression isSavedAndEqEvent(QRegistration registration, Long eventId) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
@@ -1,7 +1,41 @@
 package com.jnu.ticketdomain.domains.registration.repository;
 
+
+import com.jnu.ticketdomain.domains.registration.domain.QRegistration;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.EntityManager;
+
+import static com.jnu.ticketdomain.domains.registration.domain.QRegistration.registration;
+
 @Repository
-public class RegistrationRepositoryCustomImpl {
+@RequiredArgsConstructor
+public class RegistrationRepositoryCustomImpl implements RegistrationRepositoryCustom {
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Boolean existsByEmailAndIsSavedTrueAndEvent(String email, Long eventId) {
+        return queryFactory.selectOne()
+                .from(registration)
+                .where(registration.email.eq(email)
+                        .and(isSavedAndEqEvent(registration, eventId)))
+                .fetchFirst() != null;
+    }
+
+    @Override
+    public Boolean existsByStudentNumAndIsSavedTrue(String studentNum, Long eventId) {
+        return queryFactory.selectOne()
+                .from(registration)
+                .where(registration.studentNum.eq(studentNum)
+                        .and(isSavedAndEqEvent(registration, eventId)))
+                .fetchFirst() != null;
+    }
+
+    private BooleanExpression isSavedAndEqEvent(QRegistration registration, Long eventId) {
+        return registration.isSaved.isTrue().and(registration.sector.event.id.eq(eventId));
+    }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
@@ -1,0 +1,7 @@
+package com.jnu.ticketdomain.domains.registration.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RegistrationRepositoryCustomImpl {
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
@@ -10,6 +10,9 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
@@ -47,8 +50,8 @@ public class User {
     @ColumnDefault("false")
     private boolean emailConfirmed;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Registration registration;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Registration> registrations = new ArrayList<>();
 
     public void updateRole(UserRole userRole) {
         this.userRole = userRole;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
@@ -2,6 +2,8 @@ package com.jnu.ticketdomain.domains.user.domain;
 
 
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,9 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -50,7 +49,11 @@ public class User {
     @ColumnDefault("false")
     private boolean emailConfirmed;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(
+            mappedBy = "user",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
     private List<Registration> registrations = new ArrayList<>();
 
     public void updateRole(UserRole userRole) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -83,4 +83,9 @@ public class RedisRepository {
     public void converAndSend(String channel, ChatMessage chatMessage) {
         redisTemplate.convertAndSend(channel, chatMessage);
     }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -87,5 +87,4 @@ public class RedisRepository {
     public void delete(String key) {
         redisTemplate.delete(key);
     }
-
 }


### PR DESCRIPTION
## 주요 변경사항
1. 3월달에 신청한 사람은 4월달에 신청 못하는 현상이 발견 (이 문제는 https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/issues/274 이슈가 해결되면 해결되는 문제)
2. A라는 사람이 3월달에 신청하고 4월달에 신청하면 기존 3월달 신청이 수정되는 문제
3. 3월의 신청과 4월의 신청은 별개로 DB에 저장되야 한다.
## 리뷰어에게...
# 1. OrphanRemoval true 속성 오류

Event와 Sector가 양방향 관계이다. (주인관계를 지정해줌)

```java
@OneToMany(
            fetch = FetchType.LAZY,
            mappedBy = "event",
            cascade = CascadeType.ALL,
            orphanRemoval = true)
    private List<Sector> sector = new ArrayList<>();
```

Event가 사라지면 Sector도 사라져야 하기에 Cascade All 속성과 orphanRemoval true 속성을 주었다.

(지금 기획은 Event, Sector, Registration에 Soft Delete를 적용해서 실제로 데이터가 삭제되진 않는다)

```java
@Transactional
    public void execute(List<SectorRegisterRequest> sectors) {

        Event recentEvent = eventLoadPort.findRecentEvent();
        List<Sector> prevSector = sectorLoadPort.findByEventId(recentEvent.getId());
        Validation<Seq<TicketCodeException>, List<SectorRegisterRequest>> result =
                validateRegistrationSector(sectors, prevSector);
        result.fold(
                errors -> {
                    throw new MultiException(errors);
                },
                validSectors -> {
                    List<Sector> sectorList =
                            sectors.stream()
                                    .map(
                                            sectorRegisterRequest ->
                                                    new Sector(
                                                            sectorRegisterRequest.sectorNumber(),
                                                            sectorRegisterRequest.name(),
                                                            sectorRegisterRequest.sectorCapacity(),
                                                            sectorRegisterRequest.reserve()))
                                    .toList();
                    sectorList.forEach(sector -> sector.setEvent(recentEvent));
                    List<Sector> savedSectors = sectorRecordPort.saveAll(sectorList);
                    recentEvent.setSector(savedSectors);
                    return null;
                });
    }
```

문제의 코드이다. orphanRemoval true 속성에서 문제가 생기는데

하이버네이트는 PersistentBag를 인스턴스를 이용하여 영속성 전이와 고아객체  추적하는데, **임의로 새로운 ArrayList 타입을 생성하여 참조를 변경하니 PersistentBag 인스턴스가 엔티티와의 참조가 끊어져 버려 문제가 발생하게 된것**. (prevSector → savedSector)

이를 해결하고자 sectorRecordPort.saveAll(sectorList) 한 것을 기존에 있는 prevSector 변수가 참조하게끔 바꿧지만 

<aside>
💡 Variable used in lambda expression should be final or effectively final

</aside>

람다에서 캡쳐링 하는 대상 prevSector는 final이거나 사실상 final이어야 하기 때문에 변경될 수 없다.

따라서 코드를 수정하거나 OrphanRemoval true 속성을 없애야 한다.

코드를 수정하기엔 시간이 촉박하여 OrphanRemoval 속성을 없애기로 함. (추후에 코드를 수정할 예정… 이놈의 vavr 문제가 많네)

# 2. existsByEmailAndIsSavedTrue, existsByStudentNumAndIsSavedTrue

동일한 학생이 주차권 신청을 두번 이상하는 것을 막기 위해 DataJPA exists 문법을 써서 조건에 맞는 데이터가 있는지 없는지 (boolean 반환)를 확인 하려고 했다.

하지만 이벤트마다의 중복 신청여부를 확인해야하는데 Email과 학번으로만 중복체크를 하다보니 3월에 주차권 신청한 사람은 4월달에 주차권 신청을 못하는 에러가 발생한다.

따라서 existsByEmailAndIsSavedTrue에 eventId까지 추가해야하는데(이벤트 별로 중복신청확인 하기위해) Jpql로는 exists 문법을 사용할 수 없어서 QueryDSL을 사용함

- Jpql을 사용하여 exists 문법 비슷하게 코드를 짤 순 있긴 하지만 Data JPA exists와 성능차이가 많이난다.
    - Jpql Count문을 사용하면 된다.
## 관련 이슈

closes #276 
- [#276]
## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정