### PR TITLE
[BE-195] bug: 캡차 암호화 일정한 문제 해결

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/ConfigurationApiPropertiesConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/ConfigurationApiPropertiesConfig.java
@@ -1,12 +1,11 @@
 package com.jnu.ticketapi;
 
 
+import com.jnu.ticketapi.config.EncryptionProperties;
 import com.jnu.ticketapi.config.WebProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@EnableConfigurationProperties({
-    WebProperties.class,
-})
+@EnableConfigurationProperties({WebProperties.class, EncryptionProperties.class})
 @Configuration
 public class ConfigurationApiPropertiesConfig {}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCase.java
@@ -11,13 +11,11 @@ import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
 import com.jnu.ticketdomain.domains.captcha.out.CaptchaLogPort;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @RequiredArgsConstructor
-@Slf4j
 public class GetCaptchaUseCase {
 
     private final CaptchaAdaptor captchaAdaptor;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCase.java
@@ -2,10 +2,14 @@ package com.jnu.ticketapi.api.captcha.service;
 
 
 import com.jnu.ticketapi.api.captcha.model.response.CaptchaResponse;
+import com.jnu.ticketapi.application.HashResult;
 import com.jnu.ticketapi.application.helper.Encryption;
+import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLogPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,6 +22,7 @@ public class GetCaptchaUseCase {
 
     private final CaptchaAdaptor captchaAdaptor;
     private final Encryption encryption;
+    private final CaptchaLogPort captchaLogPort;
 
     @Value("${captcha.domain}")
     private String cloudfrontUrl;
@@ -27,7 +32,16 @@ public class GetCaptchaUseCase {
     @Transactional
     public CaptchaResponse execute() {
         Captcha captcha = captchaAdaptor.findByRandom();
-        String code = encryption.encrypt(captcha.getId());
-        return CaptchaResponse.of(cloudfrontUrl, IMAGE_POSTFIX, code, captcha);
+        HashResult result = encryption.encrypt(captcha.getId());
+        Long userId = SecurityUtils.getCurrentUserId();
+
+        captchaLogPort.save(
+                CaptchaLog.builder()
+                        .captchaId(captcha.getId())
+                        .userId(userId)
+                        .salt(result.getSalt())
+                        .build());
+
+        return CaptchaResponse.of(cloudfrontUrl, IMAGE_POSTFIX, result.getCaptchaCode(), captcha);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
@@ -9,6 +9,7 @@ import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
 import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaAnswerException;
+import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaCodeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +30,7 @@ public class ValidateCaptchaUseCase {
 
         if (!encryption.validateCaptchaId(
                 encryptedCode, captchaLog.getCaptchaId(), captchaLog.getSalt())) {
-            throw WrongCaptchaAnswerException.EXCEPTION;
+            throw WrongCaptchaCodeException.EXCEPTION;
         }
 
         Captcha captcha = captchaAdaptor.findById(captchaLog.getCaptchaId());

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
@@ -1,9 +1,13 @@
 package com.jnu.ticketapi.api.captcha.service;
 
 
+import com.jnu.ticketapi.application.helper.Encryption;
+import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
+import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
 import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaAnswerException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,14 +18,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ValidateCaptchaUseCase {
 
+    private final Encryption encryption;
+    private final CaptchaLogAdaptor captchaLogAdaptor;
     private final CaptchaAdaptor captchaAdaptor;
 
     @Transactional
-    public void execute(long captchaId, String answer) {
-        Captcha captcha = captchaAdaptor.findById(captchaId);
+    public void execute(String encryptedCode, String answer) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        CaptchaLog captchaLog = captchaLogAdaptor.findLatestByUserId(userId);
 
-        if (!captcha.validate(answer)) {
+        if (!encryption.validateCaptchaId(encryptedCode, captchaLog.getCaptchaId())) {
             throw WrongCaptchaAnswerException.EXCEPTION;
         }
+
+        Captcha captcha = captchaAdaptor.findById(captchaLog.getCaptchaId());
+        captcha.validate(answer);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
@@ -33,6 +33,8 @@ public class ValidateCaptchaUseCase {
         }
 
         Captcha captcha = captchaAdaptor.findById(captchaLog.getCaptchaId());
-        captcha.validate(answer);
+        if (!captcha.validate(answer)) {
+            throw WrongCaptchaAnswerException.EXCEPTION;
+        }
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
@@ -27,7 +27,8 @@ public class ValidateCaptchaUseCase {
         Long userId = SecurityUtils.getCurrentUserId();
         CaptchaLog captchaLog = captchaLogAdaptor.findLatestByUserId(userId);
 
-        if (!encryption.validateCaptchaId(encryptedCode, captchaLog.getCaptchaId())) {
+        if (!encryption.validateCaptchaId(
+                encryptedCode, captchaLog.getCaptchaId(), captchaLog.getSalt())) {
             throw WrongCaptchaAnswerException.EXCEPTION;
         }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -10,7 +10,6 @@ import com.jnu.ticketapi.api.registration.model.response.GetRegistrationResponse
 import com.jnu.ticketapi.api.registration.model.response.GetRegistrationsResponse;
 import com.jnu.ticketapi.api.registration.model.response.TemporarySaveResponse;
 import com.jnu.ticketapi.application.helper.Converter;
-import com.jnu.ticketapi.application.helper.Encryption;
 import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.consts.TicketStatic;
@@ -50,7 +49,6 @@ public class RegistrationUseCase {
     private final Converter converter;
     private final UserAdaptor userAdaptor;
     private final EventWithDrawUseCase eventWithDrawUseCase;
-    private final Encryption encryption;
     private final ValidateCaptchaUseCase validateCaptchaUseCase;
 
     @Autowired(required = false)
@@ -127,8 +125,7 @@ public class RegistrationUseCase {
         validateEventPeriod(event);
 
         checkDuplicateRegistration(email, eventId, requestDto.studentNum());
-        Long captchaId = encryption.decrypt(requestDto.captchaCode());
-        validateCaptchaUseCase.execute(captchaId, requestDto.captchaAnswer());
+        validateCaptchaUseCase.execute(requestDto.captchaCode(), requestDto.captchaAnswer());
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/application/HashResult.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/application/HashResult.java
@@ -1,0 +1,15 @@
+package com.jnu.ticketapi.application;
+
+
+import lombok.Getter;
+
+@Getter
+public class HashResult {
+    private final String salt;
+    private final String captchaCode;
+
+    public HashResult(String salt, String captchaCode) {
+        this.salt = salt;
+        this.captchaCode = captchaCode;
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
@@ -1,69 +1,77 @@
 package com.jnu.ticketapi.application.helper;
 
 
+import com.jnu.ticketapi.application.HashResult;
 import com.jnu.ticketcommon.annotation.Helper;
-import com.jnu.ticketcommon.exception.DecryptionErrorException;
 import com.jnu.ticketcommon.exception.EncryptionErrorException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.util.Arrays;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Base64;
-import javax.crypto.Cipher;
-import javax.crypto.spec.SecretKeySpec;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
+@Component
 @Helper
-@Slf4j
 public class Encryption {
-    @Value("${encryption.algorithm}")
-    private String algorithm;
 
-    @Value("${encryption.secret}")
-    private String secret;
+    private static final int SALT_LENGTH = 16;
+    private static final String HASH_ALGORITHM = "SHA-256";
+    private static final SecureRandom RANDOM = new SecureRandom();
 
-    private SecretKeySpec secretKeySpec;
+    public HashResult encrypt(final Long plainText) {
+        byte[] salt = generateSalt();
+        return encryptWithSaltBytes(plainText, salt);
+    }
 
-    private SecretKeySpec generateKey() {
+    public HashResult encryptWithSalt(final Long plainText, final String encodedSalt) {
+        byte[] salt = Base64.getDecoder().decode(encodedSalt);
+        return encryptWithSaltBytes(plainText, salt);
+    }
+
+    public boolean validateCaptchaId(String encryptedCode, Long captchaId) {
+        int saltBase64Length = (int) Math.ceil(SALT_LENGTH / 3.0) * 4;
+
+        String encodedSalt = encryptedCode.substring(0, saltBase64Length);
+        String storedHash = encryptedCode.substring(saltBase64Length);
+
+        HashResult computedResult = encryptWithSalt(captchaId, encodedSalt);
+
+        return storedHash.equals(computedResult.getCaptchaCode());
+    }
+
+    private HashResult encryptWithSaltBytes(final Long plainText, final byte[] salt) {
         try {
-            if (secretKeySpec == null) {
-                byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
-                MessageDigest sha = MessageDigest.getInstance("SHA-256");
-                keyBytes = sha.digest(keyBytes);
-                keyBytes = Arrays.copyOf(keyBytes, 16); // AES-128을 위한 16바이트 키
-                secretKeySpec = new SecretKeySpec(keyBytes, algorithm);
-            }
-            return secretKeySpec;
-        } catch (Exception e) {
-            log.error("Error during generateKey", e);
+            byte[] hash = computeHash(plainText.toString().getBytes(StandardCharsets.UTF_8), salt);
+
+            return new HashResult(
+                    Base64.getEncoder().encodeToString(salt),
+                    Base64.getEncoder().encodeToString(hash));
+        } catch (NoSuchAlgorithmException e) {
             throw EncryptionErrorException.EXCEPTION;
         }
     }
 
-    public String encrypt(Long value) {
-        try {
-            Cipher cipher = Cipher.getInstance(algorithm);
-            cipher.init(Cipher.ENCRYPT_MODE, generateKey());
-            byte[] valueBytes = ByteBuffer.allocate(Long.BYTES).putLong(value).array();
-            byte[] encrypted = cipher.doFinal(valueBytes);
-            return Base64.getEncoder().encodeToString(encrypted);
-        } catch (Exception e) {
-            log.error("Error during encryption", e);
-            throw EncryptionErrorException.EXCEPTION;
-        }
+    private byte[] generateSalt() {
+        byte[] salt = new byte[SALT_LENGTH];
+        RANDOM.nextBytes(salt);
+        return salt;
     }
 
-    public Long decrypt(final String encryptedValue) {
-        try {
-            Cipher cipher = Cipher.getInstance(algorithm);
-            cipher.init(Cipher.DECRYPT_MODE, generateKey());
-            byte[] encryptedBytes = Base64.getDecoder().decode(encryptedValue);
-            byte[] decryptedBytes = cipher.doFinal(encryptedBytes);
-            return ByteBuffer.wrap(decryptedBytes).getLong();
-        } catch (Exception e) {
-            log.error("Error during decryption", e);
-            throw DecryptionErrorException.EXCEPTION;
-        }
+    public byte[] computeHash(byte[] data, byte[] salt) throws NoSuchAlgorithmException {
+        byte[] saltedData = combineSaltAndData(salt, data);
+        return calculateHash(saltedData);
+    }
+
+    private byte[] combineSaltAndData(byte[] salt, byte[] data) {
+        byte[] combined = new byte[salt.length + data.length];
+        System.arraycopy(salt, 0, combined, 0, salt.length);
+        System.arraycopy(data, 0, combined, salt.length, data.length);
+        return combined;
+    }
+
+    private byte[] calculateHash(byte[] data) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
+        return digest.digest(data);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
@@ -2,6 +2,7 @@ package com.jnu.ticketapi.application.helper;
 
 
 import com.jnu.ticketapi.application.HashResult;
+import com.jnu.ticketapi.config.EncryptionProperties;
 import com.jnu.ticketcommon.annotation.Helper;
 import com.jnu.ticketcommon.exception.EncryptionErrorException;
 import java.nio.charset.StandardCharsets;
@@ -9,12 +10,13 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
+import lombok.RequiredArgsConstructor;
 
 @Helper
+@RequiredArgsConstructor
 public class Encryption {
+    private final EncryptionProperties encryptionProperties;
 
-    private static final int SALT_LENGTH = 16;
-    private static final String HASH_ALGORITHM = "SHA-256";
     private static final SecureRandom RANDOM = new SecureRandom();
 
     public HashResult encrypt(final Long plainText) {
@@ -28,7 +30,7 @@ public class Encryption {
     }
 
     private byte[] generateSalt() {
-        byte[] salt = new byte[SALT_LENGTH];
+        byte[] salt = new byte[encryptionProperties.getLength()];
         RANDOM.nextBytes(salt);
         return salt;
     }
@@ -58,7 +60,7 @@ public class Encryption {
     }
 
     private byte[] calculateHash(byte[] data) throws NoSuchAlgorithmException {
-        MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
+        MessageDigest digest = MessageDigest.getInstance(encryptionProperties.getAlgorithm());
         return digest.digest(data);
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
@@ -9,9 +9,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
-import org.springframework.stereotype.Component;
 
-@Component
 @Helper
 public class Encryption {
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
@@ -47,7 +47,7 @@ public class Encryption {
         }
     }
 
-    public byte[] computeHash(byte[] data, byte[] salt) throws NoSuchAlgorithmException {
+    private byte[] computeHash(byte[] data, byte[] salt) throws NoSuchAlgorithmException {
         byte[] saltedData = combineSaltAndData(salt, data);
         return calculateHash(saltedData);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/application/helper/Encryption.java
@@ -24,20 +24,15 @@ public class Encryption {
         return encryptWithSaltBytes(plainText, salt);
     }
 
-    public HashResult encryptWithSalt(final Long plainText, final String encodedSalt) {
-        byte[] salt = Base64.getDecoder().decode(encodedSalt);
-        return encryptWithSaltBytes(plainText, salt);
+    public boolean validateCaptchaId(String encryptedCode, Long captchaId, String captchaSalt) {
+        HashResult result = encryptWithSalt(captchaId, captchaSalt);
+        return encryptedCode.equals(result.getCaptchaCode());
     }
 
-    public boolean validateCaptchaId(String encryptedCode, Long captchaId) {
-        int saltBase64Length = (int) Math.ceil(SALT_LENGTH / 3.0) * 4;
-
-        String encodedSalt = encryptedCode.substring(0, saltBase64Length);
-        String storedHash = encryptedCode.substring(saltBase64Length);
-
-        HashResult computedResult = encryptWithSalt(captchaId, encodedSalt);
-
-        return storedHash.equals(computedResult.getCaptchaCode());
+    private byte[] generateSalt() {
+        byte[] salt = new byte[SALT_LENGTH];
+        RANDOM.nextBytes(salt);
+        return salt;
     }
 
     private HashResult encryptWithSaltBytes(final Long plainText, final byte[] salt) {
@@ -50,12 +45,6 @@ public class Encryption {
         } catch (NoSuchAlgorithmException e) {
             throw EncryptionErrorException.EXCEPTION;
         }
-    }
-
-    private byte[] generateSalt() {
-        byte[] salt = new byte[SALT_LENGTH];
-        RANDOM.nextBytes(salt);
-        return salt;
     }
 
     public byte[] computeHash(byte[] data, byte[] salt) throws NoSuchAlgorithmException {
@@ -73,5 +62,10 @@ public class Encryption {
     private byte[] calculateHash(byte[] data) throws NoSuchAlgorithmException {
         MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
         return digest.digest(data);
+    }
+
+    private HashResult encryptWithSalt(final Long plainText, final String encodedSalt) {
+        byte[] salt = Base64.getDecoder().decode(encodedSalt);
+        return encryptWithSaltBytes(plainText, salt);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/EncryptionProperties.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/EncryptionProperties.java
@@ -1,0 +1,16 @@
+package com.jnu.ticketapi.config;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@AllArgsConstructor
+@ConstructorBinding
+@ConfigurationProperties(prefix = "encryption")
+public class EncryptionProperties {
+    private final int length;
+    private final String algorithm;
+}

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -40,6 +40,10 @@ web:
     url-no-logging:
       - /api/swagger-ui.html
       - /api/actuator/*
+
+encryption:
+  algorithm: ${ENCRYPTION_ALGORITHM}
+  length: ${ENCRYPTION_LENGTH}
 ---
 spring:
   config:
@@ -51,9 +55,6 @@ server:
       charset: UTF-8
       enabled: true
       force: true
-encryption:
-  algorithm: ${ENCRYPTION_ALGORITHM:AES}
-  secret: ${ENCRYPTION_SECRET:jnu-parking-fighting}
 
 captcha:
   domain: dsrps7tt0ew8t.cloudfront.net

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/WithCustomMockUser.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/WithCustomMockUser.java
@@ -1,16 +1,17 @@
 package com.jnu.ticketapi;
 
-import org.springframework.security.test.context.support.WithSecurityContext;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.security.test.context.support.WithSecurityContext;
 
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithCustomUserContextFactory.class)
 public @interface WithCustomMockUser {
     long id() default 1L;
+
     String[] roles() default {"TEST"};
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/WithCustomMockUser.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/WithCustomMockUser.java
@@ -1,0 +1,16 @@
+package com.jnu.ticketapi;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomUserContextFactory.class)
+public @interface WithCustomMockUser {
+    long id() default 1L;
+    String[] roles() default {"TEST"};
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/WithCustomUserContextFactory.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/WithCustomUserContextFactory.java
@@ -1,5 +1,8 @@
 package com.jnu.ticketapi;
 
+
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -8,27 +11,23 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.Arrays;
-import java.util.List;
-
 @ActiveProfiles("test")
-public class WithCustomUserContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+public class WithCustomUserContextFactory
+        implements WithSecurityContextFactory<WithCustomMockUser> {
 
     @Override
     public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
 
-        List<SimpleGrantedAuthority> authorities = Arrays.stream(annotation.roles())
-                .map(role -> "ROLE_" + role)
-                .map(SimpleGrantedAuthority::new)
-                .toList();
+        List<SimpleGrantedAuthority> authorities =
+                Arrays.stream(annotation.roles())
+                        .map(role -> "ROLE_" + role)
+                        .map(SimpleGrantedAuthority::new)
+                        .toList();
         String username = String.valueOf(annotation.id());
 
-        Authentication authentication = new UsernamePasswordAuthenticationToken(
-                username,
-                "",
-                authorities
-        );
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(username, "", authorities);
 
         context.setAuthentication(authentication);
         return context;

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/WithCustomUserContextFactory.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/WithCustomUserContextFactory.java
@@ -1,0 +1,36 @@
+package com.jnu.ticketapi;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Arrays;
+import java.util.List;
+
+@ActiveProfiles("test")
+public class WithCustomUserContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        List<SimpleGrantedAuthority> authorities = Arrays.stream(annotation.roles())
+                .map(role -> "ROLE_" + role)
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+        String username = String.valueOf(annotation.id());
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                username,
+                "",
+                authorities
+        );
+
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
@@ -1,0 +1,49 @@
+package com.jnu.ticketapi.api.captcha.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketapi.WithCustomMockUser;
+import com.jnu.ticketapi.config.BaseIntegrationTest;
+import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
+import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
+import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+class GetCaptchaUseCaseTest extends BaseIntegrationTest {
+    @Autowired private GetCaptchaUseCase getCaptchaUseCase;
+
+    @MockBean private CaptchaAdaptor captchaAdaptor;
+
+    @Autowired private CaptchaLogAdaptor captchaLogAdaptor;
+
+    @Test
+    @WithCustomMockUser(id = 1L)
+    @DisplayName("성공 : 캡차 이미지 조회 시 로그 정보 저장")
+    void execute_integration() {
+        // given
+        Long userId = 1L;
+        Long captchaId = 1L;
+        Captcha captcha = mock(Captcha.class);
+        when(captcha.getId()).thenReturn(captchaId);
+        when(captchaAdaptor.findByRandom()).thenReturn(captcha);
+
+        // when
+        getCaptchaUseCase.execute();
+
+        // then
+        assertAll(
+                () ->
+                        assertEquals(
+                                captchaLogAdaptor.findLatestByUserId(userId).getCaptchaId(),
+                                captchaId),
+                () ->
+                        assertEquals(
+                                captchaLogAdaptor.findLatestByUserId(userId).getUserId(), userId),
+                () -> assertFalse(captchaLogAdaptor.findLatestByUserId(userId).getIsSuccess()));
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
@@ -23,7 +23,7 @@ class GetCaptchaUseCaseTest extends BaseIntegrationTest {
 
     @Test
     @WithCustomMockUser(id = 1L)
-    @DisplayName("성공 : 캡차 이미지 조회 시 로그 정보 저장")
+    @DisplayName("캡차 이미지 조회 시 로그 정보를 저장한다.")
     void execute_integration() {
         // given
         Long userId = 1L;

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCaseTest.java
@@ -14,6 +14,7 @@ import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
 import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaAnswerException;
+import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaCodeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,7 +74,7 @@ class ValidateCaptchaUseCaseTest extends BaseIntegrationTest {
 
         // when & then
         assertThrows(
-                WrongCaptchaAnswerException.class,
+                WrongCaptchaCodeException.class,
                 () -> validateCaptchaUseCase.execute(wrongCaptchaCode, ANSWER));
     }
 

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCaseTest.java
@@ -1,0 +1,102 @@
+package com.jnu.ticketapi.api.captcha.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import com.jnu.ticketapi.WithCustomMockUser;
+import com.jnu.ticketapi.application.HashResult;
+import com.jnu.ticketapi.application.helper.Encryption;
+import com.jnu.ticketapi.config.BaseIntegrationTest;
+import com.jnu.ticketapi.config.DatabaseClearExtension;
+import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
+import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
+import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
+import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaAnswerException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@ExtendWith({DatabaseClearExtension.class, MockitoExtension.class})
+class ValidateCaptchaUseCaseTest extends BaseIntegrationTest {
+
+    @Autowired private ValidateCaptchaUseCase validateCaptchaUseCase;
+
+    @Autowired private Encryption encryption;
+
+    @MockBean private CaptchaLogAdaptor captchaLogAdaptor;
+
+    @MockBean private CaptchaAdaptor captchaAdaptor;
+
+    private static final Long CAPTCHA_ID = 1L;
+    private static final Long USER_ID = 1L;
+    private static final String ANSWER = "answer";
+
+    private CaptchaLog createCaptchaLog(String salt) {
+        CaptchaLog captchaLog = mock(CaptchaLog.class);
+        when(captchaLog.getCaptchaId()).thenReturn(CAPTCHA_ID);
+        when(captchaLog.getSalt()).thenReturn(salt);
+        return captchaLog;
+    }
+
+    private Captcha createCaptcha(String answer) {
+        return spy(Captcha.builder().answer(answer).build());
+    }
+
+    @Test
+    @DisplayName("캡차 코드가 사용자에게 제공한 캡차코드와 일치하며 답변이 일치할 때 캡차 검증은 성공한다.")
+    @WithCustomMockUser(id = 1L)
+    void validateCaptcha_Success() {
+        // given
+        HashResult result = encryption.encrypt(CAPTCHA_ID);
+        Captcha captcha = createCaptcha(ANSWER);
+        CaptchaLog captchaLog = createCaptchaLog(result.getSalt());
+
+        given(captchaLogAdaptor.findLatestByUserId(USER_ID)).willReturn(captchaLog);
+        given(captchaAdaptor.findById(CAPTCHA_ID)).willReturn(captcha);
+
+        // when & then
+        assertDoesNotThrow(() -> validateCaptchaUseCase.execute(result.getCaptchaCode(), ANSWER));
+    }
+
+    @Test
+    @DisplayName("캡차 코드가 사용자에게 제공한 캡차코드와 일치하지 않을 때 캡차 검증은 실패한다.")
+    @WithCustomMockUser(id = 1L)
+    void validateCaptcha_WrongEncryptedCode_ThrowsException() {
+        // given
+        HashResult result = encryption.encrypt(CAPTCHA_ID);
+        CaptchaLog captchaLog = createCaptchaLog(result.getSalt());
+        String wrongCaptchaCode = "wrongCode";
+
+        given(captchaLogAdaptor.findLatestByUserId(USER_ID)).willReturn(captchaLog);
+
+        // when & then
+        assertThrows(
+                WrongCaptchaAnswerException.class,
+                () -> validateCaptchaUseCase.execute(wrongCaptchaCode, ANSWER));
+    }
+
+    @Test
+    @DisplayName("캡차 답변이 일치하지 않을 때 캡차 검증은 실패한다.")
+    @WithCustomMockUser(id = 1L)
+    void validateCaptcha_WrongAnswer_ThrowsException() {
+        // given
+        HashResult result = encryption.encrypt(CAPTCHA_ID);
+        CaptchaLog captchaLog = createCaptchaLog(result.getSalt());
+        String captchaAnswer = "differentAnswer";
+        Captcha captcha = createCaptcha(captchaAnswer);
+
+        given(captchaLogAdaptor.findLatestByUserId(USER_ID)).willReturn(captchaLog);
+        given(captchaAdaptor.findById(CAPTCHA_ID)).willReturn(captcha);
+
+        // when & then
+        assertThrows(
+                WrongCaptchaAnswerException.class,
+                () -> validateCaptchaUseCase.execute(result.getCaptchaCode(), ANSWER));
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCaseTest.java
@@ -9,7 +9,6 @@ import com.jnu.ticketapi.WithCustomMockUser;
 import com.jnu.ticketapi.application.HashResult;
 import com.jnu.ticketapi.application.helper.Encryption;
 import com.jnu.ticketapi.config.BaseIntegrationTest;
-import com.jnu.ticketapi.config.DatabaseClearExtension;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
@@ -17,12 +16,9 @@ import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
 import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaAnswerException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@ExtendWith({DatabaseClearExtension.class, MockitoExtension.class})
 class ValidateCaptchaUseCaseTest extends BaseIntegrationTest {
 
     @Autowired private ValidateCaptchaUseCase validateCaptchaUseCase;

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/application/helper/EncryptionTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/application/helper/EncryptionTest.java
@@ -1,0 +1,63 @@
+package com.jnu.ticketapi.application.helper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.jnu.ticketapi.application.HashResult;
+import java.util.Base64;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EncryptionTest {
+
+    private final Encryption encryption = new Encryption();
+
+    @Test
+    @DisplayName("평문을 암호화하면 salt와 해시값이 생성된다")
+    void encrypt_ShouldGenerateSaltAndHash() {
+        // given
+        Long plainText = 12345L;
+
+        // when
+        HashResult result = encryption.encrypt(plainText);
+
+        // then
+        assertThat(result.getSalt()).isNotNull();
+        assertThat(result.getCaptchaCode()).isNotNull();
+        assertDoesNotThrow(() -> Base64.getDecoder().decode(result.getSalt()));
+        assertDoesNotThrow(() -> Base64.getDecoder().decode(result.getCaptchaCode()));
+    }
+
+    @Test
+    @DisplayName("같은 평문이라도 매번 다른 salt로 인해 다른 해시값이 생성된다")
+    void encrypt_ShouldGenerateDifferentHashForSamePlaintext() {
+        // given
+        Long plainText = 12345L;
+
+        // when
+        HashResult result1 = encryption.encrypt(plainText);
+        HashResult result2 = encryption.encrypt(plainText);
+
+        // then
+        assertThat(result1.getSalt()).isNotEqualTo(result2.getSalt());
+        assertThat(result1.getCaptchaCode()).isNotEqualTo(result2.getCaptchaCode());
+    }
+
+    @Test
+    @DisplayName("CAPTCHA ID 검증이 정상적으로 동작한다")
+    void validateCaptchaId_ShouldWorkCorrectly() {
+        // given
+        Long captchaId = 12345L;
+        HashResult hashResult = encryption.encrypt(captchaId);
+        String encryptedCode = hashResult.getCaptchaCode();
+        String salt = hashResult.getSalt();
+
+        // when
+        boolean isValid = encryption.validateCaptchaId(encryptedCode, captchaId, salt);
+        boolean isInvalid = encryption.validateCaptchaId(encryptedCode, 54321L, salt);
+
+        // then
+        assertThat(isValid).isTrue();
+        assertThat(isInvalid).isFalse();
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/application/helper/EncryptionTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/application/helper/EncryptionTest.java
@@ -4,13 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.jnu.ticketapi.application.HashResult;
+import com.jnu.ticketapi.config.EncryptionProperties;
 import java.util.Base64;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class EncryptionTest {
 
-    private final Encryption encryption = new Encryption();
+    private final Encryption encryption = new Encryption(new EncryptionProperties(16, "SHA-256"));
 
     @Test
     @DisplayName("평문을 암호화하면 salt와 해시값이 생성된다")

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/registration/FinalSaveTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/registration/FinalSaveTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketapi.RestDocsConfig;
 import com.jnu.ticketapi.api.registration.model.request.FinalSaveRequest;
+import com.jnu.ticketapi.application.HashResult;
 import com.jnu.ticketapi.application.helper.Encryption;
 import com.jnu.ticketapi.security.JwtGenerator;
 import com.jnu.ticketcommon.exception.GlobalErrorCode;
@@ -51,14 +52,14 @@ public class FinalSaveTest extends RestDocsConfig {
         void success() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
 
             String accessToken = jwtGenerator.generateAccessToken(email, "ADMIN");
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation("AI융합대")
@@ -92,14 +93,14 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "45";
 
             String accessToken = jwtGenerator.generateAccessToken(email, "ADMIN");
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation("AI융합대")
@@ -135,14 +136,14 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail2() throws Exception {
             // given
             String email = "imFaker@T1.com";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
 
             String accessToken = jwtGenerator.generateAccessToken(email, "ADMIN");
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation("AI융합대")
@@ -179,14 +180,14 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail3() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
 
             String accessToken = jwtGenerator.generateAccessToken(email, "ADMIN");
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation("AI융합대")
@@ -267,7 +268,7 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail5() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
             String target = "이름을 ";
 
@@ -275,7 +276,7 @@ public class FinalSaveTest extends RestDocsConfig {
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name(" ")
                             .affiliation("AI융합대")
@@ -312,7 +313,7 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail6() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
             String target = "소속대학을 ";
 
@@ -320,7 +321,7 @@ public class FinalSaveTest extends RestDocsConfig {
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation(" ")
@@ -357,7 +358,7 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail7() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
             String target = "학번을 ";
 
@@ -365,7 +366,7 @@ public class FinalSaveTest extends RestDocsConfig {
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation("AI융합대")
@@ -402,7 +403,7 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail8() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
             String target = "차량번호를 ";
 
@@ -410,7 +411,7 @@ public class FinalSaveTest extends RestDocsConfig {
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation("AI융합대")
@@ -447,7 +448,7 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail9() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
             String target = "구간 ID는 ";
 
@@ -455,7 +456,7 @@ public class FinalSaveTest extends RestDocsConfig {
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation("AI융합대")
@@ -492,14 +493,14 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail10() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
 
             String accessToken = jwtGenerator.generateAccessToken(email, "ADMIN");
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation("AI융합대")
@@ -536,7 +537,7 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail11() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
+            HashResult result = encryption.encrypt(1L);
             String captchaAnswer = "1234";
             String target = "경차 여부를 ";
 
@@ -544,7 +545,7 @@ public class FinalSaveTest extends RestDocsConfig {
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(captchaAnswer)
                             .name("박영규")
                             .affiliation("AI융합대")
@@ -581,7 +582,6 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail13() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
             String captchaAnswer = "1234";
             String target = "캡챠 코드를 ";
 
@@ -626,15 +626,14 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail14() throws Exception {
             // given
             String email = "admin@jnu.ac.kr";
-            String captchaCode = encryption.encrypt(1L);
-            String captchaAnswer = "1234";
+            HashResult result = encryption.encrypt(1L);
             String target = "캡챠 답변을 ";
 
             String accessToken = jwtGenerator.generateAccessToken(email, "ADMIN");
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode(captchaCode)
+                            .captchaCode(result.getCaptchaCode())
                             .captchaAnswer(null)
                             .name("박영규")
                             .affiliation("AI융합대")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaLogAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaLogAdaptor.java
@@ -19,6 +19,6 @@ public class CaptchaLogAdaptor implements CaptchaLogPort {
 
     @Override
     public CaptchaLog findLatestByUserId(Long userId) {
-        return captchaLogRepository.findLatestByUserId(userId);
+        return captchaLogRepository.findTopByUserIdAndIsSuccessFalseOrderByTimestampDesc(userId);
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaLogAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaLogAdaptor.java
@@ -1,0 +1,24 @@
+package com.jnu.ticketdomain.domains.captcha.adaptor;
+
+
+import com.jnu.ticketcommon.annotation.Adaptor;
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLogPort;
+import com.jnu.ticketdomain.domains.captcha.repository.CaptchaLogRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Adaptor
+public class CaptchaLogAdaptor implements CaptchaLogPort {
+    private final CaptchaLogRepository captchaLogRepository;
+
+    @Override
+    public CaptchaLog save(CaptchaLog entity) {
+        return captchaLogRepository.save(entity);
+    }
+
+    @Override
+    public CaptchaLog findLatestByUserId(Long userId) {
+        return captchaLogRepository.findLatestByUserId(userId);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaLog.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaLog.java
@@ -1,0 +1,38 @@
+package com.jnu.ticketdomain.domains.captcha.domain;
+
+
+import javax.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Table(name = "captcha_log_tb")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class CaptchaLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "captcha_id", nullable = false)
+    private Long captchaId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "salt", nullable = false)
+    private String salt;
+
+    @Column(name = "is_success", nullable = false)
+    @Builder.Default
+    private Boolean isSuccess = Boolean.FALSE;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private Long timestamp;
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaLog.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/domain/CaptchaLog.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketdomain.domains.captcha.domain;
 
 
+import java.time.LocalDateTime;
 import javax.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -34,5 +35,5 @@ public class CaptchaLog {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false)
-    private Long timestamp;
+    private LocalDateTime timestamp;
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/CaptchaErrorCode.java
@@ -16,7 +16,8 @@ import lombok.Getter;
 public enum CaptchaErrorCode implements BaseErrorCode {
     NOT_FOUND_CAPTCHA(NOT_FOUND, "CAPTCHA_404_1", "존재하지 않는 캡챠입니다."),
     NOT_FOUND_CAPTCHA_PENDING(NOT_FOUND, "CAPTCHA_404_2", "존재하지 않는 캡챠 인증입니다."),
-    WRONG_CAPTCHA_ANSWER(BAD_REQUEST, "CAPTCHA_400_1", "틀린 캡챠 답변입니다.");
+    WRONG_CAPTCHA_ANSWER(BAD_REQUEST, "CAPTCHA_400_1", "틀린 캡챠 답변입니다."),
+    WRONG_CAPTCHA_CODE(BAD_REQUEST, "CAPTCHA_400_2", "올바르지 않은 캡챠 요청입니다");
 
     private final Integer status;
     private final String code;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/WrongCaptchaCodeException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/exception/WrongCaptchaCodeException.java
@@ -1,0 +1,12 @@
+package com.jnu.ticketdomain.domains.captcha.exception;
+
+
+import com.jnu.ticketcommon.exception.TicketCodeException;
+
+public class WrongCaptchaCodeException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new WrongCaptchaCodeException();
+
+    private WrongCaptchaCodeException() {
+        super(CaptchaErrorCode.WRONG_CAPTCHA_CODE);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaLogPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/out/CaptchaLogPort.java
@@ -1,0 +1,12 @@
+package com.jnu.ticketdomain.domains.captcha.out;
+
+
+import com.jnu.ticketcommon.annotation.Port;
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
+
+@Port
+public interface CaptchaLogPort {
+    CaptchaLog save(CaptchaLog entity);
+
+    CaptchaLog findLatestByUserId(Long userId);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaLogRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaLogRepository.java
@@ -3,10 +3,7 @@ package com.jnu.ticketdomain.domains.captcha.repository;
 
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface CaptchaLogRepository extends JpaRepository<CaptchaLog, Long> {
-    @Query("SELECT c FROM CaptchaLog c WHERE c.userId = :userId ORDER BY c.timestamp DESC")
-    CaptchaLog findLatestByUserId(@Param("userId") Long userId);
+    CaptchaLog findTopByUserIdAndIsSuccessFalseOrderByTimestampDesc(Long userId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaLogRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaLogRepository.java
@@ -1,0 +1,12 @@
+package com.jnu.ticketdomain.domains.captcha.repository;
+
+
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CaptchaLogRepository extends JpaRepository<CaptchaLog, Long> {
+    @Query("SELECT c FROM CaptchaLog c WHERE c.userId = :userId ORDER BY c.timestamp DESC")
+    CaptchaLog findLatestByUserId(@Param("userId") Long userId);
+}

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/captcha/CaptchaLogRepositoryTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/captcha/CaptchaLogRepositoryTest.java
@@ -1,0 +1,131 @@
+package com.jnu.ticketdomain.domains.captcha;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
+import com.jnu.ticketdomain.domains.captcha.repository.CaptchaLogRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class CaptchaLogRepositoryTest {
+
+    @Autowired private CaptchaLogRepository captchaLogRepository;
+
+    @BeforeEach
+    void setUp() {
+        captchaLogRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("유저 ID로 최신 캡차 로그를 성공적으로 조회한다")
+    void findLatestByUserId_Success() {
+        // given
+        Long userId = 1L;
+        Long otherUserId = 2L;
+
+        CaptchaLog oldLog =
+                CaptchaLog.builder()
+                        .userId(userId)
+                        .captchaId(1L)
+                        .salt("salt1")
+                        .isSuccess(false)
+                        .build();
+
+        CaptchaLog middleLog =
+                CaptchaLog.builder()
+                        .userId(userId)
+                        .captchaId(2L)
+                        .salt("salt2")
+                        .isSuccess(false)
+                        .build();
+
+        CaptchaLog latestLog =
+                CaptchaLog.builder()
+                        .userId(userId)
+                        .captchaId(3L)
+                        .salt("salt3")
+                        .isSuccess(false)
+                        .build();
+
+        CaptchaLog otherUserLog =
+                CaptchaLog.builder()
+                        .userId(otherUserId)
+                        .captchaId(4L)
+                        .salt("salt4")
+                        .isSuccess(false)
+                        .build();
+
+        CaptchaLog successLog =
+                CaptchaLog.builder()
+                        .userId(userId)
+                        .captchaId(3L)
+                        .salt("salt3")
+                        .isSuccess(true)
+                        .build();
+
+        captchaLogRepository.saveAll(
+                List.of(oldLog, middleLog, latestLog, otherUserLog, successLog));
+
+        // when
+        CaptchaLog result =
+                captchaLogRepository.findTopByUserIdAndIsSuccessFalseOrderByTimestampDesc(userId);
+
+        // then
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getCaptchaId()).isEqualTo(latestLog.getCaptchaId());
+        assertThat(result.getSalt()).isEqualTo(latestLog.getSalt());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저의 캡차 로그 조회시 null을 반환한다")
+    void findLatestByUserId_UserNotFound_ReturnsNull() {
+        // given
+        Long nonExistentUserId = 999L;
+
+        // when
+        CaptchaLog result =
+                captchaLogRepository.findTopByUserIdAndIsSuccessFalseOrderByTimestampDesc(
+                        nonExistentUserId);
+
+        // then
+        assertNull(result);
+    }
+
+    @Test
+    @DisplayName("유저의 모든 캡차 로그가 성공 상태인 경우 null을 반환한다")
+    void findLatestByUserId_AllLogsSuccess_ReturnsNull() {
+        // given
+        Long userId = 1L;
+
+        CaptchaLog successLog1 =
+                CaptchaLog.builder()
+                        .userId(userId)
+                        .captchaId(1L)
+                        .salt("salt1")
+                        .isSuccess(true)
+                        .build();
+
+        CaptchaLog successLog2 =
+                CaptchaLog.builder()
+                        .userId(userId)
+                        .captchaId(2L)
+                        .salt("salt2")
+                        .isSuccess(true)
+                        .build();
+
+        captchaLogRepository.saveAll(List.of(successLog1, successLog2));
+
+        // when
+        CaptchaLog result =
+                captchaLogRepository.findTopByUserIdAndIsSuccessFalseOrderByTimestampDesc(userId);
+
+        // then
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
### 암호화 과정
<img width="216" alt="스크린샷 2024-10-26 15 50 24" src="https://github.com/user-attachments/assets/13d39fcf-c0f4-438d-8e64-777f7ffb2fca">

A. 솔트 생성
  - SecureRandom을 사용하여 16바이트 길이의 솔트 값 생성
  - 매 요청마다 랜덤으로 값 생성

B. 데이터 준비
  1) 캡차 ID(Long)를 문자열로 변환 후 UTF-8 바이트 배열로 변환
     cf) 해시 함수 사용을 위해 바이트 배열로 변환 과정이 필요함 
  
  2) 솔트(16바이트)와 데이터 바이트를 하나의 배열로 결합
     cf) combineSaltAndData 함수에서 확인 가능
     ```java
     private byte[] combineSaltAndData(byte[] salt, byte[] data) {
         // 전체 바이트 배열 생성 (솔트 길이 + 데이터 길이)
         byte[] combined = new byte[salt.length + data.length];
         
         // 1. 먼저 솔트를 복사 (인덱스 0부터 16바이트)
         System.arraycopy(salt, 0, combined, 0, salt.length);
         
         // 2. 그 다음에 데이터를 복사 (인덱스 16부터 N바이트)
         System.arraycopy(data, 0, combined, salt.length, data.length);
         
         return combined;
     }
     ```
  
C. 해시값 생성
  - 결합된 바이트 배열에 대해 SHA-256 해시 수행

D. 결과 반환
  - salt와 해시값(captchaCode)를 인코딩하여 해당 값을 HashResult 객체에 담음

### 캡차 검증 과정
<img width="328" alt="스크린샷 2024-10-26 15 49 48" src="https://github.com/user-attachments/assets/98bd445f-af74-49c6-9077-706b128b5909">

1. SHA-256 알고리즘 특징
  - SHA-256은 단방향 해시 알고리즘
  - 해시값 → 원본 데이터로 변경은 불가능
  - 단, 동일한 입력값에 대해 항상 동일한 해시값 생성
  
2. 이러한 특징으로 인한 검증 프로세스
   1) DB에서 해당 유저의 최근 캡차 로그 조회
     - captchaLog.salt
     - captchaLog.captchaId
     
   2) DB에서 가져온 값으로 captchaCode 재생성
     - salt + captchaId로 새로운 해시값 생성
     ※ 단방향이므로 유저가 전달한 captchaCode에서 원본값 추출 불가
     
   3) 검증
     - 재생성된 해시값과 사용자가 제공한 captchaCode 비교
     - 일치하면 검증 성공, 불일치하면 검증 실패

### 테스트
* 캡차 검증 테스트
<img width="647" alt="스크린샷 2024-10-26 14 55 09" src="https://github.com/user-attachments/assets/4a5e3337-19b6-4d39-ba9b-6d8283926c92">

* 캡차 조회 테스트
<img width="650" alt="스크린샷 2024-10-26 14 56 29" src="https://github.com/user-attachments/assets/805ec2e4-fc33-412b-a346-dfa5e411cbc6">

* 암호화(해시) 테스트
<img width="457" alt="스크린샷 2024-10-26 15 00 29" src="https://github.com/user-attachments/assets/ed7ace88-e977-4750-9fb7-5099270fd870">

## 리뷰어에게...

## 관련 이슈

closes #401 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정