### PR TITLE
[BE-193] bug: 합격/예비/불합격 기준 수정 

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,5 +1,7 @@
 package com.jnu.ticketapi.api.event.handler;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
@@ -21,8 +23,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @Component
 @RequiredArgsConstructor

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
@@ -8,6 +8,7 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
@@ -47,7 +48,6 @@ public record FinalSaveRequest(
 
     public Registration toEntity(
             FinalSaveRequest requestDto, Sector sector, String email, User user) {
-        Instant now = Instant.now();
         return Registration.builder()
                 .email(email)
                 .name(requestDto.name())
@@ -59,9 +59,7 @@ public record FinalSaveRequest(
                 .sector(sector)
                 .isSaved(true)
                 .user(user)
-                .savedAt(
-                        now.getEpochSecond() * 1_000_000_000L
-                                + now.getNano()) // 현재 시간을 나노초 단위 정수로 변환
+                .savedAt(System.nanoTime())
                 .build();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
@@ -7,11 +7,15 @@ import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.persistence.criteria.CriteriaBuilder;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
 import lombok.Builder;
+
+import java.time.Instant;
 
 @Builder
 public record FinalSaveRequest(
@@ -46,6 +50,7 @@ public record FinalSaveRequest(
 
     public Registration toEntity(
             FinalSaveRequest requestDto, Sector sector, String email, User user) {
+        Instant now = Instant.now();
         return Registration.builder()
                 .email(email)
                 .name(requestDto.name())
@@ -57,7 +62,7 @@ public record FinalSaveRequest(
                 .sector(sector)
                 .isSaved(true)
                 .user(user)
-                .savedAt(System.currentTimeMillis() * 1_000_000)
+                .savedAt(now.getEpochSecond() * 1_000_000_000L + now.getNano()) // 현재 시간을 나노초 단위 정수로 변환
                 .build();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
@@ -57,6 +57,7 @@ public record FinalSaveRequest(
                 .sector(sector)
                 .isSaved(true)
                 .user(user)
+                .savedAt(System.currentTimeMillis() * 1_000_000)
                 .build();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
@@ -7,8 +7,6 @@ import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.Instant;
-import java.time.LocalDateTime;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
@@ -7,15 +7,12 @@ import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.persistence.criteria.CriteriaBuilder;
+import java.time.Instant;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
 import lombok.Builder;
-
-import java.time.Instant;
 
 @Builder
 public record FinalSaveRequest(
@@ -62,7 +59,9 @@ public record FinalSaveRequest(
                 .sector(sector)
                 .isSaved(true)
                 .user(user)
-                .savedAt(now.getEpochSecond() * 1_000_000_000L + now.getNano()) // 현재 시간을 나노초 단위 정수로 변환
+                .savedAt(
+                        now.getEpochSecond() * 1_000_000_000L
+                                + now.getNano()) // 현재 시간을 나노초 단위 정수로 변환
                 .build();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -136,17 +136,29 @@ public class RegistrationUseCase {
         return findResultByEmail(email, false, eventId)
                 .fold(
                         tempRegistration ->
-                                reFinalRegister(tempRegistration, registration, sector, user, email, eventId),
+                                reFinalRegister(
+                                        tempRegistration,
+                                        registration,
+                                        sector,
+                                        user,
+                                        email,
+                                        eventId),
                         emptyCase ->
                                 saveRegistration(
                                         registration, sector, currentUserId, email, eventId));
     }
 
     private FinalSaveResponse reFinalRegister(
-            Registration tempRegistration, Registration registration, Sector sector, User user, String email, Long eventId) {
+            Registration tempRegistration,
+            Registration registration,
+            Sector sector,
+            User user,
+            String email,
+            Long eventId) {
         sector.checkEventLeft();
         registration.setId(tempRegistration.getId()); // update 치기 위해 Id 값을 채워줌
-        registration.setCreatedAt(tempRegistration.getCreatedAt()); // create_at이 null이 들어가지 않게 하기 위해 값을 채워줌
+        registration.setCreatedAt(
+                tempRegistration.getCreatedAt()); // create_at이 null이 들어가지 않게 하기 위해 값을 채워줌
         reFinalRegisterProcess(registration, user, email, sector.getId(), eventId);
         return FinalSaveResponse.from(registration);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -137,7 +137,6 @@ public class RegistrationUseCase {
                 .fold(
                         tempRegistration ->
                                 reFinalRegister(
-                                        tempRegistration,
                                         registration,
                                         sector,
                                         user,
@@ -149,7 +148,6 @@ public class RegistrationUseCase {
     }
 
     private FinalSaveResponse reFinalRegister(
-            Registration tempRegistration,
             Registration registration,
             Sector sector,
             User user,
@@ -158,18 +156,16 @@ public class RegistrationUseCase {
         // 예비 번호가 있거나 합격인 경우
         sector.checkEventLeft();
         reFinalRegisterProcess(
-                tempRegistration, registration, user, email, sector.getId(), eventId);
-        return FinalSaveResponse.from(tempRegistration);
+                registration, user, email, sector.getId(), eventId);
+        return FinalSaveResponse.from(registration);
     }
 
     private void reFinalRegisterProcess(
-            Registration tempRegistration,
             Registration registration,
             User user,
             String email,
             Long sectorId,
             Long eventId) {
-        tempRegistration.update(registration);
         eventWithDrawUseCase.issueEvent(registration, user.getId(), sectorId, eventId);
         if (ableRedis) {
             redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -136,36 +136,22 @@ public class RegistrationUseCase {
         return findResultByEmail(email, false, eventId)
                 .fold(
                         tempRegistration ->
-                                reFinalRegister(
-                                        registration,
-                                        sector,
-                                        user,
-                                        email,
-                                        eventId),
+                                reFinalRegister(registration, sector, user, email, eventId),
                         emptyCase ->
                                 saveRegistration(
                                         registration, sector, currentUserId, email, eventId));
     }
 
     private FinalSaveResponse reFinalRegister(
-            Registration registration,
-            Sector sector,
-            User user,
-            String email,
-            Long eventId) {
+            Registration registration, Sector sector, User user, String email, Long eventId) {
         // 예비 번호가 있거나 합격인 경우
         sector.checkEventLeft();
-        reFinalRegisterProcess(
-                registration, user, email, sector.getId(), eventId);
+        reFinalRegisterProcess(registration, user, email, sector.getId(), eventId);
         return FinalSaveResponse.from(registration);
     }
 
     private void reFinalRegisterProcess(
-            Registration registration,
-            User user,
-            String email,
-            Long sectorId,
-            Long eventId) {
+            Registration registration, User user, String email, Long sectorId, Long eventId) {
         eventWithDrawUseCase.issueEvent(registration, user.getId(), sectorId, eventId);
         if (ableRedis) {
             redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -136,16 +136,17 @@ public class RegistrationUseCase {
         return findResultByEmail(email, false, eventId)
                 .fold(
                         tempRegistration ->
-                                reFinalRegister(registration, sector, user, email, eventId),
+                                reFinalRegister(tempRegistration, registration, sector, user, email, eventId),
                         emptyCase ->
                                 saveRegistration(
                                         registration, sector, currentUserId, email, eventId));
     }
 
     private FinalSaveResponse reFinalRegister(
-            Registration registration, Sector sector, User user, String email, Long eventId) {
-        // 예비 번호가 있거나 합격인 경우
+            Registration tempRegistration, Registration registration, Sector sector, User user, String email, Long eventId) {
         sector.checkEventLeft();
+        registration.setId(tempRegistration.getId()); // update 치기 위해 Id 값을 채워줌
+        registration.setCreatedAt(tempRegistration.getCreatedAt()); // create_at이 null이 들어가지 않게 하기 위해 값을 채워줌
         reFinalRegisterProcess(registration, user, email, sector.getId(), eventId);
         return FinalSaveResponse.from(registration);
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/handler/UserReflectStatusEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/handler/UserReflectStatusEventHandler.java
@@ -46,7 +46,7 @@ public class UserReflectStatusEventHandler {
 
     private void reflectUserState(UserReflectStatusEvent event, User user) {
         Integer position =
-                registrationAdaptor.findPositionById(
+                registrationAdaptor.findPositionBySavedAt(
                         event.getRegistration().getId(), event.getSector().getId());
         Integer sectorCapacity = event.getSector().getInitSectorCapacity();
         Integer issueAmount = event.getSector().getIssueAmount();

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/registration/GetRegistrationsTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/registration/GetRegistrationsTest.java
@@ -40,7 +40,7 @@ public class GetRegistrationsTest extends RestDocsConfig {
         void success() throws Exception {
             // given
             Long eventId = 1L;
-            String accessToken = jwtGenerator.generateAccessToken("council@jnu.ac.kr", "COUNCIxL");
+            String accessToken = jwtGenerator.generateAccessToken("council@jnu.ac.kr", "COUNCIL");
             // when
             ResultActions resultActions =
                     mvc.perform(

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -34,8 +34,6 @@ public class ProcessQueueDataJob implements Job {
                 for (TypedTuple<Object> messageWithScore : messagesWithScores) {
                     Double score = messageWithScore.getScore();
                     ChatMessage message = (ChatMessage) messageWithScore.getValue();
-                    waitingQueueService.reRegisterQueue(
-                            REDIS_EVENT_ISSUE_STORE, message, ChatMessageStatus.WAITING, score);
                     Events.raise(EventIssuedEvent.from(message, score));
                 }
             }

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -5,7 +5,6 @@ import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
-import com.jnu.ticketinfrastructure.model.ChatMessageStatus;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -103,7 +103,7 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
 
     @Override
     public Integer findPositionBySavedAt(Long id, Long sectorId) {
-        return registrationRepository.findPositionBySavedAt(id, sectorId) + 1;
+        return registrationRepository.findPositionBySavedAt(id, sectorId);
     }
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -102,8 +102,8 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     }
 
     @Override
-    public Integer findPositionById(Long id, Long sectorId) {
-        return registrationRepository.findPositionById(id, sectorId) + 1;
+    public Integer findPositionBySavedAt(Long id, Long sectorId) {
+        return registrationRepository.findPositionBySavedAt(id, sectorId) + 1;
     }
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -74,6 +74,10 @@ public class Registration {
     @ColumnDefault("false")
     private boolean isDeleted;
 
+    // 최종 저장 시간(nano sec)
+    @Column(name = "saved_at")
+    private Long savedAt;
+
     @JsonBackReference(value = "user-registration")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -85,7 +89,7 @@ public class Registration {
     private Sector sector;
 
     @Builder
-    public Registration(
+    private Registration(
             String email,
             String name,
             String studentNum,
@@ -95,6 +99,7 @@ public class Registration {
             String phoneNum,
             LocalDateTime createdAt,
             boolean isSaved,
+            Long savedAt,
             User user,
             Sector sector) {
         this.email = email;
@@ -106,6 +111,7 @@ public class Registration {
         this.phoneNum = phoneNum;
         this.createdAt = createdAt;
         this.isSaved = isSaved;
+        this.savedAt = savedAt;
         this.user = user;
         this.sector = sector;
     }
@@ -122,6 +128,7 @@ public class Registration {
             @JsonProperty("createdAt") LocalDateTime createdAt,
             @JsonProperty("isSaved") boolean isSaved,
             @JsonProperty("isDeleted") boolean isDeleted,
+            @JsonProperty("savedAt") Long savedAt,
             @JsonProperty("user") User user,
             @JsonProperty("sector") Sector sector) {
         this.email = email;
@@ -134,14 +141,16 @@ public class Registration {
         this.createdAt = createdAt;
         this.isSaved = isSaved;
         this.isDeleted = isDeleted;
+        this.savedAt = savedAt;
         this.user = user;
         this.sector = sector;
     }
 
     public Registration() {}
 
-    public void updateIsSaved(boolean isSaved) {
-        this.isSaved = isSaved;
+    public void finalSave() {
+        this.isSaved = true;
+        this.savedAt = System.currentTimeMillis() * 1_000_000; // 현재 시간을 나노초로 변환
     }
 
     public void updateIsDeleted(boolean isDeleted) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
-
 import java.time.Instant;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
@@ -155,7 +154,8 @@ public class Registration {
     public void finalSave() {
         this.isSaved = true;
         Instant now = Instant.now();
-        this.savedAt = now.getEpochSecond() * 1_000_000_000L + now.getNano(); // 현재 시간을 나노초 단위 정수로 변환
+        this.savedAt =
+                now.getEpochSecond() * 1_000_000_000L + now.getNano(); // 현재 시간을 나노초 단위 정수로 변환
     }
 
     public void updateIsDeleted(boolean isDeleted) {
@@ -181,7 +181,11 @@ public class Registration {
         this.user = user;
     }
 
-    public void setId(Long id) {this.id = id;}
+    public void setId(Long id) {
+        this.id = id;
+    }
 
-    public void setCreatedAt(LocalDateTime createdAt) {this.createdAt = createdAt;}
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -153,9 +153,7 @@ public class Registration {
 
     public void finalSave() {
         this.isSaved = true;
-        Instant now = Instant.now();
-        this.savedAt =
-                now.getEpochSecond() * 1_000_000_000L + now.getNano(); // 현재 시간을 나노초 단위 정수로 변환
+        this.savedAt = System.nanoTime();
     }
 
     public void updateIsDeleted(boolean isDeleted) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
+
+import java.time.Instant;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -130,7 +132,8 @@ public class Registration {
             @JsonProperty("isDeleted") boolean isDeleted,
             @JsonProperty("savedAt") Long savedAt,
             @JsonProperty("user") User user,
-            @JsonProperty("sector") Sector sector) {
+            @JsonProperty("sector") Sector sector,
+            @JsonProperty("id") Long id) {
         this.email = email;
         this.name = name;
         this.studentNum = studentNum;
@@ -144,13 +147,15 @@ public class Registration {
         this.savedAt = savedAt;
         this.user = user;
         this.sector = sector;
+        this.id = id;
     }
 
     public Registration() {}
 
     public void finalSave() {
         this.isSaved = true;
-        this.savedAt = System.currentTimeMillis() * 1_000_000; // 현재 시간을 나노초로 변환
+        Instant now = Instant.now();
+        this.savedAt = now.getEpochSecond() * 1_000_000_000L + now.getNano(); // 현재 시간을 나노초 단위 정수로 변환
     }
 
     public void updateIsDeleted(boolean isDeleted) {
@@ -175,4 +180,8 @@ public class Registration {
     public void setUser(User user) {
         this.user = user;
     }
+
+    public void setId(Long id) {this.id = id;}
+
+    public void setCreatedAt(LocalDateTime createdAt) {this.createdAt = createdAt;}
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
@@ -24,7 +24,7 @@ public interface RegistrationLoadPort {
 
     List<Registration> findByEmailAndIsSaved(String email, boolean flag);
 
-    Integer findPositionById(Long id, Long sectorId);
+    Integer findPositionBySavedAt(Long id, Long sectorId);
 
     Boolean existsByIdAndIsSavedTrue(Long id);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -64,9 +64,14 @@ public interface RegistrationRepository
 
     List<Registration> findByUser(User user);
 
-    @Query(
-            "select count (r) from Registration r where r.id < :id and r.isSaved = true and r.sector.id = :sectorId")
-    Integer findPositionById(@Param("id") Long id, @Param("sectorId") Long sectorId);
+    @Query(value = "SELECT row_num FROM ( " +
+            "  SELECT r.id, ROW_NUMBER() OVER (ORDER BY r.saved_at) AS row_num " +
+            "  FROM registration_tb r " +
+            "  WHERE r.is_saved = true AND r.sector_id = :sectorId " +
+            ") AS numbered_registrations " +
+            "WHERE numbered_registrations.id = :id",
+            nativeQuery = true)
+    Integer findPositionBySavedAt(@Param("id") Long id, @Param("sectorId") Long sectorId);
 
     Boolean existsByIdAndIsSavedTrue(Long id);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -64,12 +64,14 @@ public interface RegistrationRepository
 
     List<Registration> findByUser(User user);
 
-    @Query(value = "SELECT row_num FROM ( " +
-            "  SELECT r.id, ROW_NUMBER() OVER (ORDER BY r.saved_at) AS row_num " +
-            "  FROM registration_tb r " +
-            "  WHERE r.is_saved = true AND r.sector_id = :sectorId " +
-            ") AS numbered_registrations " +
-            "WHERE numbered_registrations.id = :id",
+    @Query(
+            value =
+                    "SELECT row_num FROM ( "
+                            + "  SELECT r.id, ROW_NUMBER() OVER (ORDER BY r.saved_at) AS row_num "
+                            + "  FROM registration_tb r "
+                            + "  WHERE r.is_saved = true AND r.sector_id = :sectorId "
+                            + ") AS numbered_registrations "
+                            + "WHERE numbered_registrations.id = :id",
             nativeQuery = true)
     Integer findPositionBySavedAt(@Param("id") Long id, @Param("sectorId") Long sectorId);
 

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
@@ -15,6 +15,4 @@ public class ChatMessage {
     private Long userId;
     private Long sectorId;
     private Long eventId;
-    // Waiting인지 아닌지만 확인하는 status -> WAITING, NOT_WAITING
-    private String status;
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessageStatus.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessageStatus.java
@@ -1,6 +1,0 @@
-package com.jnu.ticketinfrastructure.model;
-
-public enum ChatMessageStatus {
-    WAITING,
-    NOT_WAITING
-}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,7 +3,6 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
-
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,7 +3,7 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
-import com.jnu.ticketinfrastructure.model.ChatMessageStatus;
+
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
@@ -102,18 +102,6 @@ public class RedisRepository {
         if (keys != null && !keys.isEmpty()) {
             redisTemplate.delete(keys);
         }
-    }
-
-    public void removeAndAdd(
-            String key, ChatMessage message, ChatMessageStatus newStatus, Double score) {
-        // Remove the message from the set
-        redisTemplate.opsForZSet().remove(key, message);
-
-        // Update the status of the message
-        message.setStatus(newStatus.name());
-
-        // Add the message back to the set with the new status and score
-        redisTemplate.opsForZSet().addIfAbsent(key, message, score);
     }
 
     public Double getScore(String key, Object value) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -59,6 +59,7 @@ public class WaitingQueueService {
         registrationJson.put("isDeleted", registration.isDeleted());
         registrationJson.put("isLight", registration.isLight());
         registrationJson.put("isSaved", registration.isSaved());
+        registrationJson.put("savedAt", registration.getSavedAt());
         return registrationJson.toString();
     }
 

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -11,7 +11,6 @@ import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
-
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,12 +34,7 @@ public class WaitingQueueService {
             throws JsonProcessingException {
         Double score = (double) System.currentTimeMillis();
         String registrationString = convertRegistrationJSON(registration);
-        ChatMessage message =
-                new ChatMessage(
-                        registrationString,
-                        userId,
-                        sectorId,
-                        eventId);
+        ChatMessage message = new ChatMessage(registrationString, userId, sectorId, eventId);
         checkDuplicateData(key, message);
         redisRepository.zAddIfAbsent(key, message, score);
     }
@@ -83,14 +77,12 @@ public class WaitingQueueService {
         return redisRepository.zRank(key, value);
     }
 
-
     public void checkDuplicateData(String key, Object value) {
         Long rank = redisRepository.zRank(key, value);
         if (rank != null) {
             throw AlreadyExistRegistrationException.EXCEPTION;
         }
     }
-
 
     public Double getScore(String key, Object value) {
         return redisRepository.getScore(key, value);

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -60,7 +60,8 @@ public class WaitingQueueService {
         registrationJson.put("isLight", registration.isLight());
         registrationJson.put("isSaved", registration.isSaved());
         registrationJson.put("savedAt", registration.getSavedAt());
-        registrationJson.put("registrationId", registration.getId());
+        registrationJson.put("id", registration.getId());
+        registrationJson.put("createdAt", registration.getCreatedAt());
         return registrationJson.toString();
     }
 

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -60,6 +60,7 @@ public class WaitingQueueService {
         registrationJson.put("isLight", registration.isLight());
         registrationJson.put("isSaved", registration.isSaved());
         registrationJson.put("savedAt", registration.getSavedAt());
+        registrationJson.put("registrationId", registration.getId());
         return registrationJson.toString();
     }
 

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -7,13 +7,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
-import com.jnu.ticketinfrastructure.model.ChatMessageStatus;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import java.util.LinkedList;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
-import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,8 +40,7 @@ public class WaitingQueueService {
                         registrationString,
                         userId,
                         sectorId,
-                        eventId,
-                        ChatMessageStatus.NOT_WAITING.name());
+                        eventId);
         checkDuplicateData(key, message);
         redisRepository.zAddIfAbsent(key, message, score);
     }
@@ -86,23 +83,6 @@ public class WaitingQueueService {
         return redisRepository.zRank(key, value);
     }
 
-    public ChatMessage findFirstByStatus(String key, ChatMessageStatus status) {
-        Set<Object> resultSet = redisRepository.zRange(key, 0L, 0L, Object.class);
-        Set<ChatMessage> chatMessages =
-                resultSet.stream()
-                        .map(o -> (ChatMessage) o)
-                        .filter(
-                                chatMessage ->
-                                        Objects.equals(chatMessage.getStatus(), status.name()))
-                        .collect(Collectors.toSet());
-        if (chatMessages != null && !chatMessages.isEmpty()) {
-            // Return the first element in the set
-            return chatMessages.iterator().next();
-        } else {
-            // If the set is empty, return null or handle accordingly
-            return null;
-        }
-    }
 
     public void checkDuplicateData(String key, Object value) {
         Long rank = redisRepository.zRank(key, value);
@@ -111,10 +91,6 @@ public class WaitingQueueService {
         }
     }
 
-    public void reRegisterQueue(
-            String key, ChatMessage message, ChatMessageStatus newStatus, Double score) {
-        redisRepository.removeAndAdd(key, message, newStatus, score);
-    }
 
     public Double getScore(String key, Object value) {
         return redisRepository.getScore(key, value);


### PR DESCRIPTION
## 주요 변경사항
1. reRegisterQueue 제거
 - ChatMessage에서 ChatMessageStatus를 제거 했기 때문에 reRegisterQueue를 제거
 - ProcessQueueDataJob에서 publish 한 ChatMessage가 Waiting이면 EventIssuedEventHandler가 처리중인 것으로 보고
   EventIssuedEventHandler는 Not_Watiting인 것 만 처리 하도록 ChatMessageStatus 도입했지만 
   지금은 그냥 Waiting/Not_Waiting 상관없이 가장 앞에껄 가져와서 처리하기 때문에 ChatMessageStatus 삭제
2. Registration Entity에 saved_at 도입
 - LocalDateTime이 아닌 Long 타입
 - finalSave를 할 때 현재 시간을 나노 단위 정수로 변환하여 저장
3. FinalSave 할 때 RegistrationUseCase 에서 update(dirty-checking) 하는 것 제거
 - DB에 저장하는 EventIssuedEvent에서 update / insert 하도록 수정
4. 합격/불합격 기준 (UserReflectStatusEventHandler)
 - 기존 : PK 순으로 정렬 후 몇 번 째 데이터인지 확인 
 - 수정 후 : saved_at 으로 정렬 후 몇 번 째 행 데이터인지 확인
## 리뷰어에게...

## 관련 이슈

approve 받고 머지 할 때 dev, prod DB에 saved_at 컬럼 추가하도록 하겠습니다

closes #399 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정