### PR TITLE
[BE-136] feat: 합불 메일 전송시 예비번호 상태 추가 

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -57,7 +57,8 @@ public class EventIssuedEventHandler {
         } else {
             user.fail();
         }
-        Events.raise(RegistrationCreationEvent.of(registration, user.getStatus()));
+        Events.raise(
+                RegistrationCreationEvent.of(registration, user.getStatus(), user.getSequence()));
         sector.decreaseEventStock();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
@@ -25,6 +25,6 @@ public class RegistrationCreationEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(RegistrationCreationEvent event) {
         mailService.sendRegistrationResultMail(
-                event.getEmail(), event.getName(), event.getStatus());
+                event.getEmail(), event.getName(), event.getStatus(), event.getSequence());
     }
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/mailService/MailServiceTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/mailService/MailServiceTest.java
@@ -24,11 +24,12 @@ public class MailServiceTest {
     public void send_email_test() {
         // given
         String email = "pon05114@naver.com";
-        String name = "쿠키팍";
-        String status = "1차합격";
+        String name = "홍길동";
+        String status = "합격";
+        Integer sequence = -1;
 
         // when
-        boolean result = mailService.sendRegistrationResultMail(email, name, status);
+        boolean result = mailService.sendRegistrationResultMail(email, name, status, sequence);
 
         // then
         Assertions.assertTrue(result);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
@@ -14,20 +14,24 @@ public class RegistrationCreationEvent extends DomainEvent {
     private final String email;
     private final String name;
     private final String status;
+    private final Integer sequence;
 
     public static RegistrationCreationEvent of(Registration registration) {
         return RegistrationCreationEvent.builder()
                 .email(registration.getEmail())
                 .name(registration.getName())
                 .status(registration.getUser().getStatus())
+                .sequence(registration.getUser().getSequence())
                 .build();
     }
 
-    public static RegistrationCreationEvent of(Registration registration, String status) {
+    public static RegistrationCreationEvent of(
+            Registration registration, String status, Integer sequence) {
         return RegistrationCreationEvent.builder()
                 .email(registration.getEmail())
                 .name(registration.getName())
                 .status(status)
+                .sequence(sequence)
                 .build();
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/MailService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/MailService.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.ses.model.*;
 @Slf4j
 public class MailService {
 
-    @Value("${aws.ses.mail-address}")
+    @Value("${aws.ses.mail-address:centerofjnu@jnu-parking.com}")
     private String mailAddress;
 
     private final SesAsyncClient sesAsyncClient;
@@ -61,9 +61,10 @@ public class MailService {
                 .build();
     }
 
-    public boolean sendRegistrationResultMail(String email, String name, String status) {
+    public boolean sendRegistrationResultMail(
+            String email, String name, String status, Integer sequence) {
         try {
-            Context context = newRegistrationContext(name, status);
+            Context context = newRegistrationContext(name, createMailStatus(status, sequence));
             boolean result =
                     sendMail(
                             email,
@@ -84,5 +85,20 @@ public class MailService {
         context.setVariable(MailTemplate.REGISTRATION_PASS_CONTEXT, pass);
 
         return context;
+    }
+
+    /**
+     * Sequence 의 값을 보고 판단해, 예비인 경우 "예비 1번"과 같이 문자열을 출력한다. 기존과 같이 불합격, 합격인 경우는 동일하게 "불합격"/"합격"으로
+     * 출력한다. Sequence == -1 : 합격 Sequence == -2 : 불합격 그 외 : 예비 n번
+     *
+     * @param status 유저 합/불/예비 여부
+     * @param sequence 합/불/예비에 따른 정수
+     * @return String type 의 결과 상태.
+     */
+    private String createMailStatus(String status, Integer sequence) {
+        if (sequence >= 0) {
+            return status + " " + sequence + "번";
+        }
+        return status;
     }
 }


### PR DESCRIPTION
## 주요 변경사항

- 신청 메일 전송시 기존 "예비"로 보내지던 기능을 "예비 n번"으로 보내지게끔 기능 추가 했습니다.

## 리뷰어에게...

외부 API와 연동하는 부분이다 보니, 테스트가 외부 API와 의존하게 됩니다. 흑흑

지금 SES 문제 없는지 궁금하네요

로컬환경에서 테스트시 SES 부분이 샌드박스로 변경된 거 같은데, 확인 부탁드려용

세부 로그는 슬랙 `프로젝트 토의` 채널에 올렸습니다.

## 관련 이슈

closes #284 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정