### PR TITLE
[BE-203] bug: 공지사항 수정 오류 해결

### DIFF
--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/repository/AnnounceImageNativeRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/repository/AnnounceImageNativeRepository.java
@@ -18,7 +18,7 @@ public class AnnounceImageNativeRepository {
     private static final String DELETE_NOT_FOUND_IMAGE =
             "DELETE FROM AnnounceImage i WHERE i.imageUrl NOT IN :imageUrl";
     private static final String INSERT_IGNORE =
-            "INSERT IGNORE INTO ANNOUNCE_IMAGE_TB(URL, ANNOUNCE_ID) VALUES (?,?)";
+            "INSERT IGNORE INTO announce_image_tb (URL, ANNOUNCE_ID) VALUES (?,?)";
 
     @Transactional
     public void deleteNotFoundImage(List<AnnounceImage> announceImages) {


### PR DESCRIPTION
## 주요 변경사항
1. INSERT_IGNORE 쿼리 수정
 - 테이블 명의 대소문자를 구별하도록 설정되어 있는 것 같아서 실제 DB에 있는 테이블 명으로 수정함
## 리뷰어에게...

## 관련 이슈

closes #426 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정