### PR TITLE
[BE-161] : Termporary, finalSave에서 유효성 검증 추가

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -29,13 +29,12 @@ import com.jnu.ticketdomain.domains.registration.exception.NotFoundRegistrationE
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.redis.RedisService;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -179,8 +178,8 @@ public class RegistrationUseCase {
     }
 
     private void validateEventStatusIsClosed(Event event) {
-        if (event.getEventStatus().equals(EventStatus.CLOSED) ||
-                event.getDateTimePeriod().isAfterEndAt(LocalDateTime.now())) {
+        if (event.getEventStatus().equals(EventStatus.CLOSED)
+                || event.getDateTimePeriod().isAfterEndAt(LocalDateTime.now())) {
             throw AlreadyCloseStatusException.EXCEPTION;
         }
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/vo/DateTimePeriod.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/common/vo/DateTimePeriod.java
@@ -47,4 +47,8 @@ public class DateTimePeriod {
         return (datetime.isAfter(startAt) || datetime.equals(startAt))
                 && (datetime.isBefore(endAt) || datetime.equals(endAt));
     }
+
+    public boolean isAfterEndAt(LocalDateTime datetime) {
+        return datetime.isAfter(endAt);
+    }
 }


### PR DESCRIPTION
## 주요 변경사항
```java
private void validateEventStatusIsClosed(Event event) {
        if (event.getEventStatus().equals(EventStatus.CLOSED) ||
                event.getDateTimePeriod().isAfterEndAt(LocalDateTime.now())) {
            throw AlreadyCloseStatusException.EXCEPTION;
        }
    }
``` 

1. 단순히 event의 상태가 CLOSED인지만 확인하는 것이 아닌 현재 시간과 endAt을 비교하도록 수정하였습니다.
- 그 이유는 만약 OPEN 상태에서 CI/CD로 인한 재배포가 될경우 CLOSED 스케줄링이 적용이 안되는 현상을 발견함. (즉, 시간이 지나도 CLOSED로 바뀌지 않음)

2. 기존 validate 메서드 parameter로 sector -> event
  - sector에서 event를 꺼내서 사용하던 것을 수정
## 리뷰어에게...

## 관련 이슈

closes #333 

## 체크리스트

- [ ] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정