### PR TITLE
[BE-208] bug: 공지사항 오류

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/announce/service/UpdateAnnounceUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/announce/service/UpdateAnnounceUseCase.java
@@ -9,7 +9,7 @@ import com.jnu.ticketdomain.domains.announce.adaptor.AnnounceImageAdaptor;
 import com.jnu.ticketdomain.domains.announce.domain.Announce;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
@@ -21,7 +21,7 @@ public class UpdateAnnounceUseCase {
     private final AnnounceImageAdaptor announceImageAdaptor;
 
     @Transactional
-    @CachePut(value = "announceCache", key = "#announceId", cacheManager = "ehcacheManager")
+    @CacheEvict(value = "announceCache", key = "#announceId", cacheManager = "ehcacheManager")
     public UpdateAnnounceResponse execute(
             Long announceId, UpdateAnnounceRequest updateAnnounceRequest) {
         Announce announce =


### PR DESCRIPTION
## 주요 변경사항
1. UpdateAnnounceUseCase.execute에서 @CachePut을 CacheEvict로 수정
 - @CachePut은 공지사항 수정 할 때 캐시를 무효화 하는 것이 아니라 수정하는 거라서 UpdateAnnounceResponse를 캐싱하게 됨  이러면 공지사항 상세조회를 할 때 AnnounceDetailsResponse가 응답으로 가야하는데 캐싱된 UpdateAnnounceResponse가 반환되려고 하여 반환타입 불일치
 - 따라서 캐시 강제 무효화시키는 @CacheEvict로 수정
   - #434 에 나온 에러 로그 참고
## 리뷰어에게...
@pyg410 으악 버그다!
## 관련 이슈

closes #434 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정