### PR TITLE
[BE-162] feat: Event의 Period 조회

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -62,7 +62,7 @@ public class EventWithDrawUseCase {
     }
 
     public GetEventPeriodResponse getEventPeriod() {
-        Result<Event, Object> readyEvent = eventAdaptor.findReadyOrOpenEvent();
+        Result<Event, Object> readyEvent = eventAdaptor.findReadyOrOpenAndNotPublishEvent();
         return readyEvent.fold(
                 (event) -> {
                     if (event.getPublish().equals(false)) throw NotPublishEventException.EXCEPTION;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/SecurityConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/SecurityConfig.java
@@ -108,7 +108,8 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web ->
                 web.ignoring()
-                        .antMatchers(HttpMethod.GET, "/v1/notice","/v1/sectors", "/v1/events/period")
+                        .antMatchers(
+                                HttpMethod.GET, "/v1/notice", "/v1/sectors", "/v1/events/period")
                         .antMatchers(HttpMethod.OPTIONS, "/v1/notice")
                         .antMatchers(HttpMethod.GET, "/v1/announce/**")
                         .antMatchers(HttpMethod.OPTIONS, "/v1/announce/**")

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/SecurityConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/SecurityConfig.java
@@ -87,8 +87,6 @@ public class SecurityConfig {
                         "/api-docs/**",
                         "/api-docs")
                 .permitAll()
-                .antMatchers(HttpMethod.GET, "/v1/sectors", "/v1/events/period")
-                .authenticated()
                 .antMatchers(councilAndAdminUrls)
                 .hasAnyRole("COUNCIL", "ADMIN")
                 .antMatchers(adminUrls)
@@ -110,7 +108,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web ->
                 web.ignoring()
-                        .antMatchers(HttpMethod.GET, "/v1/notice")
+                        .antMatchers(HttpMethod.GET, "/v1/notice","/v1/sectors", "/v1/events/period")
                         .antMatchers(HttpMethod.OPTIONS, "/v1/notice")
                         .antMatchers(HttpMethod.GET, "/v1/announce/**")
                         .antMatchers(HttpMethod.OPTIONS, "/v1/announce/**")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
@@ -61,7 +61,10 @@ public class EventAdaptor implements EventRecordPort, EventLoadPort {
         Optional<Event> event = eventRepository.findByEventStatus(EventStatus.READY);
         if (event.isPresent() && !event.get().getPublish()) return Result.success(event.get());
         event = eventRepository.findByEventStatus(EventStatus.OPEN);
-        return event.filter(e -> !e.getPublish() && !e.getDateTimePeriod().isAfterEndAt(LocalDateTime.now()))
+        return event.filter(
+                        e ->
+                                !e.getPublish()
+                                        && !e.getDateTimePeriod().isAfterEndAt(LocalDateTime.now()))
                 .map(Result::success)
                 .orElseGet(() -> Result.failure(NotFoundEventException.EXCEPTION));
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/EventAdaptor.java
@@ -61,7 +61,7 @@ public class EventAdaptor implements EventRecordPort, EventLoadPort {
         Optional<Event> event = eventRepository.findByEventStatus(EventStatus.READY);
         if (event.isPresent() && !event.get().getPublish()) return Result.success(event.get());
         event = eventRepository.findByEventStatus(EventStatus.OPEN);
-        return event.filter(e -> !e.getPublish())
+        return event.filter(e -> !e.getPublish() && !e.getDateTimePeriod().isAfterEndAt(LocalDateTime.now()))
                 .map(Result::success)
                 .orElseGet(() -> Result.failure(NotFoundEventException.EXCEPTION));
     }


### PR DESCRIPTION
## 주요 변경사항
1. EventPeriod의 조회할 때 현재시간이 event endAt보다 이후 일때 예외 보내기
2. /events/period를 SecurityFilter에서 제외
## 리뷰어에게...

## 관련 이슈

closes #335 

## 체크리스트

- [ ] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정