### PR TITLE
[BE-153] bug: 임시저장하고 최종신청하면 신청이 두번 되는 오류

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -89,7 +89,7 @@ public class EventIssuedEventHandler {
     }
 
     private void saveRegistration(Sector sector, User user, Registration registration) {
-        if(!registration.isSaved()){
+        if (!registration.isSaved()) {
             registration.updateIsSaved(true);
             registrationAdaptor.saveAndFlush(registration);
             return;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -89,6 +89,11 @@ public class EventIssuedEventHandler {
     }
 
     private void saveRegistration(Sector sector, User user, Registration registration) {
+        if(!registration.isSaved()){
+            registration.updateIsSaved(true);
+            registrationAdaptor.saveAndFlush(registration);
+            return;
+        }
         registration.setSector(sector);
         registration.setUser(user);
         registrationAdaptor.saveAndFlush(registration);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/UpdatePublishStatusUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/UpdatePublishStatusUseCase.java
@@ -38,7 +38,7 @@ public class UpdatePublishStatusUseCase {
     }
 
     private void checkExistPublishTrue() {
-        if (eventAdaptor.existsByPublishTrue()) {
+        if (eventAdaptor.existsByPublishTrueAndStatus()) {
             throw AlreadyExistPublishEventException.EXCEPTION;
         }
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -147,7 +147,6 @@ public class RegistrationUseCase {
             String email,
             Long sectorId) {
         tempRegistration.update(registration);
-        tempRegistration.updateIsSaved(true);
         eventWithDrawUseCase.issueEvent(registration, user.getId(), sectorId);
         redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
@@ -114,7 +114,7 @@ public class EventAdaptor implements EventRecordPort, EventLoadPort {
     }
 
     @Override
-    public Boolean existsByPublishTrue() {
-        return eventRepository.existsByPublishTrue();
+    public Boolean existsByPublishTrueAndStatus() {
+        return eventRepository.existsByPublishTrueAndStatus();
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/EventLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/EventLoadPort.java
@@ -23,5 +23,5 @@ public interface EventLoadPort {
 
     Result<Event, Object> findReadyOrOpenAndNotPublishEvent();
 
-    Boolean existsByPublishTrue();
+    Boolean existsByPublishTrueAndStatus();
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/CustomEventRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/CustomEventRepository.java
@@ -1,0 +1,8 @@
+package com.jnu.ticketdomain.domains.events.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomEventRepository {
+    Boolean existsByPublishTrueAndStatus();
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/CustomEventRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/CustomEventRepository.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.events.repository;
 
+
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/CustomEventRepositoryImpl.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/CustomEventRepositoryImpl.java
@@ -1,14 +1,13 @@
 package com.jnu.ticketdomain.domains.events.repository;
 
+import static com.jnu.ticketdomain.domains.events.domain.QEvent.event;
+
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import javax.persistence.EntityManager;
-
-import static com.jnu.ticketdomain.domains.events.domain.QEvent.event;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,14 +17,13 @@ public class CustomEventRepositoryImpl implements CustomEventRepository {
 
     @Override
     public Boolean existsByPublishTrueAndStatus() {
-        return queryFactory.selectOne()
-                .from(event)
-                .where(isPublishTrueAndStatus())
-                .fetchFirst() != null;
+        return queryFactory.selectOne().from(event).where(isPublishTrueAndStatus()).fetchFirst()
+                != null;
     }
 
     private BooleanExpression isPublishTrueAndStatus() {
-        return event.publish.isTrue()
+        return event.publish
+                .isTrue()
                 .and(event.eventStatus.in(EventStatus.OPEN, EventStatus.READY));
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/CustomEventRepositoryImpl.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/CustomEventRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.jnu.ticketdomain.domains.events.repository;
+
+import com.jnu.ticketdomain.domains.events.domain.EventStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+import static com.jnu.ticketdomain.domains.events.domain.QEvent.event;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomEventRepositoryImpl implements CustomEventRepository {
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Boolean existsByPublishTrueAndStatus() {
+        return queryFactory.selectOne()
+                .from(event)
+                .where(isPublishTrueAndStatus())
+                .fetchFirst() != null;
+    }
+
+    private BooleanExpression isPublishTrueAndStatus() {
+        return event.publish.isTrue()
+                .and(event.eventStatus.in(EventStatus.OPEN, EventStatus.READY));
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/EventRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/EventRepository.java
@@ -14,7 +14,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EventRepository extends JpaRepository<Event, Long> {
+public interface EventRepository extends JpaRepository<Event, Long>, CustomEventRepository {
 
     Optional<Event> findByEventStatus(EventStatus eventStatus);
 


### PR DESCRIPTION
## 주요 변경사항
- publish된 이벤트가 있는지 확인 하는 쿼리를 QeuyDsl로 수정하였습니다.
- 임시저장된 것은 EventIssuedEventHandler에서 isSaved만 true로 바꾸고 저장하는 것으로 수정하였습니다.
## 리뷰어에게...

## 관련 이슈

closes #320 


## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정