### PR TITLE
[BE-183] feat: 레디스 없이도 서버 정상 가동

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/controller/AuthController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/controller/AuthController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "1. [인증]")
 public class AuthController {
     private final AuthUseCase authUseCase;
+
     @Value("${ableRedis:true}")
     private boolean ableRedis;
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/controller/AuthController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/controller/AuthController.java
@@ -13,11 +13,13 @@ import com.jnu.ticketapi.api.auth.model.response.*;
 import com.jnu.ticketapi.api.auth.service.AuthUseCase;
 import com.jnu.ticketapi.common.aop.GetEmail;
 import com.jnu.ticketcommon.annotation.ApiErrorExceptionsExample;
+import com.jnu.ticketcommon.exception.RefreshTokenExpiredException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,6 +30,8 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "1. [인증]")
 public class AuthController {
     private final AuthUseCase authUseCase;
+    @Value("${ableRedis:true}")
+    private boolean ableRedis;
 
     @ApiErrorExceptionsExample(UserLoginExceptionDocs.class)
     @Operation(summary = "로그인/회원가입", description = "로그인을 하면 동시에 회원가입이 되면서 로그인 처리")
@@ -47,6 +51,9 @@ public class AuthController {
             @RequestBody @Valid ReissueTokenRequest requestDto,
             @RequestHeader("Authorization") String bearerToken,
             @GetEmail String email) {
+        if (!ableRedis) {
+            throw RefreshTokenExpiredException.EXCEPTION;
+        }
         String accessToken = authUseCase.extractToken(bearerToken);
         ReissueTokenResponse responseDto =
                 authUseCase.reissue(accessToken, requestDto.refreshToken(), email);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/service/AuthUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/service/AuthUseCase.java
@@ -22,6 +22,7 @@ import com.jnu.ticketdomain.domains.council.exception.AlreadyExistEmailException
 import com.jnu.ticketdomain.domains.council.exception.IsNotCouncilException;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.redis.RedisService;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -44,8 +43,10 @@ public class AuthUseCase {
     private final CouncilUseCase councilUseCase;
     private final Converter converter;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
     @Value("${ableRedis:true}")
     private boolean ableRedis;
+
     @Autowired(required = false)
     private RedisService redisService;
 
@@ -96,7 +97,6 @@ public class AuthUseCase {
         // RT가 이미 있을 경우
         if (ableRedis && redisService.getValues("RT(" + provider + "):" + email) != null)
             redisService.deleteValues("RT(" + provider + "):" + email); // 삭제
-
 
         // AT, RT 생성 및 Redis에 RT 저장
         TokenDto tokenDto =

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/service/AuthUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/auth/service/AuthUseCase.java
@@ -94,7 +94,7 @@ public class AuthUseCase {
     */
     public TokenDto generateToken(String provider, String email, String authorities) {
         // RT가 이미 있을 경우
-        if (ableRedis && redisService.getValues("RT(" + provider + "):" + email) != null && ableRedis)
+        if (ableRedis && redisService.getValues("RT(" + provider + "):" + email) != null)
             redisService.deleteValues("RT(" + provider + "):" + email); // 삭제
 
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -32,7 +32,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventIssuedEventHandler {
     private final RegistrationAdaptor registrationAdaptor;
     private final UserAdaptor userAdaptor;
-    @Autowired(required = false) private WaitingQueueService waitingQueueService;
+
+    @Autowired(required = false)
+    private WaitingQueueService waitingQueueService;
+
     private final SectorAdaptor sectorAdaptor;
     private final ObjectMapper objectMapper;
     private final HikariDataSource hikariDataSource;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -19,6 +19,7 @@ import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import com.zaxxer.hikari.HikariDataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -31,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventIssuedEventHandler {
     private final RegistrationAdaptor registrationAdaptor;
     private final UserAdaptor userAdaptor;
-    private final WaitingQueueService waitingQueueService;
+    @Autowired(required = false) private WaitingQueueService waitingQueueService;
     private final SectorAdaptor sectorAdaptor;
     private final ObjectMapper objectMapper;
     private final HikariDataSource hikariDataSource;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -12,13 +12,14 @@ import com.jnu.ticketdomain.domains.events.event.EventDeletedEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
 public class EventDeleteUseCase {
     private final EventAdaptor eventAdaptor;
-    private final RedisRepository redisRepository;
+    @Autowired(required = false) private  RedisRepository redisRepository;
     private final SectorAdaptor sectorAdaptor;
     private final RegistrationAdaptor registrationAdaptor;
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -19,7 +19,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EventDeleteUseCase {
     private final EventAdaptor eventAdaptor;
-    @Autowired(required = false) private  RedisRepository redisRepository;
+
+    @Autowired(required = false)
+    private RedisRepository redisRepository;
+
     private final SectorAdaptor sectorAdaptor;
     private final RegistrationAdaptor registrationAdaptor;
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -17,6 +17,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
@@ -24,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class EventWithDrawUseCase {
 
-    private final WaitingQueueService waitingQueueService;
+    @Autowired(required = false) private WaitingQueueService waitingQueueService;
     private final EventAdaptor eventAdaptor;
 
     /** 재고 감소 */

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -25,7 +25,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class EventWithDrawUseCase {
 
-    @Autowired(required = false) private WaitingQueueService waitingQueueService;
+    @Autowired(required = false)
+    private WaitingQueueService waitingQueueService;
+
     private final EventAdaptor eventAdaptor;
 
     /** 재고 감소 */

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -30,16 +30,15 @@ import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.redis.RedisService;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -53,7 +52,10 @@ public class RegistrationUseCase {
     private final EventWithDrawUseCase eventWithDrawUseCase;
     private final Encryption encryption;
     private final ValidateCaptchaUseCase validateCaptchaUseCase;
-    @Autowired(required = false) private RedisService redisService;
+
+    @Autowired(required = false)
+    private RedisService redisService;
+
     private final EventAdaptor eventAdaptor;
 
     @Value("${ableRedis:true}")
@@ -239,8 +241,8 @@ public class RegistrationUseCase {
                                         .thenComparing(
                                                 r ->
                                                         r.getUser()
-                                                                .getStatus()
-                                                                .equals(UserStatus.SUCCESS)
+                                                                        .getStatus()
+                                                                        .equals(UserStatus.SUCCESS)
                                                                 ? r.getId()
                                                                 : r.getUser().getSequence())
                                         .thenComparing(

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
@@ -36,7 +36,7 @@ public class EventRegisterJob implements Job {
     @Autowired private JobBuilderFactory jobBuilderFactory;
     @Autowired private EventExpiredEventRaiseGateway eventExpiredEventRaiseGateway;
     @Autowired private ApplicationEventPublisher applicationEventPublisher;
-    @Autowired private WaitingQueueService waitingQueueService;
+    @Autowired(required = false) private WaitingQueueService waitingQueueService;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
@@ -36,7 +36,9 @@ public class EventRegisterJob implements Job {
     @Autowired private JobBuilderFactory jobBuilderFactory;
     @Autowired private EventExpiredEventRaiseGateway eventExpiredEventRaiseGateway;
     @Autowired private ApplicationEventPublisher applicationEventPublisher;
-    @Autowired(required = false) private WaitingQueueService waitingQueueService;
+
+    @Autowired(required = false)
+    private WaitingQueueService waitingQueueService;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {

--- a/Ticket-Common/build.gradle
+++ b/Ticket-Common/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     api 'org.springframework.boot:spring-boot-starter-aop'
+
+    implementation 'org.apache.commons:commons-pool2:2.11.1'
 }
 
 bootJar.enabled = false

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -51,7 +51,15 @@ logging:
       SQL: ${LOGGING_LEVEL:INFO}
       type.descriptor.sql.BasicBinder: ${LOGGING_LEVEL:INFO}
 
+
 ableEventLock: true
+ableRedis: ${ABLE_REDIS:true}
+ableRedisson: ${ABLE_REDISSON:true}
+
+management:
+  health:
+    redis:
+      enabled: ${ABLE_REDIS:true}
 ---
 
 spring:
@@ -96,6 +104,15 @@ logging:
     org.springframework.orm.jpa: DEBUG
     org.springframework.transaction: DEBUG
 
+ableEventLock: true
+ableRedis: ${ABLE_REDIS:true}
+ableRedisson: ${ABLE_REDISSON:true}
+
+management:
+  health:
+    redis:
+      enabled: ${ABLE_REDIS:true}
+
 ---
 
 spring:
@@ -128,3 +145,12 @@ thread:
 logging:
   level:
     root: ${LOGGING_LEVEL:debug}
+ableEventLock: true
+ableRedis: ${ABLE_REDIS:true}
+ableRedisson: ${ABLE_REDISSON:true}
+
+management:
+  health:
+    redis:
+      enabled: ${ABLE_REDIS:true}
+

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
@@ -6,6 +6,7 @@ import com.jnu.ticketinfrastructure.model.ChatMessage;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @Configuration
 @EnableTransactionManagement
 @Slf4j
+@ConditionalOnExpression("${ableRedis:true}")
 public class RedisConfig {
 
     @Value("${spring.redis.host}")
@@ -39,6 +41,7 @@ public class RedisConfig {
     private String redisPassword;
 
     @Bean
+    @ConditionalOnExpression("${ableRedis:true}")
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisConfig =
                 new RedisStandaloneConfiguration(redisHost, redisPort);
@@ -55,6 +58,7 @@ public class RedisConfig {
     }
 
     @Bean(name = "redisTemplate")
+    @ConditionalOnExpression("${ableRedis:true}")
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
@@ -69,9 +73,10 @@ public class RedisConfig {
         return redisTemplate;
     }
 
-    // 메세지 리스너 설정
+    // 메세지 리스너 설정x
     // pub/sub 메세지를 받을 채널 설정
     @Bean
+    @ConditionalOnExpression("${ableRedis:true}")
     ChannelTopic topic() {
         return new ChannelTopic(REDIS_EVENT_CHANNEL);
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedissonConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedissonConfig.java
@@ -12,11 +12,13 @@ import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.redisson.jcache.configuration.RedissonConfiguration;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @RequiredArgsConstructor
+@ConditionalOnExpression("${ableRedisson:true}")
 public class RedissonConfig {
 
     @Value("${spring.redis.host}")

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/redissonLock/RedissonLockAop.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/redissonLock/RedissonLockAop.java
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 @Component
 @Slf4j
-@ConditionalOnExpression("${ableRedissonLock:true}")
+@ConditionalOnExpression("${ableRedissonLock:false}")
 public class RedissonLockAop {
 
     private final RedissonClient redissonClient;

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -8,6 +8,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.connection.ReturnType;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @Slf4j
+@ConditionalOnExpression("${ableRedis:true}")
 public class RedisRepository {
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisService.java
@@ -3,6 +3,7 @@ package com.jnu.ticketinfrastructure.redis;
 
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@ConditionalOnExpression("${ableRedis:true}")
 public class RedisService {
 
     private final RedisTemplate<String, String> redisTemplate;

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -17,11 +17,13 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@ConditionalOnExpression("${ableRedis:true}")
 public class WaitingQueueService {
     private final RedisRepository redisRepository;
     @Autowired private ObjectMapper objectMapper;


### PR DESCRIPTION
## 주요 변경사항
- @ConditionOnExpression으로 ableRedis가 false일 때 redis 관련된 것 Bean 등록 안되게 수정
- Common pools 2 의존성 추가
- redis health check on/off 환경변수화

> @Kwon770 redis가 꺼져있을 때는 .env에서 ABLE_REDIS=false, ABLE_REDISSON=false 으로 실행시켜주시고 redis가 정상적으로 켜졌을 때는 ABLE_REDIS=true, ABLE_REDISSON=true 로 실행시켜주세요

## 리뷰어에게...
1. ableRedis와 ableRedisson을 false로 하고 redis를 실행시키지 않았을 때 Commons pool2 에러가 떠서 의존성을 추가해주었습니다.
<img width="1724" alt="image" src="https://github.com/user-attachments/assets/75182bd7-9cc9-4a3e-901d-aae123e73669">

2. redis health check를 제외시키지 않았을 때 redis가 연결되지 않았다고 에러가 떠서 redis가 켜지지 않았을 때는 health check에서 제외시켰습니다.
<img width="1724" alt="image" src="https://github.com/user-attachments/assets/5d11025a-d626-4d49-ac87-5dc6bcc39892">

## 테스트 결과
1. ableRedis와 ableRedission을 false로 하고 redis를 실행시키지 않았을 때 정상적으로 springBoot가 실행되는 모습
<img width="1724" alt="image" src="https://github.com/user-attachments/assets/a7aa366d-858b-405b-bcac-bb86e2813d66">

2. 로그인 정상적으로 성공
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/fdd50d0f-2a7d-4d2e-bd16-5d104c7aebf7">


3. 임시저장 정상적으로 성공
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/4797c833-e320-4b64-9fbb-30463248ad97">

> @Kwon770 redis가 꺼져있을 때는 .env에서 ABLE_REDIS=false, ABLE_REDISSON=false 으로 실행시켜주시고 redis가 정상적으로 켜졌을 때는 ABLE_REDIS=true, ABLE_REDISSON=true 로 실행시켜주세요

## 관련 이슈

closes #378 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정