### PR TITLE
[BE-175] bug: redis 대기열에서 데이터를 pop 하고 db에 저장하지 못하는 문제

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -53,12 +53,13 @@ public class EventIssuedEventHandler {
             try {
                 Registration registration =
                         objectMapper.readValue(
-                                eventIssuedEvent.getMessage().getRegistration(), Registration.class);
+                                eventIssuedEvent.getMessage().getRegistration(),
+                                Registration.class);
                 processQueueData(sector, registration, eventIssuedEvent.getMessage().getUserId());
                 waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
                 sector.decreaseEventStock();
                 log.info("주차권 신청 저장 완료");
-            }catch (NoEventStockLeftException e) {
+            } catch (NoEventStockLeftException e) {
                 log.error("해당 구간 잔여 여석이 없습니다.");
                 waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
             } catch (Exception e) {
@@ -102,7 +103,7 @@ public class EventIssuedEventHandler {
     }
 
     private void saveRegistration(Sector sector, User user, Registration registration) {
-        if(!sector.isRemainingAmount()) {
+        if (!sector.isRemainingAmount()) {
             throw NoEventStockLeftException.EXCEPTION;
         }
         if (!registration.isSaved()) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.event.RegistrationCreationEvent;
@@ -47,28 +48,28 @@ public class EventIssuedEventHandler {
     public void handle(EventIssuedEvent eventIssuedEvent) {
         log.info("주차권 신청 저장 시작");
         if (isIdleConnectionAvailable()) {
-            Sector sector = sectorAdaptor.findById(eventIssuedEvent.getSectorId());
+            Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
             try {
                 Registration registration =
                         objectMapper.readValue(
-                                eventIssuedEvent.getRegistration(), Registration.class);
-                processQueueData(sector, registration, eventIssuedEvent.getUserId());
+                                eventIssuedEvent.getMessage().getRegistration(), Registration.class);
+                processQueueData(sector, registration, eventIssuedEvent.getMessage().getUserId());
+                waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
                 sector.decreaseEventStock();
-                Object message =
-                        waitingQueueService.getValueByStatus(
-                                REDIS_EVENT_ISSUE_STORE, ChatMessageStatus.WAITING);
-                Long removeNum = waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, message);
                 log.info("주차권 신청 저장 완료");
+            }catch (NoEventStockLeftException e) {
+                log.error("해당 구간 잔여 여석이 없습니다.");
+                waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
             } catch (Exception e) {
                 // 에러가 났을 때 redis에 데이터를 재등록 한다.(Not Waiting 상태로)
-                log.error("EventIssuedEventHandler Exception: {}", e.getMessage());
+                log.error("EventIssuedEventHandler Exception: ", e);
                 ChatMessage message =
                         new ChatMessage(
-                                eventIssuedEvent.getRegistration(),
-                                eventIssuedEvent.getUserId(),
-                                eventIssuedEvent.getSectorId(),
-                                eventIssuedEvent.getEventId(),
+                                eventIssuedEvent.getMessage().getRegistration(),
+                                eventIssuedEvent.getMessage().getUserId(),
+                                eventIssuedEvent.getMessage().getSectorId(),
+                                eventIssuedEvent.getMessage().getEventId(),
                                 ChatMessageStatus.WAITING.name());
                 waitingQueueService.reRegisterQueue(
                         REDIS_EVENT_ISSUE_STORE,
@@ -101,11 +102,14 @@ public class EventIssuedEventHandler {
     }
 
     private void saveRegistration(Sector sector, User user, Registration registration) {
+        if(!sector.isRemainingAmount()) {
+            throw NoEventStockLeftException.EXCEPTION;
+        }
         if (!registration.isSaved()) {
             registration.updateIsSaved(true);
             registration.setSector(sector);
             registration.setUser(user);
-            registrationAdaptor.saveAndFlush(registration);
+            registrationAdaptor.save(registration);
             return;
         }
         registration.setSector(sector);

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -26,25 +26,18 @@ public class ProcessQueueDataJob implements Job {
 
             WaitingQueueService waitingQueueService =
                     (WaitingQueueService) jobDataMap.get("waitingQueueService");
-            ChatMessage message =
-                    waitingQueueService.getValueByStatus(
-                            REDIS_EVENT_ISSUE_STORE, ChatMessageStatus.NOT_WAITING);
+            ChatMessage message = (ChatMessage) waitingQueueService.findFirst(REDIS_EVENT_ISSUE_STORE);
 
             if (message != null) {
                 log.info("Message found, raising event");
                 Double score = waitingQueueService.getScore(REDIS_EVENT_ISSUE_STORE, message);
                 waitingQueueService.reRegisterQueue(
                         REDIS_EVENT_ISSUE_STORE, message, ChatMessageStatus.WAITING, score);
-                Events.raise(
-                        EventIssuedEvent.from(
-                                message.getSectorId(),
-                                message.getUserId(),
-                                message.getEventId(),
-                                message.getRegistration(),
-                                score));
+                Events.raise(EventIssuedEvent.from(message, score));
             }
         } catch (Exception e) {
             log.error("ProcessQueueDataJob Exception: {}", e.getMessage());
         }
     }
+
 }

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -26,7 +26,8 @@ public class ProcessQueueDataJob implements Job {
 
             WaitingQueueService waitingQueueService =
                     (WaitingQueueService) jobDataMap.get("waitingQueueService");
-            ChatMessage message = (ChatMessage) waitingQueueService.findFirst(REDIS_EVENT_ISSUE_STORE);
+            ChatMessage message =
+                    (ChatMessage) waitingQueueService.findFirst(REDIS_EVENT_ISSUE_STORE);
 
             if (message != null) {
                 log.info("Message found, raising event");
@@ -39,5 +40,4 @@ public class ProcessQueueDataJob implements Job {
             log.error("ProcessQueueDataJob Exception: {}", e.getMessage());
         }
     }
-
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -28,6 +28,11 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     }
 
     @Override
+    public Registration save(Registration registration) {
+        return registrationRepository.save(registration);
+    }
+
+    @Override
     public void delete(Registration registration) {
         registrationRepository.delete(registration);
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
@@ -16,15 +16,6 @@ public class RegistrationCreationEvent extends DomainEvent {
     private final String status;
     private final Integer sequence;
 
-    public static RegistrationCreationEvent of(Registration registration) {
-        return RegistrationCreationEvent.builder()
-                .email(registration.getEmail())
-                .name(registration.getName())
-                .status(registration.getUser().getStatus())
-                .sequence(registration.getUser().getSequence())
-                .build();
-    }
-
     public static RegistrationCreationEvent of(
             Registration registration, String status, Integer sequence) {
         return RegistrationCreationEvent.builder()

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationRecordPort.java
@@ -11,4 +11,6 @@ public interface RegistrationRecordPort {
     void deleteBySector(Long sectorId);
 
     void deleteByEvent(Long eventId);
+
+    Registration save(Registration registration);
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
@@ -11,11 +11,7 @@ public class EventIssuedEvent extends InfrastructureEvent {
     private ChatMessage message;
     private final Double score;
 
-    public static EventIssuedEvent from(
-            ChatMessage message, Double score) {
-        return EventIssuedEvent.builder()
-                .message(message)
-                .score(score)
-                .build();
+    public static EventIssuedEvent from(ChatMessage message, Double score) {
+        return EventIssuedEvent.builder().message(message).score(score).build();
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
@@ -1,25 +1,20 @@
 package com.jnu.ticketinfrastructure.domainEvent;
 
 
+import com.jnu.ticketinfrastructure.model.ChatMessage;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
 public class EventIssuedEvent extends InfrastructureEvent {
-    private final Long sectorId;
-    private final Long userId;
-    private final Long eventId;
-    private final String registration;
+    private ChatMessage message;
     private final Double score;
 
     public static EventIssuedEvent from(
-            Long sectorId, Long userId, Long eventId, String registration, Double score) {
+            ChatMessage message, Double score) {
         return EventIssuedEvent.builder()
-                .sectorId(sectorId)
-                .userId(userId)
-                .eventId(eventId)
-                .registration(registration)
+                .message(message)
                 .score(score)
                 .build();
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -135,5 +135,4 @@ public class WaitingQueueService {
             return null;
         }
     }
-
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -84,7 +84,7 @@ public class WaitingQueueService {
         return redisRepository.zRank(key, value);
     }
 
-    public ChatMessage getValueByStatus(String key, ChatMessageStatus status) {
+    public ChatMessage findFirstByStatus(String key, ChatMessageStatus status) {
         // Get the first element in the ZSET (lowest score) without removing it
         Set<Object> resultSet = redisRepository.zRange(key, 0L, 0L, Object.class);
         Set<ChatMessage> chatMessages =
@@ -124,7 +124,7 @@ public class WaitingQueueService {
         return redisRepository.remove(key, value);
     }
 
-    public Object getValue(String key) {
+    public Object findFirst(String key) {
         // Get the first element in the ZSET (lowest score) without removing it
         Set<Object> resultSet = redisRepository.zRange(key, 0L, 0L, Object.class);
         if (resultSet != null && !resultSet.isEmpty()) {
@@ -135,4 +135,5 @@ public class WaitingQueueService {
             return null;
         }
     }
+
 }


### PR DESCRIPTION
## 주요 변경사항

> redis 대기열 가장 앞에 있는 데이터로 EventIssuedEvent를 publish -> Handler에서 EventIssuedEvent에 있는 Registration을 저장 -> 이메일 전송 -> redis에서 해당 데이터 pop 

위와 같은 방식으로 코드를 수정
## 리뷰어에게...
예전에 코드를 이렇게 짜고 테스트를 했었는데 redis에서 pop이 되지 않아 계속 같은 신청 데이터만 저장이 되어서 코드를 다르게 짯었는데 
그때는 ProcessQueueDataJob 주기를 5 seconds로 적용해서 병목 현상 때문에 안된 것 같습니다... 200ms 로 바꾸니 잘 되네요

## 1차 테스트

### 테스트 사양

칩 : Apple M1 pro

메모리 : 16GB

OS : macOs Sonma 14.6.1

### 초기세팅 [구간번호, 구간 정원, 예비 정원, 잔여 재고]

<img width="1661" alt="1" src="https://github.com/user-attachments/assets/5476e878-c9a0-45c8-b4c5-8c05949428e0">


- [1구간, 20, 40, 60]
- [2구간, 30, 30, 60]
- [3구간, 20, 40, 60]
- [4구간, 5, 55, 60]
- [5구간, 10, 50, 60]

### 결과

<img width="1675" alt="2" src="https://github.com/user-attachments/assets/ec55cda5-4140-4b42-97ee-6c77fbc1cf6b">

<img width="1467" alt="3" src="https://github.com/user-attachments/assets/9474575f-9c9b-4c4a-a6a2-9003ed2de85f">


총 290 개의 신청 요청이 날라감.

총 282개의 신청이 저장 되었음.

총 구간 재고(300) - 총 신청 수 (282) = 남은 재고 수 (18) 이 예상됨.

<img width="1467" alt="4" src="https://github.com/user-attachments/assets/a4832cde-962f-49c6-a3bc-f2401fe6ad3d">


2구간 (7) + 4구간(11) = 18

예상과 정확히 맞아 떨어짐

<img width="1503" alt="5" src="https://github.com/user-attachments/assets/0b64d305-5f56-4516-99b9-896b67157fc8">


“쿠폰 발급 저장소”의 key가 안보임으로 정상적으로 redis 대기열에서 모든 신청 데이터가 pop 되었음을 알 수 있음.

**총 신청(290) - 총 신청 저장 수(282) = 8개는  k6 테스트 할 때 구간을 랜덤하게 신청을 보내는데  재고가 다 찬 곳에 신청을 넣으려고 하고 있는 것**

##  2차 테스트

### 테스트 사양

칩 : Apple M1 pro

메모리 : 16GB

OS : macOs Sonma 14.6.1

### 초기세팅 [구간번호, 구간 정원, 예비 정원, 잔여 재고]

<img width="1677" alt="6" src="https://github.com/user-attachments/assets/67738cad-250e-4650-b337-43bd3e824961">


- [1구간, 20, 40, 60]
- [2구간, 30, 30, 60]
- [3구간, 20, 40, 60]
- [4구간, 5, 55, 60]
- [5구간, 10, 50, 60]

### 결과

<img width="1673" alt="7" src="https://github.com/user-attachments/assets/7238b400-9d6f-4366-aa6f-dddb133ba8e0">

<img width="1675" alt="8" src="https://github.com/user-attachments/assets/b412bb41-14a6-48d0-b555-aebfef2e88f5">


총 634 개의 요청 날라감.

총 300 개의 신청이 저장됨.

총 구간 재고(300) - 총 신청 수 (300) = 남은 재고 수 (0) 이 예상됨.

<img width="1675" alt="9" src="https://github.com/user-attachments/assets/a4166045-b1d7-4956-8cfd-60b0ad3a2536">


모든 구간 재고 없음 (0) → 예상과 정확히 일치함

마찬가지로 **총 신청(634) - 총 신청 저장 수(300) = 334개는  k6 테스트 할 때 구간을 랜덤하게 신청을 보내는데  재고가 다 찬 곳에 신청을 넣으려고 하고 있는 것**

## 관련 이슈

closes #359 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정