### PR TITLE
[BE-178] feat: mail 발송 시간 변경 및 딜레이 발송 기능 추가 #366

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -40,7 +40,6 @@ public class EventIssuedEventHandler {
     @EventListener(classes = EventIssuedEvent.class)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(EventIssuedEvent eventIssuedEvent) {
-        log.info("주차권 신청 저장 시작");
         if (isIdleConnectionAvailable()) {
             Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
@@ -56,9 +55,8 @@ public class EventIssuedEventHandler {
                 processQueueData(sector, registration, eventIssuedEvent.getMessage().getUserId());
                 waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
                 sector.decreaseEventStock();
-                log.info("주차권 신청 저장 완료");
             } catch (NoEventStockLeftException e) {
-                log.error("해당 구간 잔여 여석이 없습니다.");
+                log.info("해당 구간 잔여 여석이 없습니다.");
                 waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
             } catch (Exception e) {
                 // 에러가 났을 때 redis에 데이터를 재등록 한다.(Not Waiting 상태로)

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EventExpiredEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EventExpiredEventHandler.java
@@ -1,0 +1,152 @@
+package com.jnu.ticketapi.api.registration.handler;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
+
+import com.jnu.ticketdomain.domains.events.event.EventExpiredEvent;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketinfrastructure.service.MailService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EventExpiredEventHandler {
+    private final MailService mailService;
+    private final RegistrationAdaptor registrationAdaptor;
+
+    @Retryable(
+            retryFor = {Exception.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 30000))
+    @SneakyThrows
+    @Async
+    @TransactionalEventListener(
+            classes = EventExpiredEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(EventExpiredEvent eventExpiredEvent) {
+        int startIndex = 0;
+        int batchSize = 14;
+        Page<Registration> registrations;
+        Queue<Registration> failQueue = new LinkedList<>();
+        Map<Registration, Integer> retryCounts = new HashMap<>(); // Map to track retry counts
+
+        do {
+            registrations =
+                    registrationAdaptor.findByIsDeletedFalseAndIsSavedTrueByPage(
+                            eventExpiredEvent.getEventId(), startIndex);
+
+            List<Registration> batch = new ArrayList<>(batchSize);
+            for (Registration registration : registrations.getContent()) {
+                batch.add(registration);
+
+                if (batch.size() == batchSize) {
+                    processBatch(batch, failQueue, retryCounts);
+                    batch.clear();
+
+                    TimeUnit.SECONDS.sleep(1);
+                }
+            }
+
+            if (!batch.isEmpty()) {
+                processBatch(batch, failQueue, retryCounts);
+                batch.clear();
+                TimeUnit.SECONDS.sleep(1);
+            }
+            startIndex++;
+
+        } while (registrations.hasNext());
+
+        failOver(failQueue, retryCounts);
+    }
+
+    private void processBatch(
+            List<Registration> batch,
+            Queue<Registration> failQueue,
+            Map<Registration, Integer> retryCounts) {
+        for (Registration registration : batch) {
+            try {
+                boolean result =
+                        mailService.sendRegistrationResultMail(
+                                registration.getEmail(),
+                                registration.getName(),
+                                registration.getUser().getStatus().getValue(),
+                                registration.getUser().getSequence());
+
+                if (!result) {
+                    failQueue.add(registration);
+                    retryCounts.put(
+                            registration,
+                            retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
+                }
+            } catch (Exception e) {
+                log.error(
+                        "Email sending failed for {}: {}", registration.getEmail(), e.getMessage());
+                failQueue.add(registration);
+                retryCounts.put(
+                        registration,
+                        retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
+            }
+        }
+    }
+
+    private void failOver(Queue<Registration> failQueue, Map<Registration, Integer> retryCounts)
+            throws InterruptedException {
+        while (!failQueue.isEmpty()) {
+            int queueSize = failQueue.size();
+            for (int i = 0; i < queueSize; i++) {
+                Registration registration = failQueue.poll();
+
+                int retryCount = retryCounts.getOrDefault(registration, 0);
+                if (retryCount >= MAX_EMAIL_SEND_RETRY) {
+                    log.error("최대 10번 retry 실패시: {}", registration.getEmail());
+                    continue;
+                }
+                try {
+                    boolean result =
+                            mailService.sendRegistrationResultMail(
+                                    registration.getEmail(),
+                                    registration.getName(),
+                                    registration.getUser().getStatus().getValue(),
+                                    registration.getUser().getSequence());
+
+                    if (!result) {
+                        retryCounts.put(registration, retryCount + 1);
+                        failQueue.add(registration);
+                        log.warn(
+                                "Retry failed for email: {} (Attempt {})",
+                                registration.getEmail(),
+                                retryCount + 1);
+                    }
+                } catch (Exception e) {
+                    log.error(
+                            "Retry exception for email {}: {}",
+                            registration.getEmail(),
+                            e.getMessage());
+                    retryCounts.put(registration, retryCount + 1);
+                    failQueue.add(registration);
+                }
+            }
+            TimeUnit.SECONDS.sleep(1);
+        }
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
@@ -25,7 +25,7 @@ public class RegistrationCreationEventHandler {
             classes = RegistrationCreationEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Deprecated
+    @Deprecated(since = "Email 발송 시점 변경", forRemoval = true)
     @Retryable(
             retryFor = {Exception.class},
             maxAttempts = 3,

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/RegistrationCreationEventHandler.java
@@ -25,14 +25,15 @@ public class RegistrationCreationEventHandler {
             classes = RegistrationCreationEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Deprecated
     @Retryable(
             retryFor = {Exception.class},
             maxAttempts = 3,
             backoff = @Backoff(delay = 1000))
     public void handle(RegistrationCreationEvent event) {
         // 새로운 persistence context에서 User를 조회 (User를 영속화 하기 위해)
-
-        mailService.sendRegistrationResultMail(
-                event.getEmail(), event.getName(), event.getStatus(), event.getSequence());
+        //        mailService.sendRegistrationResultMail(
+        //                event.getEmail(), event.getName(), event.getStatus(),
+        // event.getSequence());
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/slack/sender/SlackInternalErrorSender.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/slack/sender/SlackInternalErrorSender.java
@@ -73,6 +73,6 @@ public class SlackInternalErrorSender {
         layoutBlocks.add(
                 section(section -> section.fields(List.of(errorNameMarkdown, errorStackMarkdown))));
 
-                slackProvider.sendNotification(layoutBlocks);
+        slackProvider.sendNotification(layoutBlocks);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/handler/UserReflectStatusEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/handler/UserReflectStatusEventHandler.java
@@ -1,9 +1,7 @@
 package com.jnu.ticketapi.api.user.handler;
 
 
-import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
-import com.jnu.ticketdomain.domains.registration.event.RegistrationCreationEvent;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.event.UserReflectStatusEvent;
@@ -38,9 +36,12 @@ public class UserReflectStatusEventHandler {
         // 새로운 persistence context에서 User를 조회 (User를 영속화 하기 위해)
         User user = userAdaptor.findById(event.getUserId());
         reflectUserState(event, user);
-        Events.raise(
-                RegistrationCreationEvent.of(
-                        event.getRegistration(), user.getStatus().getValue(), user.getSequence()));
+
+        // 이메일 발송은 Closed 될때 배치로 돌릴 수 있도록 리펙토링 완료했습니다.
+        //        Events.raise(
+        //                RegistrationCreationEvent.of(
+        //                        event.getRegistration(), user.getStatus().getValue(),
+        // user.getSequence()));
     }
 
     private void reflectUserState(UserReflectStatusEvent event, User user) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/common/actuator/ThreadPoolConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/common/actuator/ThreadPoolConfig.java
@@ -11,8 +11,7 @@ import org.springframework.stereotype.Component;
 @Endpoint(id = "threadpool")
 public class ThreadPoolConfig {
 
-    @Autowired
-    private ThreadPoolTaskExecutor threadPoolTaskExecutor;
+    @Autowired private ThreadPoolTaskExecutor threadPoolTaskExecutor;
 
     @ReadOperation
     public ThreadPoolStats threadPoolStats() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/common/actuator/ThreadPoolConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/common/actuator/ThreadPoolConfig.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketapi.common.actuator;
 
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -10,11 +11,8 @@ import org.springframework.stereotype.Component;
 @Endpoint(id = "threadpool")
 public class ThreadPoolConfig {
 
-    private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
-
-    public ThreadPoolConfig(ThreadPoolTaskExecutor threadPoolTaskExecutor) {
-        this.threadPoolTaskExecutor = threadPoolTaskExecutor;
-    }
+    @Autowired
+    private ThreadPoolTaskExecutor threadPoolTaskExecutor;
 
     @ReadOperation
     public ThreadPoolStats threadPoolStats() {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchConfiguration.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchConfiguration.java
@@ -2,6 +2,8 @@ package com.jnu.ticketbatch.expired;
 
 
 import com.jnu.ticketbatch.writer.RegistrationWriter;
+import com.jnu.ticketdomain.common.domainEvent.Events;
+import com.jnu.ticketdomain.domains.events.event.EventExpiredEvent;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -67,6 +69,7 @@ public class BatchConfiguration {
     @StepScope
     public HibernateCursorItemReader<Registration> customItemReader(
             @Value("#{jobParameters['eventId']}") Long eventId) {
+        Events.raise(new EventExpiredEvent(eventId));
         return new HibernateCursorItemReaderBuilder<Registration>()
                 .name("hibernateCursorReader")
                 .sessionFactory(sessionFactory)

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
@@ -30,6 +30,9 @@ public class TicketStatic {
 
     public static final String REDIS_EVENT_CHANNEL = "쿠폰 발급 채널";
     public static final String REDIS_EVENT_ISSUE_STORE = "쿠폰 발급 저장소";
+
+    public static final Integer REGISTRATION_SIZE = 14;
+    public static final Integer MAX_EMAIL_SEND_RETRY = 10;
     public static final String[] SwaggerPatterns = {
         "/api/swagger-resources/**",
         "/api/swagger-ui/**",

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/event/EventExpiredEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/event/EventExpiredEvent.java
@@ -1,0 +1,18 @@
+package com.jnu.ticketdomain.domains.events.event;
+
+
+import com.jnu.ticketdomain.common.domainEvent.DomainEvent;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class EventExpiredEvent extends DomainEvent {
+    private final Long eventId;
+
+    public EventExpiredEvent(Long eventId) {
+        this.eventId = eventId;
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.registration.adaptor;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REGISTRATION_SIZE;
 
 import com.jnu.ticketcommon.annotation.Adaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
@@ -11,6 +12,9 @@ import com.jnu.ticketdomain.domains.user.domain.User;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @RequiredArgsConstructor
 @Adaptor
@@ -72,6 +76,11 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     @Override
     public List<Registration> findByIsDeletedFalseAndIsSavedTrue(Long eventId) {
         return registrationRepository.findByIsDeletedFalseAndIsSavedTrue(eventId);
+    }
+
+    public Page<Registration> findByIsDeletedFalseAndIsSavedTrueByPage(Long eventId, int page) {
+        Pageable pageable = PageRequest.of(page, REGISTRATION_SIZE);
+        return registrationRepository.findByIsDeletedFalseAndIsSavedTrueByPage(eventId, pageable);
     }
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -5,6 +5,8 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -34,6 +36,11 @@ public interface RegistrationRepository
     @Query(
             "select r from Registration r join fetch r.sector join fetch r.user where r.isSaved = true and r.sector.event.id = :eventId")
     List<Registration> findByIsDeletedFalseAndIsSavedTrue(@Param("eventId") Long eventId);
+
+    @Query(
+            "select r from Registration r where r.isDeleted = false and r.isSaved = true and r.sector.event.id = :eventId")
+    Page<Registration> findByIsDeletedFalseAndIsSavedTrueByPage(
+            @Param("eventId") Long eventId, Pageable pageable);
 
     @Query("UPDATE Registration r SET r.isDeleted = true WHERE r.sector.id = :sectorId")
     @Modifying(clearAutomatically = true)

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
@@ -19,8 +19,7 @@ public class EnableAsyncConfig implements AsyncConfigurer {
 
     private final CustomAsyncExceptionHandler customAsyncExceptionHandler;
 
-    @Autowired
-    private ThreadPoolTaskExecutor executor;
+    @Autowired private ThreadPoolTaskExecutor executor;
 
     @Value("${thread.core-pool-size}")
     private int corePoolSize;

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
@@ -5,6 +5,7 @@ import com.jnu.ticketinfrastructure.slack.CustomAsyncExceptionHandler;
 import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
@@ -18,6 +19,9 @@ public class EnableAsyncConfig implements AsyncConfigurer {
 
     private final CustomAsyncExceptionHandler customAsyncExceptionHandler;
 
+    @Autowired
+    private ThreadPoolTaskExecutor executor;
+
     @Value("${thread.core-pool-size}")
     private int corePoolSize;
 
@@ -29,7 +33,6 @@ public class EnableAsyncConfig implements AsyncConfigurer {
 
     @Override
     public Executor getAsyncExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(corePoolSize);
         executor.setMaxPoolSize(maxPoolSize);
         executor.setQueueCapacity(queueCapacity);

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -57,9 +57,6 @@ public class RedisRepository {
                         + "    return nil "
                         + "end";
 
-        // Log before executing the script
-        log.info("Executing Lua script to pop min element from key: {}", key);
-
         return redisTemplate.execute(
                 (RedisCallback<Object>)
                         connection ->

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -34,10 +34,7 @@ public class WaitingQueueService {
             String key, Registration registration, Long userId, Long sectorId, Long eventId)
             throws JsonProcessingException {
         Double score = (double) System.currentTimeMillis();
-        //        registration to JSON String
-        //        String registrationString = registration.toString();
         String registrationString = convertRegistrationJSON(registration);
-        //            String registrationString = objectMapper.writeValueAsString(registration);
         ChatMessage message =
                 new ChatMessage(
                         registrationString,
@@ -57,7 +54,6 @@ public class WaitingQueueService {
         registrationJson.put("affiliation", registration.getAffiliation());
         registrationJson.put("carNum", registration.getCarNum());
         registrationJson.put("phoneNum", registration.getPhoneNum());
-        //        registrationJson.put("createdAt", registration.getCreatedAt());
         registrationJson.put("isDeleted", registration.isDeleted());
         registrationJson.put("isLight", registration.isLight());
         registrationJson.put("isSaved", registration.isSaved());
@@ -86,7 +82,6 @@ public class WaitingQueueService {
     }
 
     public ChatMessage findFirstByStatus(String key, ChatMessageStatus status) {
-        // Get the first element in the ZSET (lowest score) without removing it
         Set<Object> resultSet = redisRepository.zRange(key, 0L, 0L, Object.class);
         Set<ChatMessage> chatMessages =
                 resultSet.stream()
@@ -95,7 +90,6 @@ public class WaitingQueueService {
                                 chatMessage ->
                                         Objects.equals(chatMessage.getStatus(), status.name()))
                         .collect(Collectors.toSet());
-        log.info("chatMessages: {}", chatMessages);
         if (chatMessages != null && !chatMessages.isEmpty()) {
             // Return the first element in the set
             return chatMessages.iterator().next();


### PR DESCRIPTION
## 주요 변경사항

14건 기준으로 1초씩 딜레이를 걸어서 이메일을 발송합니다.
추가적으로 실패한 건에 대해서는 완료될때까지 retry를 시도하며, 최대 10번 반복하게 CLOSED TIME에 실행될 수 있도록 event 기반으로 변경해두었습니다. (JOB 하고는 상관 없게끔 SpEL 방식으로 parameter bind 시켜두었습니다.)


## 리뷰어에게...
- 오물풍선마냥 로그 저한테 지우라고 하지 마세요.
- 한줄 추가할때, 이슈 하나 올리기 귀찮아서 화웨이 애를 불러다가 이런거 시키는거 상당히 문제요소가 있다고 여겨집니다. (@pyg410 @LJH098 )

## 관련 이슈
- closed #366 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정