### PR TITLE
[BE-186] bug: 이벤트 삭제가 되지 않는 오류

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -13,6 +13,7 @@ import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
@@ -26,13 +27,18 @@ public class EventDeleteUseCase {
     private final SectorAdaptor sectorAdaptor;
     private final RegistrationAdaptor registrationAdaptor;
 
+    @Value("${ableRedis:true}")
+    private boolean ableRedis;
+
     @Transactional
     public void deleteEvent(Long eventId) {
         Event event = eventAdaptor.findById(eventId);
         Events.raise(EventDeletedEvent.of(event));
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
-        redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
+        if (ableRedis) {
+            redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
+        }
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);
     }


### PR DESCRIPTION
## 주요 변경사항
ableRedis가 false일 때 redis 대기열을 삭제하지 않도록 수정
## 리뷰어에게...

## 관련 이슈

closes #384 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정