### PR TITLE
[BE-204] bug: 공지사항 수정시 created_at null입력 오류

### DIFF
--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/Announce/cache/CacheTestConfiguration.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/Announce/cache/CacheTestConfiguration.java
@@ -32,8 +32,9 @@ public class CacheTestConfiguration {
                         .setExpiryPolicyFactory(
                                 CreatedExpiryPolicy.factoryOf(Duration.TEN_MINUTES));
 
-        ehCacheManager.createCache("myCache", cacheConfig);
-
+        if(ehCacheManager.getCache("myCache") == null){
+            ehCacheManager.createCache("myCache", cacheConfig);
+        }
         return new JCacheCacheManager(ehCacheManager);
     }
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/Announce/cache/CacheTestConfiguration.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/Announce/cache/CacheTestConfiguration.java
@@ -32,7 +32,7 @@ public class CacheTestConfiguration {
                         .setExpiryPolicyFactory(
                                 CreatedExpiryPolicy.factoryOf(Duration.TEN_MINUTES));
 
-        if(ehCacheManager.getCache("myCache") == null){
+        if (ehCacheManager.getCache("myCache") == null) {
             ehCacheManager.createCache("myCache", cacheConfig);
         }
         return new JCacheCacheManager(ehCacheManager);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/domain/AnnounceImage.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/domain/AnnounceImage.java
@@ -42,6 +42,6 @@ public class AnnounceImage {
     public AnnounceImage(String imageUrl, Announce announce, LocalDateTime createdAt) {
         this.imageUrl = imageUrl;
         this.announce = announce;
-        this.createdAt= createdAt;
+        this.createdAt = createdAt;
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/domain/AnnounceImage.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/domain/AnnounceImage.java
@@ -31,8 +31,7 @@ public class AnnounceImage {
     @JoinColumn(name = "announce_id")
     private Announce announce;
 
-    // MySQL은 BOOLEAN = tinyint(1), 디폴트값 : false
-    @Column(name = "is_deleted", nullable = false, columnDefinition = "tinyint(1) default 0")
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "bit(1) default 0")
     private boolean isDeleted;
 
     @Column(name = "created_at")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/domain/AnnounceImage.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/domain/AnnounceImage.java
@@ -39,8 +39,9 @@ public class AnnounceImage {
     private LocalDateTime createdAt;
 
     @Builder
-    public AnnounceImage(String imageUrl, Announce announce) {
+    public AnnounceImage(String imageUrl, Announce announce, LocalDateTime createdAt) {
         this.imageUrl = imageUrl;
         this.announce = announce;
+        this.createdAt= createdAt;
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/repository/AnnounceImageNativeRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/repository/AnnounceImageNativeRepository.java
@@ -2,6 +2,8 @@ package com.jnu.ticketdomain.domains.announce.repository;
 
 
 import com.jnu.ticketdomain.domains.announce.domain.AnnounceImage;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
@@ -18,7 +20,7 @@ public class AnnounceImageNativeRepository {
     private static final String DELETE_NOT_FOUND_IMAGE =
             "DELETE FROM AnnounceImage i WHERE i.imageUrl NOT IN :imageUrl";
     private static final String INSERT_IGNORE =
-            "INSERT IGNORE INTO announce_image_tb (URL, ANNOUNCE_ID) VALUES (?,?)";
+            "INSERT IGNORE INTO announce_image_tb (URL, ANNOUNCE_ID, CREATED_AT) VALUES (?,?,?)";
 
     @Transactional
     public void deleteNotFoundImage(List<AnnounceImage> announceImages) {
@@ -39,6 +41,7 @@ public class AnnounceImageNativeRepository {
                     .createNativeQuery(INSERT_IGNORE)
                     .setParameter(1, announceImage.getImageUrl())
                     .setParameter(2, announceImage.getAnnounce().getAnnounceId())
+                    .setParameter(3, LocalDateTime.now().toString())
                     .executeUpdate();
         }
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/repository/AnnounceImageNativeRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/announce/repository/AnnounceImageNativeRepository.java
@@ -2,7 +2,6 @@ package com.jnu.ticketdomain.domains.announce.repository;
 
 
 import com.jnu.ticketdomain.domains.announce.domain.AnnounceImage;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/AnnounceImage/repository/AnnounceImageNativeRepositoryTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/AnnounceImage/repository/AnnounceImageNativeRepositoryTest.java
@@ -103,5 +103,34 @@ public class AnnounceImageNativeRepositoryTest {
                         .isEqualTo("http://example.com/image" + (i + 1) + ".jpg");
             }
         }
+
+        @Test
+        @DisplayName("수정시 created_at이 잘 들어온다.")
+        public void insert_created_at_test() {
+            // given
+            AnnounceImage imageToInsert1 =
+                    AnnounceImage.builder()
+                            .imageUrl("http://example.com/image1.jpg")
+                            .announce(announce)
+                            .build();
+            AnnounceImage imageToInsert2 =
+                    AnnounceImage.builder()
+                            .imageUrl("http://example.com/image3.jpg")
+                            .announce(announce)
+                            .build();
+            announceImageNativeRepository.saveAllDuplicateOn(
+                    Arrays.asList(imageToInsert1, imageToInsert2));
+
+            List<AnnounceImage> remainingImages =
+                    entityManager
+                            .createQuery("SELECT i FROM AnnounceImage i", AnnounceImage.class)
+                            .getResultList();
+
+            for (AnnounceImage remainingImage : remainingImages) {
+                assertThat(remainingImage.getCreatedAt()).isNotNull();
+            }
+        }
     }
+
+
 }

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/AnnounceImage/repository/AnnounceImageNativeRepositoryTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/AnnounceImage/repository/AnnounceImageNativeRepositoryTest.java
@@ -131,6 +131,4 @@ public class AnnounceImageNativeRepositoryTest {
             }
         }
     }
-
-
 }


### PR DESCRIPTION
## 주요 변경사항

- 공지사항 수정시 created_at null로 들어가는 bug Fix
- isDeleted 컬럼 매핑 타입 변경(tinyint -> bit)
- 테스트 수정

## 리뷰어에게...

수정완료

## 관련 이슈

closes #428 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정