### PR TITLE
[BE-169] refactor: ProcessQueueDataJob 실행 주기 변경

### DIFF
--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
@@ -139,7 +139,7 @@ public class EventRegisterJob implements Job {
         triggerTriggerBuilder.endAt(end);
         triggerTriggerBuilder.withSchedule(
                 SimpleScheduleBuilder.simpleSchedule()
-                        .withIntervalInSeconds(1)
+                        .withIntervalInMilliseconds(200)
                         .repeatForever()); // 1초마다 실행;
         triggerTriggerBuilder.forJob(processQueueDataJob);
         Trigger reserveTrigger = triggerTriggerBuilder.build();


### PR DESCRIPTION
## 주요 변경사항
t2.micro 기준 ProcessQueueDataJob 실행 주기 1초(1000ms)로 테스트 했을 때  #348 같은 문제가 발생.
실제 prod 환경에서는 t3.2xlarge 이기 때문에 실행 주기를 200ms로 변경
### 변경 수치 근거
실행주기를 판단하는 기준
1. TaskExecutor Thread Pool
- ProcessQueueDataJob에서 publish 하는 event를 listen하는 곳이 EventIssedEventHandler 인데 이것은 @Async로 되어있어 AsyncConfig에 정의한 TaskExecutor Thread Pool에서 관리가 된다.
2. WorkerThread
- 스케줄러에 등록된 job을 workerThread에서 수행되기 때문에 이또한 실행 주기에 밀접한 관련이 있다고 판단하였다.
3. CPU 및 메모리
- 병렬 처리 향상과 컨택스트 스위칭 최소화는 CPU와 밀접한 관계가 있다고 판단 하였고, ec2의 메모리는 Redis 환경과 관계가 있다고 판단

CPU 및 메모리 이외에 TaskExecutor Thread Pool 갯수나 Batch, Scheduler Worker Thread pool 갯수 설정은 변함이 없다. 
<img width="860" alt="image" src="https://github.com/user-attachments/assets/41defa67-ebd8-4c4e-bdc4-713d4ad41ae2">
<img width="860" alt="image" src="https://github.com/user-attachments/assets/d2d1fb5a-0618-46f4-b71d-f05c3c1d7811">

CPU가 8배 차이가 남으로 1000ms / 8 = 125ms... 그러나 너무 짧은 주기는 오버헤드를 증가 시킬 수 있기에 일단 200ms로 수정 후 prod환경에서 테스트를 진행해보려고 한다.

- 출처 : https://aws.amazon.com/ko/ec2/instance-types/
## 리뷰어에게...

## 관련 이슈

closes #348 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정