### PR TITLE
[BE-134] bug: sector의 reserve가 감소하지 않는 오류

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -48,7 +48,7 @@ public class EventIssuedEventHandler {
         Sector sector = registration.getSector();
         User user = registration.getUser();
 
-        if (sector.isSectorRemaining()) {
+        if (sector.isSectorCapacityRemaining()) {
             user.success();
         } else if (sector.isSectorReserveRemaining()) {
             Long waitingOrder =

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -133,9 +133,7 @@ public class RegistrationUseCase {
             User user,
             String email) {
         // 예비 번호가 있거나 합격인 경우
-        if (!sector.isSectorRemaining() && (!sector.isSectorReserveRemaining())) {
-            throw NoEventStockLeftException.EXCEPTION;
-        }
+        sector.checkEventLeft();
         reFinalRegisterProcess(tempRegistration, registration, user, email);
         return FinalSaveResponse.from(tempRegistration);
     }
@@ -150,9 +148,7 @@ public class RegistrationUseCase {
 
     private FinalSaveResponse saveRegistration(
             Registration registration, Sector sector, Long currentUserId, String email) {
-        if (!sector.isSectorRemaining() && (!sector.isSectorReserveRemaining())) {
-            throw NoEventStockLeftException.EXCEPTION;
-        }
+        sector.checkEventLeft();
         return saveRegistrationProcess(registration, currentUserId, email);
     }
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -84,7 +84,7 @@ public class Sector {
 
     public void decreaseEventStock() {
         checkEventLeft();
-        if (isSectorRemaining()) {
+        if (isSectorCapacityRemaining()) {
             decreaseCapacity();
         } else if (isSectorReserveRemaining()) {
             decreaseReserve();
@@ -109,8 +109,8 @@ public class Sector {
         }
     }
 
-    public boolean isSectorRemaining() {
-        return remainingAmount > 0;
+    public boolean isSectorCapacityRemaining() {
+        return sectorCapacity > 0;
     }
 
     public boolean isSectorReserveRemaining() {


### PR DESCRIPTION
## 주요 변경사항
```java
 public void decreaseEventStock() {
        checkEventLeft();
        if (isSectorCapacityRemaining()) {
            decreaseCapacity();
        } else if (isSectorReserveRemaining()) {
            decreaseReserve();
        } else {
            throw NoEventStockLeftException.EXCEPTION;
        }
    }
``` 

remain_amount를 checkEventLeft에서도 if에서도 검사하고 있어서 Capacity가 남았는지 검사하도록 수정
## 리뷰어에게...

## 관련 이슈 
closes #280 
- [#280]

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정