### PR TITLE
[BE-151] fix: DateTimePeriod format 변경

### DIFF
--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/vo/DateTimePeriod.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/vo/DateTimePeriod.java
@@ -17,10 +17,10 @@ import lombok.NoArgsConstructor;
 // @JsonFormat(shape = JsonFormat.Shape.OBJECT, timezone = "Asia/Seoul")
 public class DateTimePeriod {
     // 쿠폰 발행 시작 시각
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime startAt;
     // 쿠폰 발행 마감 시각
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime endAt;
 
     @Builder


### PR DESCRIPTION
## 주요 변경사항
DateTimePeriod format변경
## 리뷰어에게...
이벤트 생성요청의 DateTimePeriod가 format이 일치하지 않아 에러가 났다.

## 관련 이슈

closes #315 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정