### PR TITLE
Refactor #177

### DIFF
--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.7'
     implementation project(':Ticket-Domain')
     implementation project(':Ticket-Common')
     implementation project(':Ticket-Infrastructure')

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -165,16 +165,19 @@ public class EventController {
         eventDeleteUseCase.deleteEvent(eventId);
         return new SuccessResponse(EVENT_SUCCESS_DELETE_MESSAGE);
     }
+
     @Operation(description = "OPEN 중인 이벤트를 닫고 이벤트를 생성한다.")
     @PostMapping("/events/test")
     public void test() {
         testUseCase.execute();
     }
+
     @Operation(description = "issueAmount가 60인 구간 5개를 만든다.")
     @PostMapping("/events/test2")
     public void test2() {
         testUseCase.execute2();
     }
+
     @Operation(description = "주차권 신청 2개를 신청한다.")
     @PostMapping("/events/test3")
     public void test3() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -177,10 +177,4 @@ public class EventController {
     public void test2() {
         testUseCase.execute2();
     }
-
-    @Operation(description = "주차권 신청 2개를 신청한다.")
-    @PostMapping("/events/test3")
-    public void test3() {
-        testUseCase.execute3();
-    }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -43,6 +43,7 @@ public class EventController {
     private final UpdatePublishStatusUseCase updatePublishStatusUseCase;
     private final EventDeleteUseCase eventDeleteUseCase;
     private final EventUpdateUseCase eventUpdateUseCase;
+    private final TestUseCase testUseCase;
 
     @Operation(summary = "주차권 설정", description = "주차권 행사 세부 설정(시작일, 종료일, 잔고)")
     @ApiErrorExceptionsExample(CreateEventExceptionDocs.class)
@@ -163,5 +164,20 @@ public class EventController {
     public SuccessResponse deleteEvent(@PathVariable("event-id") Long eventId) {
         eventDeleteUseCase.deleteEvent(eventId);
         return new SuccessResponse(EVENT_SUCCESS_DELETE_MESSAGE);
+    }
+    @Operation(description = "OPEN 중인 이벤트를 닫고 이벤트를 생성한다.")
+    @PostMapping("/events/test")
+    public void test() {
+        testUseCase.execute();
+    }
+    @Operation(description = "issueAmount가 60인 구간 5개를 만든다.")
+    @PostMapping("/events/test2")
+    public void test2() {
+        testUseCase.execute2();
+    }
+    @Operation(description = "주차권 신청 2개를 신청한다.")
+    @PostMapping("/events/test3")
+    public void test3() {
+        testUseCase.execute3();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/TestUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/TestUseCase.java
@@ -1,0 +1,91 @@
+package com.jnu.ticketapi.api.event.service;
+
+
+import com.jnu.ticketapi.api.event.model.request.EventRegisterRequest;
+import com.jnu.ticketapi.api.registration.model.request.FinalSaveRequest;
+import com.jnu.ticketapi.api.registration.service.RegistrationUseCase;
+import com.jnu.ticketdomain.common.vo.DateTimePeriod;
+import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Event;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.events.repository.EventRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TestUseCase {
+    private final EventAdaptor eventAdaptor;
+    private final EventRepository eventRepository;
+    private final EventRegisterUseCase eventRegisterUseCase;
+    private final RegistrationUseCase registrationUseCase;
+    private final AtomicInteger counter = new AtomicInteger(0);
+
+    @Transactional
+    public void execute() {
+        Event event = eventAdaptor.findOpenEvent();
+        eventRepository.delete(event);
+
+        DateTimePeriod dateTimePeriod =
+                new DateTimePeriod(
+                        LocalDateTime.now().plusSeconds(1), LocalDateTime.now().plusHours(3));
+
+        EventRegisterRequest eventRegisterRequest =
+                new EventRegisterRequest(dateTimePeriod, "test");
+        eventRegisterUseCase.registerEvent(eventRegisterRequest);
+    }
+
+    @Transactional
+    public void execute2() {
+        Event event = eventAdaptor.findOpenEvent();
+        Sector sector = new Sector("1구간", "사회대", 20, 40);
+        Sector sector2 = new Sector("2구간", "사회대2", 30, 30);
+        Sector sector3 = new Sector("3구간", "사회대3", 40, 20);
+        Sector sector4 = new Sector("4구간", "사회대4", 5, 55);
+        Sector sector5 = new Sector("5구간", "사회대5", 10, 50);
+        sector.setEvent(event);
+        sector2.setEvent(event);
+        sector3.setEvent(event);
+        sector4.setEvent(event);
+        sector5.setEvent(event);
+        List<Sector> sectorList = new ArrayList<>();
+        sectorList.add(sector);
+        sectorList.add(sector2);
+        sectorList.add(sector3);
+        sectorList.add(sector4);
+        sectorList.add(sector5);
+        event.setSector(sectorList);
+        event.isPublish(true);
+    }
+
+    @Transactional
+    public void execute3() {
+        String email1 = "ekrrdj07@naver.com";
+        String email2 = "ekrrdj07@gmail.com";
+        Event event = eventAdaptor.findOpenEvent();
+        FinalSaveRequest request =
+                FinalSaveRequest.builder()
+                        .name("이진혁")
+                        .studentNum(String.valueOf(counter.get()))
+                        .affiliation("컴퓨터공학과")
+                        .carNum("12가1234")
+                        .isLight(true)
+                        .phoneNum("010-1111-3333")
+                        .selectSectorId(event.getSector().get(0).getId())
+                        .captchaCode("uTz0clvmTKvmU/6JmOSXng==")
+                        .captchaAnswer("1234")
+                        .build();
+        registrationUseCase.finalSave(request, email1, event.getId());
+        registrationUseCase.finalSave(request, email2, event.getId());
+        increment();
+    }
+
+    private void increment() {
+        counter.incrementAndGet();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
@@ -1,10 +1,7 @@
 package com.jnu.ticketapi.api.registration.handler;
 
 
-import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.event.RegistrationCreationEvent;
-import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
-import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.service.MailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +20,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class RegistrationCreationEventHandler {
     private final MailService mailService;
 
-
     @Async
     @TransactionalEventListener(
             classes = RegistrationCreationEvent.class,
@@ -39,7 +35,4 @@ public class RegistrationCreationEventHandler {
         mailService.sendRegistrationResultMail(
                 event.getEmail(), event.getName(), event.getStatus(), event.getSequence());
     }
-
-
-
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
@@ -1,10 +1,15 @@
 package com.jnu.ticketapi.api.registration.handler;
 
 
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.event.RegistrationCreationEvent;
+import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
+import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.service.MailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -18,13 +23,23 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class RegistrationCreationEventHandler {
     private final MailService mailService;
 
+
     @Async
     @TransactionalEventListener(
             classes = RegistrationCreationEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+            retryFor = {Exception.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000))
     public void handle(RegistrationCreationEvent event) {
+        // 새로운 persistence context에서 User를 조회 (User를 영속화 하기 위해)
+
         mailService.sendRegistrationResultMail(
                 event.getEmail(), event.getName(), event.getStatus(), event.getSequence());
     }
+
+
+
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -34,8 +34,6 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -210,16 +208,36 @@ public class RegistrationUseCase {
 
     @Transactional(readOnly = true)
     public GetRegistrationsResponse getRegistrations(Long eventId) {
-        List<Registration> registrations = registrationAdaptor.findByIsDeletedFalseAndIsSavedTrue(eventId).stream()
-                .filter(registration -> {
-                    UserStatus status = registration.getUser().getStatus();
-                    return status.equals(UserStatus.SUCCESS) || status.equals(UserStatus.PREPARE);
-                })
-                .sorted(Comparator.comparing((Registration r) -> r.getSector().getSectorNumber())// 구간 순으로 정렬
-                        .thenComparing(r -> r.getUser().getStatus())// 합격자가 예비자보다 우선되도록
-                        .thenComparing(r -> r.getUser().getStatus().equals(UserStatus.SUCCESS) ? r.getId() : r.getUser().getSequence()) //합격자는 id로 정렬, 예비자는 sequence로 정렬
-                        .thenComparing(registration -> registration.getSector().getSectorNumber()))
-                .toList();
+        List<Registration> registrations =
+                registrationAdaptor.findByIsDeletedFalseAndIsSavedTrue(eventId).stream()
+                        .filter(
+                                registration -> {
+                                    UserStatus status = registration.getUser().getStatus();
+                                    return status.equals(UserStatus.SUCCESS)
+                                            || status.equals(UserStatus.PREPARE);
+                                })
+                        .sorted(
+                                Comparator.comparing(
+                                                (Registration r) ->
+                                                        r.getSector()
+                                                                .getSectorNumber()) // 구간 순으로 정렬
+                                        .thenComparing(
+                                                r -> r.getUser().getStatus()) // 합격자가 예비자보다 우선되도록
+                                        .thenComparing(
+                                                r ->
+                                                        r.getUser()
+                                                                        .getStatus()
+                                                                        .equals(UserStatus.SUCCESS)
+                                                                ? r.getId()
+                                                                : r.getUser()
+                                                                        .getSequence()) // 합격자는 id로
+                                        // 정렬, 예비자는
+                                        // sequence로
+                                        // 정렬
+                                        .thenComparing(
+                                                registration ->
+                                                        registration.getSector().getSectorNumber()))
+                        .toList();
 
         return GetRegistrationsResponse.of(registrations);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -206,6 +206,10 @@ public class RegistrationUseCase {
         }
     }
 
+    /*
+     * 신청자 목록 조회
+     * 먼저 구간 순으로 정렬하고, 합격자가 예비자보다 우선되도록 정렬, 합격자는 id로 정렬, 예비자는 sequence로 정렬
+     */
     @Transactional(readOnly = true)
     public GetRegistrationsResponse getRegistrations(Long eventId) {
         List<Registration> registrations =
@@ -218,22 +222,15 @@ public class RegistrationUseCase {
                                 })
                         .sorted(
                                 Comparator.comparing(
-                                                (Registration r) ->
-                                                        r.getSector()
-                                                                .getSectorNumber()) // 구간 순으로 정렬
-                                        .thenComparing(
-                                                r -> r.getUser().getStatus()) // 합격자가 예비자보다 우선되도록
+                                                (Registration r) -> r.getSector().getSectorNumber())
+                                        .thenComparing(r -> r.getUser().getStatus())
                                         .thenComparing(
                                                 r ->
                                                         r.getUser()
                                                                         .getStatus()
                                                                         .equals(UserStatus.SUCCESS)
                                                                 ? r.getId()
-                                                                : r.getUser()
-                                                                        .getSequence()) // 합격자는 id로
-                                        // 정렬, 예비자는
-                                        // sequence로
-                                        // 정렬
+                                                                : r.getUser().getSequence())
                                         .thenComparing(
                                                 registration ->
                                                         registration.getSector().getSectorNumber()))

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -28,10 +28,14 @@ import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrat
 import com.jnu.ticketdomain.domains.registration.exception.NotFoundRegistrationException;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.redis.RedisService;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -206,8 +210,16 @@ public class RegistrationUseCase {
 
     @Transactional(readOnly = true)
     public GetRegistrationsResponse getRegistrations(Long eventId) {
-        List<Registration> registrations =
-                registrationAdaptor.findByIsDeletedFalseAndIsSavedTrue(eventId);
+        List<Registration> registrations = registrationAdaptor.findByIsDeletedFalseAndIsSavedTrue(eventId).stream()
+                .filter(registration -> {
+                    UserStatus status = registration.getUser().getStatus();
+                    return status.equals(UserStatus.SUCCESS) || status.equals(UserStatus.PREPARE);
+                })
+                .sorted(Comparator.comparing((Registration r) -> r.getSector().getSectorNumber())// 구간 순으로 정렬
+                        .thenComparing(r -> r.getUser().getStatus())// 합격자가 예비자보다 우선되도록
+                        .thenComparing(r -> r.getUser().getStatus().equals(UserStatus.SUCCESS) ? r.getId() : r.getUser().getSequence()) //합격자는 id로 정렬, 예비자는 sequence로 정렬
+                        .thenComparing(registration -> registration.getSector().getSectorNumber()))
+                .toList();
 
         return GetRegistrationsResponse.of(registrations);
     }
@@ -217,5 +229,9 @@ public class RegistrationUseCase {
                 || registrationAdaptor.existsByStudentNumAndIsSavedTrue(studentNum, eventId)) {
             throw AlreadyExistRegistrationException.EXCEPTION;
         }
+    }
+
+    private Integer parseSectorNumber(String sectorNumber) {
+        return Integer.parseInt(sectorNumber.split("구간")[0]);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/slack/sender/SlackInternalErrorSender.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/slack/sender/SlackInternalErrorSender.java
@@ -73,6 +73,6 @@ public class SlackInternalErrorSender {
         layoutBlocks.add(
                 section(section -> section.fields(List.of(errorNameMarkdown, errorStackMarkdown))));
 
-        //        slackProvider.sendNotification(layoutBlocks);
+                slackProvider.sendNotification(layoutBlocks);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/handler/UserReflectStatusEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/handler/UserReflectStatusEventHandler.java
@@ -1,0 +1,56 @@
+package com.jnu.ticketapi.api.user.handler;
+
+import com.jnu.ticketdomain.common.domainEvent.Events;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.registration.event.RegistrationCreationEvent;
+import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.event.UserReflectStatusEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserReflectStatusEventHandler {
+    private final RegistrationAdaptor registrationAdaptor;
+    private final UserAdaptor userAdaptor;
+
+    @Async
+    @TransactionalEventListener(
+            classes = UserReflectStatusEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+            retryFor = {Exception.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000))
+    public void handle(UserReflectStatusEvent event) {
+        // 새로운 persistence context에서 User를 조회 (User를 영속화 하기 위해)
+        User user = userAdaptor.findById(event.getUserId());
+        reflectUserState(event, user);
+        Events.raise(
+                RegistrationCreationEvent.of(event.getRegistration(), user.getStatus().getValue(), user.getSequence()));
+    }
+    private void reflectUserState(UserReflectStatusEvent event, User user) {
+        Integer position = registrationAdaptor.findPositionById(event.getRegistration().getId(), event.getSector().getId());
+        Integer sectorCapacity = event.getSector().getInitSectorCapacity();
+        Integer issueAmount = event.getSector().getIssueAmount();
+        if (position <= sectorCapacity) {
+            user.success();
+        } else if (position <= issueAmount) {
+            user.prepare(position - sectorCapacity);
+        } else {
+            user.fail();
+        }
+        userAdaptor.save(user);
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/handler/UserReflectStatusEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/handler/UserReflectStatusEventHandler.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.user.handler;
 
+
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.event.RegistrationCreationEvent;
@@ -38,10 +39,14 @@ public class UserReflectStatusEventHandler {
         User user = userAdaptor.findById(event.getUserId());
         reflectUserState(event, user);
         Events.raise(
-                RegistrationCreationEvent.of(event.getRegistration(), user.getStatus().getValue(), user.getSequence()));
+                RegistrationCreationEvent.of(
+                        event.getRegistration(), user.getStatus().getValue(), user.getSequence()));
     }
+
     private void reflectUserState(UserReflectStatusEvent event, User user) {
-        Integer position = registrationAdaptor.findPositionById(event.getRegistration().getId(), event.getSector().getId());
+        Integer position =
+                registrationAdaptor.findPositionById(
+                        event.getRegistration().getId(), event.getSector().getId());
         Integer sectorCapacity = event.getSector().getInitSectorCapacity();
         Integer issueAmount = event.getSector().getIssueAmount();
         if (position <= sectorCapacity) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -1,18 +1,17 @@
 package com.jnu.ticketbatch.config;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.ChatMessageStatus;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
-
-import java.util.Set;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @Slf4j
 @DisallowConcurrentExecution
@@ -29,7 +28,8 @@ public class ProcessQueueDataJob implements Job {
             WaitingQueueService waitingQueueService =
                     (WaitingQueueService) jobDataMap.get("waitingQueueService");
 
-            Set<TypedTuple<Object>> messagesWithScores = waitingQueueService.findAllWithScore(REDIS_EVENT_ISSUE_STORE);
+            Set<TypedTuple<Object>> messagesWithScores =
+                    waitingQueueService.findAllWithScore(REDIS_EVENT_ISSUE_STORE);
 
             if (!messagesWithScores.isEmpty()) {
                 for (TypedTuple<Object> messageWithScore : messagesWithScores) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.Where;
 
 @Entity
@@ -20,6 +21,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @Where(clause = "is_deleted = false")
 @JsonIgnoreProperties("registrations")
+@DynamicUpdate
 public class Sector {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -91,4 +91,14 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     public List<Registration> findByUserId(Long userId) {
         return registrationRepository.findByUserId(userId);
     }
+
+    @Override
+    public Integer findPositionById(Long id, Long sectorId) {
+        return registrationRepository.findPositionById(id, sectorId) + 1;
+    }
+
+    @Override
+    public Boolean existsByIdAndIsSavedTrue(Long id) {
+        return registrationRepository.existsByIdAndIsSavedTrue(id);
+    }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
@@ -2,7 +2,9 @@ package com.jnu.ticketdomain.domains.registration.event;
 
 
 import com.jnu.ticketdomain.common.domainEvent.DomainEvent;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationCreationEvent.java
@@ -2,9 +2,7 @@ package com.jnu.ticketdomain.domains.registration.event;
 
 
 import com.jnu.ticketdomain.common.domainEvent.DomainEvent;
-import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
-import com.jnu.ticketdomain.domains.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationPublishEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/event/RegistrationPublishEvent.java
@@ -20,7 +20,7 @@ public class RegistrationPublishEvent extends DomainEvent {
         return RegistrationPublishEvent.builder()
                 .email(registration.getEmail())
                 .name(registration.getName())
-                .status(registration.getUser().getStatus())
+                .status(registration.getUser().getStatus().getValue())
                 .sequence(registration.getUser().getSequence())
                 .build();
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
@@ -23,4 +23,8 @@ public interface RegistrationLoadPort {
     Boolean existsByStudentNumAndIsSavedTrue(String studentNum, Long eventId);
 
     Optional<Registration> findByEmailAndIsSaved(String email, boolean flag, Long eventId);
+
+    Integer findPositionById(Long id, Long sectorId);
+
+    Boolean existsByIdAndIsSavedTrue(Long id);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -55,7 +55,9 @@ public interface RegistrationRepository
     List<Registration> findByUserId(@Param("userId") Long userId);
 
     List<Registration> findByUser(User user);
-    @Query("select count (r) from Registration r where r.id < :id and r.isSaved = true and r.sector.id = :sectorId")
+
+    @Query(
+            "select count (r) from Registration r where r.id < :id and r.isSaved = true and r.sector.id = :sectorId")
     Integer findPositionById(@Param("id") Long id, @Param("sectorId") Long sectorId);
 
     Boolean existsByIdAndIsSavedTrue(Long id);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -32,7 +32,7 @@ public interface RegistrationRepository
     Optional<Registration> findByEmail(String email);
 
     @Query(
-            "select r from Registration r where r.isDeleted = false and r.isSaved = true and r.sector.event.id = :eventId")
+            "select r from Registration r join fetch r.sector join fetch r.user where r.isSaved = true and r.sector.event.id = :eventId")
     List<Registration> findByIsDeletedFalseAndIsSavedTrue(@Param("eventId") Long eventId);
 
     @Query("UPDATE Registration r SET r.isDeleted = true WHERE r.sector.id = :sectorId")
@@ -55,4 +55,8 @@ public interface RegistrationRepository
     List<Registration> findByUserId(@Param("userId") Long userId);
 
     List<Registration> findByUser(User user);
+    @Query("select count (r) from Registration r where r.id < :id and r.isSaved = true and r.sector.id = :sectorId")
+    Integer findPositionById(@Param("id") Long id, @Param("sectorId") Long sectorId);
+
+    Boolean existsByIdAndIsSavedTrue(Long id);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/User.java
@@ -13,12 +13,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
 @Table(name = "user_tb")
 @DynamicInsert
+@DynamicUpdate
 @JsonIgnoreProperties("registrations")
 public class User {
     @Id
@@ -36,15 +38,16 @@ public class User {
 
     @Column(name = "status", nullable = false)
     @ColumnDefault("'불합격'")
-    private String status;
+    @Convert(converter = UserStatusConverter.class)
+    private UserStatus status;
 
     @Column(name = "sequence", nullable = false)
     /*
     User 엔티티의 인스턴스가 생성되고 sequence 필드에 별도의 값이 할당되지 않으면,
     자바의 기본값 규칙에 따라 0으로 초기화 되기 때문에 @ColumnDefault('-2')를 하면 안된다.
-    불합격일 경우 -2, 합격일 경우 -1, 예비일경우는 그냥 숫자
+    합격일 경우 -2, 불합격일 경우 -1, 예비일경우는 그냥 숫자
     */
-    private Integer sequence = -2;
+    private Integer sequence = -1;
 
     @Column(name = "email", nullable = false, unique = true)
     private String email;
@@ -70,17 +73,17 @@ public class User {
     }
 
     public void success() {
-        this.status = "합격";
-        this.sequence = -1;
-    }
-
-    public void fail() {
-        this.status = "불합격";
+        this.status = UserStatus.SUCCESS;
         this.sequence = -2;
     }
 
+    public void fail() {
+        this.status = UserStatus.FAIL;
+        this.sequence = -1;
+    }
+
     public void prepare(Integer sequence) {
-        this.status = "예비";
+        this.status = UserStatus.PREPARE;
         this.sequence = sequence;
     }
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/UserStatus.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/UserStatus.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.user.domain;
 
+
 import com.jnu.ticketcommon.annotation.EnumClass;
 import lombok.Getter;
 
@@ -16,5 +17,4 @@ public enum UserStatus {
     }
 
     private final String value;
-
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/UserStatus.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/UserStatus.java
@@ -1,0 +1,20 @@
+package com.jnu.ticketdomain.domains.user.domain;
+
+import com.jnu.ticketcommon.annotation.EnumClass;
+import lombok.Getter;
+
+@EnumClass
+@Getter
+public enum UserStatus {
+    // 절대 이 순서를 바꾸지 마세요. 신청서를 조회할 때 합격자가 예비자보다 먼저 나오게 하기 위함입니다.
+    SUCCESS("합격"),
+    PREPARE("예비"),
+    FAIL("불합격");
+
+    UserStatus(String value) {
+        this.value = value;
+    }
+
+    private final String value;
+
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/UserStatusConverter.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/UserStatusConverter.java
@@ -1,0 +1,30 @@
+package com.jnu.ticketdomain.domains.user.domain;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter(autoApply = true)
+public class UserStatusConverter implements AttributeConverter<UserStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(UserStatus userStatus) {
+        if (userStatus == null) {
+            return null;
+        }
+        return userStatus.getValue();
+    }
+
+    @Override
+    public UserStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+
+        return switch (dbData) {
+            case "합격" -> UserStatus.SUCCESS;
+            case "예비" -> UserStatus.PREPARE;
+            case "불합격" -> UserStatus.FAIL;
+            default -> throw new IllegalArgumentException("Unknown value: " + dbData);
+        };
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/UserStatusConverter.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/domain/UserStatusConverter.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.user.domain;
 
+
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
 

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/event/UserReflectStatusEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/event/UserReflectStatusEvent.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.user.event;
 
+
 import com.jnu.ticketdomain.common.domainEvent.DomainEvent;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
@@ -15,8 +16,7 @@ public class UserReflectStatusEvent extends DomainEvent {
     private Registration registration;
     private Sector sector;
 
-    public static UserReflectStatusEvent of(
-            Long userId, Registration registration, Sector sector) {
+    public static UserReflectStatusEvent of(Long userId, Registration registration, Sector sector) {
         return UserReflectStatusEvent.builder()
                 .userId(userId)
                 .registration(registration)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/event/UserReflectStatusEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/user/event/UserReflectStatusEvent.java
@@ -1,0 +1,26 @@
+package com.jnu.ticketdomain.domains.user.event;
+
+import com.jnu.ticketdomain.common.domainEvent.DomainEvent;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class UserReflectStatusEvent extends DomainEvent {
+    private Long userId;
+    private Registration registration;
+    private Sector sector;
+
+    public static UserReflectStatusEvent of(
+            Long userId, Registration registration, Sector sector) {
+        return UserReflectStatusEvent.builder()
+                .userId(userId)
+                .registration(registration)
+                .sector(sector)
+                .build();
+    }
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -37,7 +37,8 @@ public class RedisRepository {
         return redisTemplate.opsForZSet().range(key, startRank, endRank);
     }
 
-    public Set<ZSetOperations.TypedTuple<Object>> zRangeWithScores(String key, Long startRank, Long endRank) {
+    public Set<ZSetOperations.TypedTuple<Object>> zRangeWithScores(
+            String key, Long startRank, Long endRank) {
         return redisTemplate.opsForZSet().rangeWithScores(key, startRank, endRank);
     }
 
@@ -93,7 +94,6 @@ public class RedisRepository {
     public void delete(String key) {
         redisTemplate.delete(key);
     }
-
 
     public void deleteKeysByPrefix(String prefix) {
         // 1. 해당 prefix로 시작하는 모든 키 검색

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -37,6 +37,10 @@ public class RedisRepository {
         return redisTemplate.opsForZSet().range(key, startRank, endRank);
     }
 
+    public Set<ZSetOperations.TypedTuple<Object>> zRangeWithScores(String key, Long startRank, Long endRank) {
+        return redisTemplate.opsForZSet().rangeWithScores(key, startRank, endRank);
+    }
+
     public <T> Queue<T> zPopMin(String key, Long count, Class<T> type) {
         Set<T> set = (Set<T>) redisTemplate.opsForZSet().popMin(key, count);
         return new LinkedList<>(set);
@@ -90,9 +94,6 @@ public class RedisRepository {
         redisTemplate.delete(key);
     }
 
-    public <T> Set<Object> zReverseRange(String key, Long startRank, Long endRank, Class<T> type) {
-        return redisTemplate.opsForZSet().reverseRange(key, startRank, endRank);
-    }
 
     public void deleteKeysByPrefix(String prefix) {
         // 1. 해당 prefix로 시작하는 모든 키 검색

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -136,9 +137,7 @@ public class WaitingQueueService {
         }
     }
 
-    public Set<ChatMessage> findAll(String key) {
-        return redisRepository.zRange(key, 0L, -1L, Object.class).stream()
-                .map(o -> (ChatMessage) o)
-                .collect(Collectors.toSet());
+    public Set<ZSetOperations.TypedTuple<Object>> findAllWithScore(String key) {
+        return redisRepository.zRangeWithScores(key, 0L, -1L);
     }
 }


### PR DESCRIPTION
## 주요 변경사항
1. [ProcessQueueDataJob 최적화](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/commit/5796ef95a0b1e60f012985143af150451ae273dd) 
- value와 socre를 따로 조회하는 것이 아닌 한번에 조회하기

2. [Sector에 DynamicUpdate 추가](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/commit/9ef7a81080100abe857e449ba315b81b8f9ba1cb) 
- 재고 감소가 빠르게 될 수 있도록 더티체킹 시 변동이 있는 필드에만 update

3. [reflectUserStatus 분리](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/commit/11b0a2143cc0e2ec066a9063b29fe74b8f488476) 
-  user의 상태 체크는 다른 트랜잭션으로 분리 (구간별로 저장된 신청이 몇번째로 들어왔는지로 합격 여부 판별)

4. [UserStatus 도입 및 신청서 조회 로직 수정](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/commit/83e03c124e627125d3be582852d62fce696cd60a) 
- 신청서 조회 할 때 합격자가 예비자보다 먼저 오도록 하기위해 UserRole(Enum을 도입하면 더 쉽게 관리 할 수 있음)을 도입

5. [테스트 간편화 하기 위한 테스트 매크로](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/commit/4945f831df662a2acba8680f496272fd4f7da21d)

6. [spring-retry 의존성 추가](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/commit/7dad65402e8a0edfeaf3b3dd492473cef778136e)
## 기존 에러케이스 

신청서는 누락 없이 잘 저장되게 수정되었지만 user의 status와 sequence가 실제 저장된 신청 순서와 많이 상이함.

sequence를 AtomicLong으로 관리하고 있었는데도 동시성 문제가 많았음. (에러가 나면 increment로 증가했던 long이 롤백이 되야하는데 이 롤백 처리가 되지 않았던 것 같음)

A,B,C,D,E,F 순으로 신청이 저장되었을 때 sequence는 1,1,4,5,7 이렇게 예상과는 다른 sequence가 저장됌

## 해결

동시성에 특화된 Atomic 클래스를 사용했음에도 불구하고 동시서 제어가 어려웠고 교착상태(dead-lock) 를 완벽하게 해결하지 못하여 이를 근본적인 해결방법을 모색

- registration을 일단 저장하고 저장된 registraion이 해당 구간에 몇번째 데이터인지를 확인하고 이를 통해 합격/예비/불합을 결정
    
    ```jsx
    if (position(몇 번째 데이터인지 나타내는 수) < = sectorCapcity(구간 정원)) → 합격
    else if (position < issueAmount(구간 정원 + 예비 정원)) → 예비
    else → 불합격
    ```
    
    - 합격자 sequence = -2
    - 불합격자 sequence = -1
    - 예비 sequence = positon - sectorCapcity

## 테스트 1차

- 메모리 16GB
- DBCP Size : 200
- Thread Core Pool Size : 500
- Thread Max Pool Size : 1000
- Thread Queue Capacity : 3000

### 초기세팅

<img width="1631" alt="2-1" src="https://github.com/user-attachments/assets/c0b4e72d-743e-48bb-9726-198f77c42212">

<img width="1728" alt="2-2" src="https://github.com/user-attachments/assets/c686db27-2414-4339-9824-e34d83c1f46b">


- 총 435건의 로그인 & 주차권 신청 요청
- 로그인 모두 성공
- registration은 419 성공 16 실패 →419개의 registration 데이터가 redis 대기열에 삽입, 16건은 여석이 없는 구간에 신청하려고 하여 실패
    - 초기 세팅 총 구간 여석은 300개인데 419개가 저장되었다는 것은 구간의 여석을 감소하는 로직에 동시성 이슈가 있는 것을 알 수 있음.

### 검증

<img width="1728" alt="2-3" src="https://github.com/user-attachments/assets/c7b18ab5-ead6-461a-9013-3ebc58a21eb4">

- 1구간에 1개의 여석이 남음
- 419개의 registration이 저장되었음에도 아직 여석이 남은 것을 보아 역시 정상적으로 여석을 감소하지 않고 있다. (여러 쓰레드에서 sector의 여석을 감소하려고 하는데 lock이 걸려 제대로 감소하지 못하고 있음)

<img width="1728" alt="2-4" src="https://github.com/user-attachments/assets/b346dbe5-e690-401d-9215-63bad22b9994">


<img width="1172" alt="2-5" src="https://github.com/user-attachments/assets/2130a682-bd19-4a3e-a425-8dca37ac0e8f">


- 실제 registration 신청 요청은 419개의 들어왔고 410개가 저장됨 (410개의 데이터가 redis에서 pop이되며 db에저장되었고 9개의 데이터가 redis에서 pop되어 db에 저장하려고 할 때 신청하려고 하는 구간의 재고가 0이여서 저장이 안되는 모습)
- 여기서 알 수 있는 것은 410개의 데이터가 짧은 시간에 pop이되면서 db에 저장되는데 이때 1개의 데이터가 db에 저장이 되면 해당 구간의 여석이 1 감소되야 하지만 그렇지 못하고 있다는 사실을 알 수 있다.
    - **정상적으로 구간 여석이 감소되었다면 410개가 아닌 300개가 저장되었어야 하는데 110개의 데이터가 초과하여 저장되었고 겨우 9개의 데이터만 정상적으로 저장되지 않은 모습**

<img width="1709" alt="2-6" src="https://github.com/user-attachments/assets/695c55f4-5725-42c3-9ca4-62eb66103ee5">


1구간 총 여석은 60개(구간 정원 20 + 예비 정원 40) → 그렇다면 61번째 신청한 사람은 불합격이 되야 한다. 

61번째 신청자 이메일 : `user_9zrsxrl86@example.com`

<img width="1709" alt="2-7" src="https://github.com/user-attachments/assets/81f02441-1f38-433c-bd46-8e582b48af78">


정상적으로 불합격 

<img width="1709" alt="2-8" src="https://github.com/user-attachments/assets/6815930a-948e-4272-acc1-cb75b212261c">


48번째 지원자 → 48 - 20 = 28

예비자여야 하고 예비번호는 28이어야 한다.

정확히 예비에 28번인 것을 확인 할 수 있다.

<img width="1675" alt="2-9" src="https://github.com/user-attachments/assets/ad09fc2c-18d6-4ecc-9dac-41701742f775">


중복되는 신청서가 하나도 없다.

### 결론

[문제 상황]

1. 여전히 동시성 구간 잔여 여석 감소와 다른 곳에서 동시성 문제가  발생하고있다. → 총 구간 여석보다 더 많은 registration이 DB에 저장된다.
2. 여러 쓰레드가 비동기로 ProcessQueueDataJob과 EventHandler를 작업하면서 redis와 DB(mysql)에 교착상태가 발생한다.

<img width="1374" alt="2-10" src="https://github.com/user-attachments/assets/8f35a80f-8d8d-4a32-af47-addb3d09f295">


<img width="1374" alt="2-11" src="https://github.com/user-attachments/assets/eeffc718-0a99-454d-9b34-570895d7db6f">


[문제 상황 해결]

1. 총 구간 여석보다 더 많은 registration이 저장되더라도 저장된 registration에 맞게 status와 sequence가 설정이 된다. → 구간 여석 보다 더 많이 신청한 사람은 불합격 → 주차권 관리자 홈페이지에서 registration을 조회하는 api에서 불합격인 registration을 제외하고 보여준다. → 관리자는 합격 + 예비인 신청명단만을 확인 할 수 있다.(문제 없음)
```java
     /*
     * 신청자 목록 조회
     * 먼저 구간 순으로 정렬하고, 합격자가 예비자보다 우선되도록 정렬, 합격자는 id로 정렬, 예비자는 sequence로 정렬
     */
@Transactional(readOnly = true)
    public GetRegistrationsResponse getRegistrations(Long eventId) {
        List<Registration> registrations =
                registrationAdaptor.findByIsDeletedFalseAndIsSavedTrue(eventId).stream()
                        .filter(
                                registration -> {
                                    UserStatus status = registration.getUser().getStatus();
                                    return status.equals(UserStatus.SUCCESS)
                                            || status.equals(UserStatus.PREPARE);
                                })
                        .sorted(
                                Comparator.comparing(
                                                (Registration r) -> r.getSector().getSectorNumber())
                                        .thenComparing(r -> r.getUser().getStatus())
                                        .thenComparing(
                                                r ->
                                                        r.getUser()
                                                                        .getStatus()
                                                                        .equals(UserStatus.SUCCESS)
                                                                ? r.getId()
                                                                : r.getUser().getSequence())
                                        .thenComparing(
                                                registration ->
                                                        registration.getSector().getSectorNumber()))
                        .toList();

        return GetRegistrationsResponse.of(registrations);
    }
``` 


2. redis 대기열 에서 교착상태로 문제가 되는 경우 → redis 대기열에서 pop이 되지 않음 → pop이 되지 않으니 redis 대기열에 남아있다.→ 스케줄러로 400ms 마다 redis 대기열에서 가장 앞에 있는 데이터를 DB에 저장하고 pop 하기 때문에 결국 나중에라도 무조건 저장되면서 pop이 됨 (지원서 누락이 되지 않는다.)

결론 적으로 동시성 문제는 여전히 해결되지 않았지만 서비스 운영에 문제가 없을 거라 판단된다.

**위와 같은 테스트를 7번 진행 했으며 모두 동일한 결과가 나왔습니다**

## 관련 이슈

closes #364 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정