### PR TITLE
[BE-370] 비유저가 호출할 수 있는 요청 로깅 시 anonymous로 유저 정보 남기도록 변경

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
@@ -1,20 +1,20 @@
 package com.jnu.ticketapi.config;
 
-
 import com.jnu.ticketapi.security.JwtResolver;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,28 +23,26 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
     private static final String START_TIME_ATTR_NAME = "startTime";
     private static final String REQUEST_ID_KEY = "requestId";
     private static final String REGISTRATION_PATH = "/api/v1/registration/";
+
     private final WebProperties webProperties;
     private final JwtResolver jwtResolver;
 
     @Override
-    public boolean preHandle(
-            HttpServletRequest request, HttpServletResponse response, Object handler) {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         MDC.put(REQUEST_ID_KEY, generateRequestId());
         request.setAttribute(START_TIME_ATTR_NAME, System.currentTimeMillis());
-
         return true;
     }
 
     @Override
-    public void afterCompletion(
-            HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
             throws IOException {
-        if (isSkipLogging(request)) {
+        if (shouldSkipLogging(request)) {
             return;
         }
 
-        createBaseLogMessage(request, response);
-        appendSensitiveDataToLogMessage(request);
+        logRequestDetails(request, response);
+        logSensitiveData(request);
 
         MDC.clear();
     }
@@ -52,14 +50,13 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
     private String generateRequestId() {
         return IntStream.range(0, 8)
                 .mapToObj(i -> String.valueOf((char) ThreadLocalRandom.current().nextInt(48, 123)))
-                .filter(
-                        ch ->
-                                (ch.charAt(0) <= '9' || ch.charAt(0) >= 'A')
-                                        && (ch.charAt(0) <= 'Z' || ch.charAt(0) >= 'a'))
+                .filter(ch -> (ch.charAt(0) >= '0' && ch.charAt(0) <= '9') ||
+                        (ch.charAt(0) >= 'A' && ch.charAt(0) <= 'Z') ||
+                        (ch.charAt(0) >= 'a' && ch.charAt(0) <= 'z'))
                 .collect(Collectors.joining());
     }
 
-    private boolean isSkipLogging(HttpServletRequest request) {
+    private boolean shouldSkipLogging(HttpServletRequest request) {
         return webProperties.isNoLoggable(request.getServletPath()) || isPreflight(request);
     }
 
@@ -67,30 +64,34 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
         return HttpMethod.OPTIONS.matches(request.getMethod());
     }
 
-    private void createBaseLogMessage(HttpServletRequest request, HttpServletResponse response) {
-        String bearerToken = request.getHeader("Authorization");
-        String accessToken = jwtResolver.extractToken(bearerToken);
-
-        String currentUserId = jwtResolver.getAuthentication(accessToken).getName();
+    private void logRequestDetails(HttpServletRequest request, HttpServletResponse response) {
+        String currentUserId = getCurrentUserId(request);
         long executionTime = getExecutionTime(request);
         String requestUrl = request.getRequestURI();
         String method = request.getMethod();
         String responseType = response.getContentType();
 
-        log.info(
-                String.format(
-                        "Method : %s, URL: %s, User: %s, ResponseType: %s, ResponseTime: %dms",
-                        method, requestUrl, currentUserId, responseType, executionTime));
+        log.info("Method: {}, URL: {}, User: {}, ResponseType: {}, ResponseTime: {}ms",
+                method, requestUrl, currentUserId, responseType, executionTime);
     }
 
-    private void appendSensitiveDataToLogMessage(HttpServletRequest request) throws IOException {
+    private String getCurrentUserId(HttpServletRequest request) {
+        if (webProperties.isNoLoggable(request.getServletPath())) {
+            return "anonymous";
+        }
+        String bearerToken = request.getHeader("Authorization");
+        String accessToken = jwtResolver.extractToken(bearerToken);
+        return jwtResolver.getAuthentication(accessToken).getName();
+    }
+
+    private void logSensitiveData(HttpServletRequest request) throws IOException {
         String requestUri = request.getRequestURI();
         if (requestUri.trim().startsWith(REGISTRATION_PATH)) {
-            log.info("[registration request]" + getBody(request));
+            log.info("[registration request] {}", getRequestBody(request));
         }
     }
 
-    private String getBody(HttpServletRequest request) throws IOException {
+    private String getRequestBody(HttpServletRequest request) throws IOException {
         CacheAccessRequestFilter wrapRequest = (CacheAccessRequestFilter) request;
         byte[] contents = wrapRequest.getContents();
         return new String(contents, StandardCharsets.UTF_8);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
@@ -85,11 +85,13 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
     }
 
     private String getCurrentUserId(HttpServletRequest request) {
-        if (webProperties.isAnonymous(request.getServletPath())) {
-            return "anonymous";
-        }
         String bearerToken = request.getHeader("Authorization");
         String accessToken = jwtResolver.extractToken(bearerToken);
+
+        if (accessToken == null) {
+            return "anonymous";
+        }
+
         return jwtResolver.getAuthentication(accessToken).getName();
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
@@ -86,12 +86,11 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
 
     private String getCurrentUserId(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-        String accessToken = jwtResolver.extractToken(bearerToken);
-
-        if (accessToken == null) {
+        if (bearerToken == null) {
             return "anonymous";
         }
 
+        String accessToken = jwtResolver.extractToken(bearerToken);
         return jwtResolver.getAuthentication(accessToken).getName();
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
@@ -39,12 +39,12 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
     public void afterCompletion(
             HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
             throws IOException {
-        if (shouldSkipLogging(request)) {
+        if (isSkipLogging(request)) {
             return;
         }
 
-        logRequestDetails(request, response);
-        logSensitiveData(request);
+        createRequestLog(request, response);
+        createAdditionalLog(request);
 
         MDC.clear();
     }
@@ -60,7 +60,7 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
                 .collect(Collectors.joining());
     }
 
-    private boolean shouldSkipLogging(HttpServletRequest request) {
+    private boolean isSkipLogging(HttpServletRequest request) {
         return webProperties.isNoLoggable(request.getServletPath()) || isPreflight(request);
     }
 
@@ -68,7 +68,7 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
         return HttpMethod.OPTIONS.matches(request.getMethod());
     }
 
-    private void logRequestDetails(HttpServletRequest request, HttpServletResponse response) {
+    private void createRequestLog(HttpServletRequest request, HttpServletResponse response) {
         String currentUserId = getCurrentUserId(request);
         long executionTime = getExecutionTime(request);
         String requestUrl = request.getRequestURI();
@@ -93,7 +93,7 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
         return jwtResolver.getAuthentication(accessToken).getName();
     }
 
-    private void logSensitiveData(HttpServletRequest request) throws IOException {
+    private void createAdditionalLog(HttpServletRequest request) throws IOException {
         String requestUri = request.getRequestURI();
         if (requestUri.trim().startsWith(REGISTRATION_PATH)) {
             log.info("[registration request] {}", getRequestBody(request));

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
@@ -1,20 +1,20 @@
 package com.jnu.ticketapi.config;
 
+
 import com.jnu.ticketapi.security.JwtResolver;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,14 +28,16 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
     private final JwtResolver jwtResolver;
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    public boolean preHandle(
+            HttpServletRequest request, HttpServletResponse response, Object handler) {
         MDC.put(REQUEST_ID_KEY, generateRequestId());
         request.setAttribute(START_TIME_ATTR_NAME, System.currentTimeMillis());
         return true;
     }
 
     @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+    public void afterCompletion(
+            HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
             throws IOException {
         if (shouldSkipLogging(request)) {
             return;
@@ -50,9 +52,11 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
     private String generateRequestId() {
         return IntStream.range(0, 8)
                 .mapToObj(i -> String.valueOf((char) ThreadLocalRandom.current().nextInt(48, 123)))
-                .filter(ch -> (ch.charAt(0) >= '0' && ch.charAt(0) <= '9') ||
-                        (ch.charAt(0) >= 'A' && ch.charAt(0) <= 'Z') ||
-                        (ch.charAt(0) >= 'a' && ch.charAt(0) <= 'z'))
+                .filter(
+                        ch ->
+                                (ch.charAt(0) >= '0' && ch.charAt(0) <= '9')
+                                        || (ch.charAt(0) >= 'A' && ch.charAt(0) <= 'Z')
+                                        || (ch.charAt(0) >= 'a' && ch.charAt(0) <= 'z'))
                 .collect(Collectors.joining());
     }
 
@@ -71,12 +75,17 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
         String method = request.getMethod();
         String responseType = response.getContentType();
 
-        log.info("Method: {}, URL: {}, User: {}, ResponseType: {}, ResponseTime: {}ms",
-                method, requestUrl, currentUserId, responseType, executionTime);
+        log.info(
+                "Method: {}, URL: {}, User: {}, ResponseType: {}, ResponseTime: {}ms",
+                method,
+                requestUrl,
+                currentUserId,
+                responseType,
+                executionTime);
     }
 
     private String getCurrentUserId(HttpServletRequest request) {
-        if (webProperties.isNoLoggable(request.getServletPath())) {
+        if (webProperties.isAnonymous(request.getServletPath())) {
             return "anonymous";
         }
         String bearerToken = request.getHeader("Authorization");

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebProperties.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebProperties.java
@@ -35,14 +35,7 @@ public class WebProperties {
     }
 
     private boolean isMatchPattern(String pattern, String input) {
-        String regex;
-        if (pattern.contains("**")) {
-            regex = pattern.replace(".", "\\.").replace("**", ".*").replace("*", "[^/]*");
-            regex = "^" + regex + "$";
-
-            return Pattern.matches(regex, input);
-        }
-        regex = pattern.replace("*", ".*");
+        String regex = pattern.replace("*", ".*");
         return Pattern.matches(regex, input);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebProperties.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebProperties.java
@@ -14,19 +14,9 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 @ConfigurationProperties(prefix = "web.log")
 public class WebProperties {
     private List<String> urlNoLogging;
-    private List<String> anonymousLogging;
 
     public boolean isNoLoggable(String path) {
         for (String pattern : urlNoLogging) {
-            if (isMatchPattern(pattern, path)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public boolean isAnonymous(String path) {
-        for (String pattern : anonymousLogging) {
             if (isMatchPattern(pattern, path)) {
                 return true;
             }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebProperties.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebProperties.java
@@ -14,6 +14,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 @ConfigurationProperties(prefix = "web.log")
 public class WebProperties {
     private List<String> urlNoLogging;
+    private List<String> anonymousLogging;
 
     public boolean isNoLoggable(String path) {
         for (String pattern : urlNoLogging) {
@@ -24,8 +25,24 @@ public class WebProperties {
         return false;
     }
 
+    public boolean isAnonymous(String path) {
+        for (String pattern : anonymousLogging) {
+            if (isMatchPattern(pattern, path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private boolean isMatchPattern(String pattern, String input) {
-        String regex = pattern.replace("*", ".*");
+        String regex;
+        if (pattern.contains("**")) {
+            regex = pattern.replace(".", "\\.").replace("**", ".*").replace("*", "[^/]*");
+            regex = "^" + regex + "$";
+
+            return Pattern.matches(regex, input);
+        }
+        regex = pattern.replace("*", ".*");
         return Pattern.matches(regex, input);
     }
 }

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -39,8 +39,9 @@ web:
   log:
     url-no-logging:
       - /api/swagger-ui.html
-      - /api/actuator/**
-
+      - /api/actuator/*
+    anonymous-logging:
+      - /v1/auth/*
 ---
 spring:
   config:

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -40,8 +40,6 @@ web:
     url-no-logging:
       - /api/swagger-ui.html
       - /api/actuator/*
-    anonymous-logging:
-      - /v1/auth/*
 ---
 spring:
   config:


### PR DESCRIPTION
## 주요 변경사항
### 비로그인 요청 로깅 .anonymous로 유정 정보를 남긴다.
```
M3M4 2024-09-05 00:03:20.705  INFO --- [nio-8080-exec-1] c.j.t.config.WebLoggingInterceptor       : Method: POST, URL: /api/v1/auth/check/email, User: anonymous, ResponseType: application/json, ResponseTime: 158ms
```

### 로그인 요청 로깅은 기존과 동일합니다.
```
oO7mzD 2024-09-05 00:05:19.095  INFO --- [nio-8080-exec-5] c.j.t.config.WebLoggingInterceptor       : Method: POST, URL: /api/v1/registration/1, User: 7, ResponseType: application/json, ResponseTime: 81ms
oO7mzD 2024-09-05 00:05:19.096  INFO --- [nio-8080-exec-5] c.j.t.config.WebLoggingInterceptor       : [registration request] {
  "name": "홍길동",
  "studentNum": "183027",
  "affiliation": "공과대학",
  "carNum": "12가1234",
  "isLight": true,
  "phoneNum": "010-1111-3333",
  "selectSectorId": 1,
  "captchaCode": "1234",
  "captchaAnswer": "1234"
}
```

## 리뷰어에게...

## 관련 이슈

closes #370 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정