### PR TITLE
[BE-135] bug: processEvent에서 registration이 null이뜨는 오류

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -46,8 +46,8 @@ public class RegistrationUseCase {
     private final ValidateCaptchaUseCase validateCaptchaUseCase;
     private final RedisService redisService;
 
-    public Registration save(Registration registration) {
-        return registrationAdaptor.save(registration);
+    public Registration saveAndFlush(Registration registration) {
+        return registrationAdaptor.saveAndFlush(registration);
     }
 
     public Result<Registration, Object> findResultByEmail(
@@ -97,7 +97,7 @@ public class RegistrationUseCase {
                             return TemporarySaveResponse.from(tempRegistration);
                         },
                         emptyCase -> {
-                            Registration jpaRegistration = save(registration);
+                            Registration jpaRegistration = saveAndFlush(registration);
                             return TemporarySaveResponse.from(jpaRegistration);
                         });
     }
@@ -154,7 +154,7 @@ public class RegistrationUseCase {
 
     private FinalSaveResponse saveRegistrationProcess(
             Registration registration, Long currentUserId, String email) {
-        Registration saveReg = save(registration);
+        Registration saveReg = saveAndFlush(registration);
         eventWithDrawUseCase.issueEvent(currentUserId);
         redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);
         return FinalSaveResponse.from(saveReg);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -22,8 +22,8 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     }
 
     @Override
-    public Registration save(Registration registration) {
-        return registrationRepository.save(registration);
+    public Registration saveAndFlush(Registration registration) {
+        return registrationRepository.saveAndFlush(registration);
     }
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationRecordPort.java
@@ -4,7 +4,7 @@ package com.jnu.ticketdomain.domains.registration.out;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 
 public interface RegistrationRecordPort {
-    Registration save(Registration registration);
+    Registration saveAndFlush(Registration registration);
 
     void delete(Registration registration);
 


### PR DESCRIPTION
## 주요 변경사항
Registration을 저장하는 코드 save -> saveAndFlush로 변경

ProcessEventData는 EventIssuedEventHandler에 위치되어있으며 비동기로 메인로직과 분리되어있다.
```java
private void processEventData(Long userId) {
        Registration registration = registrationAdaptor.findByUserId(userId);
        Sector sector = registration.getSector();
        User user = registration.getUser();

        if (sector.isSectorCapacityRemaining()) {
            user.success();
        } else if (sector.isSectorReserveRemaining()) {
            Long waitingOrder =
                    waitingQueueService.getWaitingOrder(REDIS_EVENT_ISSUE_STORE, userId);
            user.prepare(Integer.valueOf(waitingOrder.intValue()));
        } else {
            user.fail();
        }
        Events.raise(RegistrationCreationEvent.of(registration, user.getStatus()));
        sector.decreaseEventStock();
    }
``` 
따라서 메인로직 (Registration을 save) 보다 processEventData가 먼저 실행되면 `registrationAdaptor.findByUserId(userId);` 
여기서 registration이 null이 되는 것 
따라서 바로 Flush가 되는 saveAndFlush로 변경하였다.
## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정