### PR TITLE
[fix] : RedissonLock waitTime, leaseTime

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -33,8 +33,8 @@ public class EventWithDrawUseCase {
     @RedissonLock(
             LockName = "주차권_발급",
             identifier = "userId",
-            waitTime = 3000,
-            leaseTime = 3000,
+            waitTime = 5000,
+            leaseTime = 10000,
             timeUnit = TimeUnit.MILLISECONDS)
     public void issueEvent(Long userId) {
         // 재고 감소 로직 구현


### PR DESCRIPTION
## 주요 변경사항
```java
 @RedissonLock(
            LockName = "주차권_발급",
            identifier = "userId",
            waitTime = 5000,
            leaseTime = 10000,
            timeUnit = TimeUnit.MILLISECONDS)
``` 

 leasetime을 지금 3초로 처리하고 있는데 이메일이 길어지면 분산락이 풀리면서 에러가 터진다. 따라서 leaseTime을 3초 -> 10초로 변경
## 리뷰어에게...

## 관련 이슈

closes #278 
- [#278]
## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정