### PR TITLE
[BE-145] bug: processEventData에서 WaitingOrder가 null이 들어가는 오류

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -2,7 +2,6 @@ package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -48,7 +48,7 @@ public class WaitingQueueService {
         registrationJson.put("affiliation", registration.getAffiliation());
         registrationJson.put("carNum", registration.getCarNum());
         registrationJson.put("phoneNum", registration.getPhoneNum());
-//        registrationJson.put("createdAt", registration.getCreatedAt());
+        //        registrationJson.put("createdAt", registration.getCreatedAt());
         registrationJson.put("deleted", registration.isDeleted());
         registrationJson.put("light", registration.isLight());
         registrationJson.put("saved", registration.isSaved());


### PR DESCRIPTION
## 주요 변경사항
```java
 } else if (sector.isSectorReserveRemaining()) {
            try {
                String registrationString =
                        objectMapper.writeValueAsString(event.getRegistration());
                        waitingQueueService.convertRegistrationJSON(event.getRegistration());
                Long waitingOrder =
                        waitingQueueService.getWaitingOrder( // getWaitingOrder는 0번부터 시작
                                REDIS_EVENT_ISSUE_STORE,
@@ -78,7 +77,7 @@ private void reflectUserState(EventIssuedEvent event, Sector sector, User user)
                                        event.getCurrentUserId(),
                                        event.getSectorId()));
                user.prepare(Integer.valueOf(waitingOrder.intValue()) + 1);
            } catch (JsonProcessingException e) {
            } catch (Exception e) {
                e.printStackTrace();
            }
        } else {
``` 

## 리뷰어에게...
redis에 ZSET으로 저장하는 값이랑 조회하려는 value가 서로 달라서 null이 들어오고 있어서 똑같이 맞춰줬습니다.

## 관련 이슈

closes #302 
- [#302]

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정