### PR TITLE
[BE-142] bug: prod 환경에서 모든 요청이 block 되는 버그

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/security/JwtAuthenticationFilter.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/security/JwtAuthenticationFilter.java
@@ -56,6 +56,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private boolean isSwaggerRequest(String uri) {
         return Arrays.stream(TicketStatic.SwaggerPatterns)
-                .anyMatch(pattern -> antPathMatcher.matchStart(pattern, uri));
+                .anyMatch(pattern -> antPathMatcher.match(pattern, uri));
     }
 }


### PR DESCRIPTION
## 주요 변경사항
```java
private boolean isSwaggerRequest(String uri) {
        return Arrays.stream(TicketStatic.SwaggerPatterns)
                .anyMatch(pattern -> antPathMatcher.match(pattern, uri));
    }
``` 

matchStrat로 되어있다보니 다른 요청도 SwaggerPattern과 일치하다고 되어 오류 발상한 것 이었습니다.
따라서 matchStart -> match로 수정
## 리뷰어에게...

## 관련 이슈

closes #296 
- [#296]

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정