### PR TITLE
[fix] : doFilterInternal의 if조건문 수정

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/security/JwtAuthenticationFilter.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/security/JwtAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 && (isSwaggerRequest(request.getRequestURI()))) {
             filterChain.doFilter(request, response);
             return;
-        } else if (Boolean.TRUE.equals(!springEnvironmentHelper.isProdProfile())
+        } else if (Boolean.TRUE.equals(springEnvironmentHelper.isProdProfile())
                 && (isSwaggerRequest(request.getRequestURI()))) {
             throw SwaggerException.EXCEPTION;
         }


### PR DESCRIPTION
## 주요 변경사항
```java

        } else if (Boolean.TRUE.equals(!springEnvironmentHelper.isProdProfile())
                && (isSwaggerRequest(request.getRequestURI()))) {
            throw SwaggerException.EXCEPTION;
        }
``` 
에서 springEnvironmentHelper.isProdProfile()에서 !가 붙어있다 (원래는 !가 있으면 안됨)
## 리뷰어에게...
My mistake...
## 관련 이슈

closes #293 
- [#293]

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정