### PR TITLE
[BE-172] bug: 이벤트 삭제 시 redis 데이터 삭제되지 않는 현상

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -2,6 +2,7 @@ package com.jnu.ticketapi.api.event.service;
 
 
 import com.jnu.ticketcommon.annotation.UseCase;
+import com.jnu.ticketcommon.consts.TicketStatic;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
@@ -12,6 +13,8 @@ import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @UseCase
 @RequiredArgsConstructor
@@ -27,7 +30,7 @@ public class EventDeleteUseCase {
         Events.raise(EventDeletedEvent.of(event));
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
-        redisRepository.deleteKeysByPrefix(eventId.toString());
+        redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -1,8 +1,8 @@
 package com.jnu.ticketapi.api.event.service;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 import com.jnu.ticketcommon.annotation.UseCase;
-import com.jnu.ticketcommon.consts.TicketStatic;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
@@ -13,8 +13,6 @@ import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @UseCase
 @RequiredArgsConstructor

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketbatch.expired;
 
 
+import com.jnu.ticketcommon.consts.TicketStatic;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
@@ -16,6 +17,8 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.quartz.QuartzJobBean;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @Slf4j
 public class BatchQuartzJob extends QuartzJobBean {
@@ -41,7 +44,7 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
-        redisRepository.deleteKeysByPrefix(eventId.toString());
+        redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 
         JobParameters jobParameters =

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -1,7 +1,7 @@
 package com.jnu.ticketbatch.expired;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
-import com.jnu.ticketcommon.consts.TicketStatic;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
@@ -17,8 +17,6 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.quartz.QuartzJobBean;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @Slf4j
 public class BatchQuartzJob extends QuartzJobBean {


### PR DESCRIPTION
## 주요 변경사항
주차권 신청 redis 대기열(zset) key가 "쿠폰 발급 저장소" 하나만 사용하기 때문에 deleteKeysByPrefix -> delete 로 수정
## 리뷰어에게...

## 관련 이슈

closes #354 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정