### PR TITLE
[BE-218] feat: fixed 환경에서 captcha 요청 및 답변 검증이 가능하도록 구현

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/FixedCaptchaHashProcessor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/FixedCaptchaHashProcessor.java
@@ -29,7 +29,8 @@ public class FixedCaptchaHashProcessor implements CaptchaHashProcessor {
     @Override
     public Long verify(String hashedCode, Long userId) {
         CaptchaLog captchaLog = captchaLogPort.findLatestByUserId(userId);
-        String decryptedCaptchaId = encryption.decrypt(hashedCode, captchaLog.getSalt()); // getSalt() -> FIXED_IV
+        String decryptedCaptchaId =
+                encryption.decrypt(hashedCode, captchaLog.getSalt()); // getSalt() -> FIXED_IV
 
         if (!decryptedCaptchaId.equals(String.valueOf(captchaLog.getCaptchaId()))) {
             throw WrongCaptchaCodeException.EXCEPTION;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCase.java
@@ -5,9 +5,9 @@ import com.jnu.ticketapi.api.captcha.model.response.CaptchaResponse;
 import com.jnu.ticketapi.api.captcha.service.vo.HashResult;
 import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
-import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLoadPort;
 import com.jnu.ticketdomain.domains.captcha.out.CaptchaLogPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GetCaptchaUseCase {
 
-    private final CaptchaAdaptor captchaAdaptor;
+    private final CaptchaLoadPort captchaLoadPort;
     private final CaptchaHashProcessor captchaHashProcessor;
     private final CaptchaLogPort captchaLogPort;
 
@@ -28,7 +28,7 @@ public class GetCaptchaUseCase {
 
     @Transactional
     public CaptchaResponse execute() {
-        Captcha captcha = captchaAdaptor.findByRandom();
+        Captcha captcha = captchaLoadPort.findByRandom();
         HashResult result = captchaHashProcessor.hash(captcha.getId());
         Long userId = SecurityUtils.getCurrentUserId();
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/RandomCaptchaHashProcessor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/RandomCaptchaHashProcessor.java
@@ -4,9 +4,9 @@ package com.jnu.ticketapi.api.captcha.service;
 import com.jnu.ticketapi.api.captcha.service.vo.HashResult;
 import com.jnu.ticketapi.application.helper.Encryption;
 import com.jnu.ticketapi.config.EncryptionProperties;
-import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
 import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaCodeException;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLogPort;
 import java.security.SecureRandom;
 import java.util.Base64;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ public class RandomCaptchaHashProcessor implements CaptchaHashProcessor {
     private static final SecureRandom RANDOM = new SecureRandom();
 
     private final Encryption encryption;
-    private final CaptchaLogAdaptor captchaLogAdaptor;
+    private final CaptchaLogPort captchaLogPort;
     private final EncryptionProperties properties;
 
     @Override
@@ -35,7 +35,7 @@ public class RandomCaptchaHashProcessor implements CaptchaHashProcessor {
     @Transactional
     @Override
     public Long verify(String encryptedCode, Long userId) {
-        CaptchaLog captchaLog = captchaLogAdaptor.findLatestByUserId(userId);
+        CaptchaLog captchaLog = captchaLogPort.findLatestByUserId(userId);
         String decryptedCaptchaId = encryption.decrypt(encryptedCode, captchaLog.getSalt());
 
         if (!decryptedCaptchaId.equals(String.valueOf(captchaLog.getCaptchaId()))) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/captcha/service/ValidateCaptchaUseCase.java
@@ -3,9 +3,9 @@ package com.jnu.ticketapi.api.captcha.service;
 
 import com.jnu.ticketapi.config.SecurityUtils;
 import com.jnu.ticketcommon.annotation.UseCase;
-import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaAnswerException;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLoadPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ValidateCaptchaUseCase {
 
-    private final CaptchaAdaptor captchaAdaptor;
+    private final CaptchaLoadPort captchaLoadPort;
     private final CaptchaHashProcessor captchaHashProcessor;
 
     @Transactional
@@ -23,7 +23,7 @@ public class ValidateCaptchaUseCase {
         Long userId = SecurityUtils.getCurrentUserId();
         Long captchaId = captchaHashProcessor.verify(encryptedCode, userId);
 
-        Captcha captcha = captchaAdaptor.findById(captchaId);
+        Captcha captcha = captchaLoadPort.findById(captchaId);
         if (!captcha.validate(answer)) {
             throw WrongCaptchaAnswerException.EXCEPTION;
         }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebConfig.java
@@ -36,8 +36,12 @@ public class WebConfig implements WebMvcConfigurer {
                         "https://apply.dev.jnu-parking.com",
                         "https://manager.jnu-parking.com/",
                         "https://manager.dev.jnu-parking.com",
-                        "http://168.131.34.108:10025",
-                        "http://168.131.34.108:10026")
+                        "http://168.131.34.108:10025", // 사용자 페이지
+                        "http://168.131.34.108:10026", // 관리자 페이지
+                        "https://jnu-parking.econovation.kr", // 사용자 페이지
+                        "https://jnu-parking-manager.econovation.kr", // 관리자 페이지
+                        "https://jnu-parking-api.econovation.kr" // API 서버 (swagger 요청 시 허용)
+                        )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .maxAge(3600);

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -50,7 +50,7 @@ encryption:
   algorithm: ${ENCRYPTION_ALGORITHM:AES/CBC/PKCS5Padding}
   key-spec-algorithm: ${ENCRYPTION_KEY_ALGORITHM:AES}
   length:  ${ENCRYPTION_LENGTH:16}
-  salt-type: ${ENCRYPTION_TYPE:random}
+  salt-type: ${ENCRYPTION_TYPE:fixed}
 
 ---
 spring:

--- a/Ticket-Api/src/main/resources/db/teardown.sql
+++ b/Ticket-Api/src/main/resources/db/teardown.sql
@@ -60,7 +60,9 @@ values
 
 
 insert into captcha_tb(id, answer, image_name)
-values (1, '1234', '1234.png');
+values (1, '1234', '1234.png'),
+    (2, '5678', '5678.png'),
+    (3, '9012', '9012.png');
 
 insert into announce_tb(id, content, title, created_at)
 values (1, '공지사항입니다.', '공지사항', CURRENT_TIMESTAMP);

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
@@ -1,14 +1,16 @@
 package com.jnu.ticketapi.api.captcha.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.jnu.ticketapi.WithCustomMockUser;
 import com.jnu.ticketapi.config.BaseIntegrationTest;
-import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaAdaptor;
 import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLoadPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +19,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 class GetCaptchaUseCaseTest extends BaseIntegrationTest {
     @Autowired private GetCaptchaUseCase getCaptchaUseCase;
 
-    @MockBean private CaptchaAdaptor captchaAdaptor;
+    @MockBean private CaptchaLoadPort captchaLoadPort;
 
     @Autowired private CaptchaLogAdaptor captchaLogAdaptor;
 
@@ -30,7 +32,7 @@ class GetCaptchaUseCaseTest extends BaseIntegrationTest {
         Long captchaId = 1L;
         Captcha captcha = mock(Captcha.class);
         when(captcha.getId()).thenReturn(captchaId);
-        when(captchaAdaptor.findByRandom()).thenReturn(captcha);
+        when(captchaLoadPort.findByRandom()).thenReturn(captcha);
 
         // when
         getCaptchaUseCase.execute();

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
@@ -43,9 +43,7 @@ class GetCaptchaUseCaseTest extends BaseIntegrationTest {
                         assertEquals(
                                 captchaLogPort.findLatestByUserId(userId).getCaptchaId(),
                                 captchaId),
-                () ->
-                        assertEquals(
-                                captchaLogPort.findLatestByUserId(userId).getUserId(), userId),
+                () -> assertEquals(captchaLogPort.findLatestByUserId(userId).getUserId(), userId),
                 () -> assertFalse(captchaLogPort.findLatestByUserId(userId).getIsSuccess()));
     }
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/GetCaptchaUseCaseTest.java
@@ -8,9 +8,9 @@ import static org.mockito.Mockito.when;
 
 import com.jnu.ticketapi.WithCustomMockUser;
 import com.jnu.ticketapi.config.BaseIntegrationTest;
-import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.out.CaptchaLoadPort;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLogPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +21,7 @@ class GetCaptchaUseCaseTest extends BaseIntegrationTest {
 
     @MockBean private CaptchaLoadPort captchaLoadPort;
 
-    @Autowired private CaptchaLogAdaptor captchaLogAdaptor;
+    @Autowired private CaptchaLogPort captchaLogPort;
 
     @Test
     @WithCustomMockUser(id = 1L)
@@ -41,11 +41,11 @@ class GetCaptchaUseCaseTest extends BaseIntegrationTest {
         assertAll(
                 () ->
                         assertEquals(
-                                captchaLogAdaptor.findLatestByUserId(userId).getCaptchaId(),
+                                captchaLogPort.findLatestByUserId(userId).getCaptchaId(),
                                 captchaId),
                 () ->
                         assertEquals(
-                                captchaLogAdaptor.findLatestByUserId(userId).getUserId(), userId),
-                () -> assertFalse(captchaLogAdaptor.findLatestByUserId(userId).getIsSuccess()));
+                                captchaLogPort.findLatestByUserId(userId).getUserId(), userId),
+                () -> assertFalse(captchaLogPort.findLatestByUserId(userId).getIsSuccess()));
     }
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/RandomCaptchaHashProcessorTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/captcha/service/RandomCaptchaHashProcessorTest.java
@@ -9,9 +9,9 @@ import static org.mockito.Mockito.when;
 import com.jnu.ticketapi.api.captcha.service.vo.HashResult;
 import com.jnu.ticketapi.application.helper.Encryption;
 import com.jnu.ticketapi.config.EncryptionProperties;
-import com.jnu.ticketdomain.domains.captcha.adaptor.CaptchaLogAdaptor;
 import com.jnu.ticketdomain.domains.captcha.domain.CaptchaLog;
 import com.jnu.ticketdomain.domains.captcha.exception.WrongCaptchaCodeException;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLogPort;
 import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 class RandomCaptchaHashProcessorTest {
     private EncryptionProperties properties;
-    private CaptchaLogAdaptor captchaLogAdaptor;
+    private CaptchaLogPort captchaLogPort;
     private Encryption encryption;
     private CaptchaHashProcessor hashProcessor;
 
@@ -33,9 +33,9 @@ class RandomCaptchaHashProcessorTest {
                         "AES", // key-spec-algorithm
                         16L // length
                         );
-        captchaLogAdaptor = mock(CaptchaLogAdaptor.class);
+        captchaLogPort = mock(CaptchaLogPort.class);
         encryption = new Encryption(properties);
-        hashProcessor = new RandomCaptchaHashProcessor(encryption, captchaLogAdaptor, properties);
+        hashProcessor = new RandomCaptchaHashProcessor(encryption, captchaLogPort, properties);
     }
 
     @Nested
@@ -88,7 +88,7 @@ class RandomCaptchaHashProcessorTest {
             CaptchaLog captchaLog = mock(CaptchaLog.class);
             when(captchaLog.getCaptchaId()).thenReturn(captchaId);
             when(captchaLog.getSalt()).thenReturn(hashResult.getSalt());
-            when(captchaLogAdaptor.findLatestByUserId(userId)).thenReturn(captchaLog);
+            when(captchaLogPort.findLatestByUserId(userId)).thenReturn(captchaLog);
 
             // when & then
             assertDoesNotThrow(() -> hashProcessor.verify(captchaCode, userId));
@@ -108,7 +108,7 @@ class RandomCaptchaHashProcessorTest {
             CaptchaLog captchaLog = mock(CaptchaLog.class);
             when(captchaLog.getCaptchaId()).thenReturn(captchaId);
             when(captchaLog.getSalt()).thenReturn(hashResult.getSalt());
-            when(captchaLogAdaptor.findLatestByUserId(userId)).thenReturn(captchaLog);
+            when(captchaLogPort.findLatestByUserId(userId)).thenReturn(captchaLog);
 
             // when & then
             assertThrows(

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/registration/FinalSaveTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/registration/FinalSaveTest.java
@@ -154,11 +154,12 @@ public class FinalSaveTest extends RestDocsConfig {
         void fail15() throws Exception {
             // given
             String email = "user@jnu.ac.kr";
+            HashResult hash = captchaHashProcessor.hash(1L);
             String accessToken = jwtGenerator.generateAccessToken(email, "USER");
 
             FinalSaveRequest request =
                     FinalSaveRequest.builder()
-                            .captchaCode("testCaptchaCode")
+                            .captchaCode(hash.getCaptchaCode())
                             .captchaAnswer("testCaptchaAnswer")
                             .name("박영규")
                             .affiliation("AI융합대")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaLogAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/CaptchaLogAdaptor.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Adaptor
-public class CaptchaLogAdaptor implements CaptchaLogPort {
+class CaptchaLogAdaptor implements CaptchaLogPort {
     private final CaptchaLogRepository captchaLogRepository;
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/FixedCaptchaAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/FixedCaptchaAdaptor.java
@@ -12,7 +12,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "encryption", name = "salt-type", havingValue = "fixed")
 @Adaptor
-public class FixedCaptchaAdaptor implements CaptchaLoadPort {
+class FixedCaptchaAdaptor implements CaptchaLoadPort {
     private final CaptchaRepository captchaRepository;
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/FixedCaptchaAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/FixedCaptchaAdaptor.java
@@ -6,21 +6,20 @@ import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.exception.NotFoundCaptchaException;
 import com.jnu.ticketdomain.domains.captcha.out.CaptchaLoadPort;
 import com.jnu.ticketdomain.domains.captcha.repository.CaptchaRepository;
-import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "encryption", name = "salt-type", havingValue = "fixed")
 @Adaptor
-public class CaptchaAdaptor implements CaptchaLoadPort {
+public class FixedCaptchaAdaptor implements CaptchaLoadPort {
     private final CaptchaRepository captchaRepository;
 
     @Override
-    public Captcha findByRandom() {
-        long captchaTotalCount = captchaRepository.count();
-        long randomOffset = ThreadLocalRandom.current().nextLong(captchaTotalCount);
-
-        // id가 offset + 1 인 캡챠 조회
-        return captchaRepository.findOneByOffset(randomOffset);
+    public Captcha findByRandom() { // fixed
+        return captchaRepository
+                .findFirstByOrderByIdAsc()
+                .orElseThrow(() -> NotFoundCaptchaException.EXCEPTION);
     }
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/RandomCaptchaAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/RandomCaptchaAdaptor.java
@@ -1,0 +1,32 @@
+package com.jnu.ticketdomain.domains.captcha.adaptor;
+
+
+import com.jnu.ticketcommon.annotation.Adaptor;
+import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import com.jnu.ticketdomain.domains.captcha.exception.NotFoundCaptchaException;
+import com.jnu.ticketdomain.domains.captcha.out.CaptchaLoadPort;
+import com.jnu.ticketdomain.domains.captcha.repository.CaptchaRepository;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "encryption", name = "salt-type", havingValue = "random")
+@Adaptor
+public class RandomCaptchaAdaptor implements CaptchaLoadPort {
+    private final CaptchaRepository captchaRepository;
+
+    @Override
+    public Captcha findByRandom() {
+        long captchaTotalCount = captchaRepository.count();
+        long randomOffset = ThreadLocalRandom.current().nextLong(captchaTotalCount);
+
+        // id가 offset + 1 인 캡챠 조회
+        return captchaRepository.findOneByOffset(randomOffset);
+    }
+
+    @Override
+    public Captcha findById(long id) {
+        return captchaRepository.findById(id).orElseThrow(() -> NotFoundCaptchaException.EXCEPTION);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/RandomCaptchaAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/adaptor/RandomCaptchaAdaptor.java
@@ -13,7 +13,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "encryption", name = "salt-type", havingValue = "random")
 @Adaptor
-public class RandomCaptchaAdaptor implements CaptchaLoadPort {
+class RandomCaptchaAdaptor implements CaptchaLoadPort {
     private final CaptchaRepository captchaRepository;
 
     @Override

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/captcha/repository/CaptchaRepository.java
@@ -11,6 +11,8 @@ public interface CaptchaRepository extends JpaRepository<Captcha, Long> {
 
     Optional<Captcha> findById(long id);
 
+    Optional<Captcha> findFirstByOrderByIdAsc();
+
     @Query(value = "select * from captcha_tb LIMIT 1 OFFSET :offset", nativeQuery = true)
     Captcha findOneByOffset(@Param("offset") long offset);
 }

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/captcha/CaptchaRepositoryTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/captcha/CaptchaRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.jnu.ticketdomain.domains.captcha;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
+import com.jnu.ticketdomain.domains.captcha.repository.CaptchaRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class CaptchaRepositoryTest {
+
+    @Autowired private CaptchaRepository captchaRepository;
+
+    @BeforeEach
+    void setUp() {
+        captchaRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("fixed 환경에서 사용할 캡챠 조회 쿼리는 저장된 가장 첫번째 캡챠를 조회한다.")
+    void findFirstTest1() {
+        // given
+        Captcha first = Captcha.builder().answer("answer1").imageName("image1").build();
+
+        Captcha second = Captcha.builder().answer("answer2").imageName("image2").build();
+
+        Captcha third = Captcha.builder().answer("answer3").imageName("image3").build();
+
+        captchaRepository.saveAll(List.of(first, second, third));
+
+        // when
+        Captcha result = captchaRepository.findFirstByOrderByIdAsc().orElseThrow();
+
+        // then
+        assertThat(result).isEqualTo(first);
+        assertThat(result.getAnswer()).isEqualTo("answer1");
+        assertThat(result.getImageName()).isEqualTo("image1");
+    }
+}

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/captcha/CaptchaRepositoryTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/captcha/CaptchaRepositoryTest.java
@@ -23,7 +23,7 @@ class CaptchaRepositoryTest {
 
     @Test
     @DisplayName("fixed 환경에서 사용할 캡챠 조회 쿼리는 저장된 가장 첫번째 캡챠를 조회한다.")
-    void findFirstTest1() {
+    void findFirstCaptchaTest() {
         // given
         Captcha first = Captcha.builder().answer("answer1").imageName("image1").build();
 


### PR DESCRIPTION
## 주요 변경사항

- 부하 테스트를 위한 `fixed` 환경에서 captcha 요청 및 답변 검증이 가능하도록 구현했습니다.
  - 신청을 위해 `captcha` 이미지 조회 시 DB에 저장된 첫번째 captcha 데이터가 조회됩니다.

- 개발서버 도메인을 CORS에 추가했습니다.

- 테스트 환경의 `encryption.salt-type`이 `fixed`로 변경되었습니다.

## 리뷰어에게...

## 관련 이슈

closes #457 

## 테스트 결과

- 테스트 케이스가 추가되었습니다.
  - `fixed` 환경에서 사용하는 `hashProcessor`의 코드 검증 실패 케이스
  - `fixed` 환경에서 사용할 첫번째 캡챠 조회 쿼리


<img width="375" alt="image" src="https://github.com/user-attachments/assets/a646ef60-49b1-455f-86f2-69c33a7f1321" />

<img width="418" alt="image" src="https://github.com/user-attachments/assets/57e10caa-39c4-4fa9-a918-487759c402b8" />


<img width="1319" alt="image" src="https://github.com/user-attachments/assets/62af13b2-1599-4b45-9a92-eea1f976ffef" />


## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정