### PR TITLE
[BE-191] refactor: 엑세스 토큰 만료일 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ dump.rdb
 
 application-local.yml
 logs/**
+*.log

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/security/JwtGenerator.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/security/JwtGenerator.java
@@ -19,7 +19,7 @@ public class JwtGenerator {
     private static final String USER_EMAIL_CLAIM_KEY = "Email";
     private static final String USER_AUTH_CLAM_KEY = "Auth";
 
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24; // 1일
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
 
     private final Key key;


### PR DESCRIPTION
## 주요 변경사항
토큰 재발급이 안되는 것을 대비하여 엑세스 토큰 만료일을 30분에서 1일로 수정하였습니다.
## 리뷰어에게...

## 관련 이슈

closes #394 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정