### PR TITLE
[BE-192] bug: Commons-pool2 의존성 제거

### DIFF
--- a/Ticket-Common/build.gradle
+++ b/Ticket-Common/build.gradle
@@ -9,8 +9,6 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     api 'org.springframework.boot:spring-boot-starter-aop'
-
-    implementation 'org.apache.commons:commons-pool2:2.11.1'
 }
 
 bootJar.enabled = false


### PR DESCRIPTION
## 주요 변경사항
- commons-pool2 의존성 제거
## 리뷰어에게...
- [#379] 에서 commons-pool2를 빼고 ABLE_REDIS, ABLE_REDISSON을 false로 시작하면 lettuceFactory에러가 떳었는데 이번에 commons-pool2를 빼니 정상작동함... 아마 lettuce:pool:enabled를 true로 하고 있었어서 그런 것 같음

## 관련 이슈

closes #397 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정