### PR TITLE
[BE-211] feat: 신청 정보 조회 API 렌더링을 위한 id 필드 추가

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/internal/RegistrationDto.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/internal/RegistrationDto.java
@@ -3,11 +3,13 @@ package com.jnu.ticketapi.api.registration.model.internal;
 
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.Builder;
 
 @Builder
 public record RegistrationDto(
+        Long id,
         Long registrationId,
         String name,
         String email,
@@ -18,20 +20,21 @@ public record RegistrationDto(
         String affiliation,
         String sectorNum) {
     public static List<RegistrationDto> of(List<Registration> registrations) {
+        AtomicLong counter = new AtomicLong(1);
         return registrations.stream()
-                .map(
-                        registration ->
-                                RegistrationDto.builder()
-                                        .registrationId(registration.getId())
-                                        .name(registration.getName())
-                                        .email(registration.getEmail())
-                                        .phoneNum(registration.getPhoneNum())
-                                        .studentNum(registration.getStudentNum())
-                                        .isLight(registration.isLight())
-                                        .carNum(registration.getCarNum())
-                                        .affiliation(registration.getAffiliation())
-                                        .sectorNum(registration.getSector().getSectorNumber())
-                                        .build())
+                .map(registration ->
+                        RegistrationDto.builder()
+                                .id(counter.getAndIncrement()) // id 값을 1부터 순차적으로 부여
+                                .registrationId(registration.getId())
+                                .name(registration.getName())
+                                .email(registration.getEmail())
+                                .phoneNum(registration.getPhoneNum())
+                                .studentNum(registration.getStudentNum())
+                                .isLight(registration.isLight())
+                                .carNum(registration.getCarNum())
+                                .affiliation(registration.getAffiliation())
+                                .sectorNum(registration.getSector().getSectorNumber())
+                                .build())
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 주요 변경사항

신청 정보 명단에 오름차순으로 증가하는 id 필드를 추가했습니다.
FE에서 렌더링 시 이 `id` 필드를 사용해 응답한 JSON 순서대로 명단을 표시할 수 있도록 합니다.

## 리뷰어에게...

FE에도 필드 추가와 관련해 전달하도록 하겠습니다!

## 관련 이슈

closes #441 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정