### PR TITLE
[fix] : bug: 이벤트 시작전이면 신청폼으로 안들어가지는 버그

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -114,6 +114,7 @@ public class RegistrationUseCase {
         Event event = eventAdaptor.findById(eventId);
         validateEventPublish(event);
         validateEventStatusIsClosed(event);
+        validateEventPeriod(event);
         if (registrationAdaptor.existsByEmailAndIsSavedTrue(email, eventId)
                 || registrationAdaptor.existsByStudentNumAndIsSavedTrue(
                         requestDto.studentNum(), eventId)) {
@@ -178,8 +179,13 @@ public class RegistrationUseCase {
     }
 
     private void validateEventStatusIsClosed(Event event) {
-        if (event.getEventStatus().equals(EventStatus.CLOSED)
-                || event.getDateTimePeriod().isAfterEndAt(LocalDateTime.now())) {
+        if (event.getEventStatus().equals(EventStatus.CLOSED)) {
+            throw AlreadyCloseStatusException.EXCEPTION;
+        }
+    }
+
+    private void validateEventPeriod(Event event) {
+        if(event.getDateTimePeriod().isAfterEndAt(LocalDateTime.now())) {
             throw AlreadyCloseStatusException.EXCEPTION;
         }
     }


### PR DESCRIPTION
## 주요 변경사항
이벤트가 closed인지 확인하는 부분과 시간을 검증하는 부분을 분리하여습니다.
## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정