### PR TITLE
[BE-217] feat: 이메일 전송 기능 구현

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/controller/CouncilController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/controller/CouncilController.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketapi.api.council.controller;
 
 
+import com.jnu.ticketapi.api.council.docs.CouncilSendEmailException;
 import com.jnu.ticketapi.api.council.docs.CouncilSignUpExceptionDocs;
 import com.jnu.ticketapi.api.council.model.request.SignUpCouncilRequest;
 import com.jnu.ticketapi.api.council.model.response.SignUpCouncilResponse;
@@ -12,10 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @SecurityRequirement(name = "access-token")
 @RestController
@@ -33,4 +31,12 @@ public class CouncilController {
         SignUpCouncilResponse responseDto = councilUseCase.signUp(signUpCouncilRequest);
         return ResponseEntity.ok(responseDto);
     }
+
+    @Operation(summary = "메일 수동전송", description = "메일 수동전송")
+    @PostMapping("/council/emails/{eventId}")
+    @ApiErrorExceptionsExample(CouncilSendEmailException.class)
+    public void sendEmailsByManually(@PathVariable Long eventId) {
+        councilUseCase.sendEmail(eventId);
+    }
+
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/controller/CouncilController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/controller/CouncilController.java
@@ -38,5 +38,4 @@ public class CouncilController {
     public void sendEmailsByManually(@PathVariable Long eventId) {
         councilUseCase.sendEmail(eventId);
     }
-
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/docs/CouncilSendEmailException.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/docs/CouncilSendEmailException.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.council.docs;
 
+
 import com.jnu.ticketcommon.annotation.ExceptionDoc;
 import com.jnu.ticketcommon.annotation.ExplainError;
 import com.jnu.ticketcommon.exception.TicketCodeException;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/docs/CouncilSendEmailException.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/docs/CouncilSendEmailException.java
@@ -9,5 +9,5 @@ import com.jnu.ticketdomain.domains.council.exception.SendFailEmailException;
 @ExceptionDoc
 public class CouncilSendEmailException implements SwaggerExampleExceptions {
     @ExplainError("이메일 전송 요청이 실패한 경우")
-    public TicketCodeException 이메일_전송이_실패하였습니다 = SendFailEmailException.FAIL_TO_SEND_EMAIL;
+    public TicketCodeException 이메일_전송이_실패하였습니다 = SendFailEmailException.EXCEPTION;
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/docs/CouncilSendEmailException.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/docs/CouncilSendEmailException.java
@@ -1,0 +1,13 @@
+package com.jnu.ticketapi.api.council.docs;
+
+import com.jnu.ticketcommon.annotation.ExceptionDoc;
+import com.jnu.ticketcommon.annotation.ExplainError;
+import com.jnu.ticketcommon.exception.TicketCodeException;
+import com.jnu.ticketcommon.interfaces.SwaggerExampleExceptions;
+import com.jnu.ticketdomain.domains.council.exception.SendFailEmailException;
+
+@ExceptionDoc
+public class CouncilSendEmailException implements SwaggerExampleExceptions {
+    @ExplainError("이메일 전송 요청이 실패한 경우")
+    public TicketCodeException 이메일_전송이_실패하였습니다 = SendFailEmailException.FAIL_TO_SEND_EMAIL;
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
@@ -150,4 +150,3 @@ public class EmailSendEventHandler {
         }
     }
 }
-

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
@@ -1,0 +1,153 @@
+package com.jnu.ticketapi.api.council.handler;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
+
+import com.jnu.ticketdomain.domains.events.event.EventExpiredEvent;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketinfrastructure.service.MailService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EmailSendEventHandler {
+    private final MailService mailService;
+    private final RegistrationAdaptor registrationAdaptor;
+
+    @Retryable(
+            retryFor = {Exception.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 30000))
+    @SneakyThrows
+    @Async
+    @TransactionalEventListener(
+            classes = EventExpiredEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(EventExpiredEvent eventExpiredEvent) {
+        int startIndex = 0;
+        int batchSize = 14;
+        Page<Registration> registrations;
+        Queue<Registration> failQueue = new LinkedList<>();
+        Map<Registration, Integer> retryCounts = new HashMap<>(); // Map to track retry counts
+
+        do {
+            registrations =
+                    registrationAdaptor.findByIsDeletedFalseAndIsSavedTrueByPage(
+                            eventExpiredEvent.getEventId(), startIndex);
+
+            List<Registration> batch = new ArrayList<>(batchSize);
+            for (Registration registration : registrations.getContent()) {
+                batch.add(registration);
+
+                if (batch.size() == batchSize) {
+                    processBatch(batch, failQueue, retryCounts);
+                    batch.clear();
+
+                    TimeUnit.SECONDS.sleep(1);
+                }
+            }
+
+            if (!batch.isEmpty()) {
+                processBatch(batch, failQueue, retryCounts);
+                batch.clear();
+                TimeUnit.SECONDS.sleep(1);
+            }
+            startIndex++;
+
+        } while (registrations.hasNext());
+
+        failOver(failQueue, retryCounts);
+    }
+
+    private void processBatch(
+            List<Registration> batch,
+            Queue<Registration> failQueue,
+            Map<Registration, Integer> retryCounts) {
+        for (Registration registration : batch) {
+            try {
+                boolean result =
+                        mailService.sendRegistrationResultMail(
+                                registration.getEmail(),
+                                registration.getName(),
+                                registration.getUser().getStatus().getValue(),
+                                registration.getUser().getSequence());
+
+                if (!result) {
+                    failQueue.add(registration);
+                    retryCounts.put(
+                            registration,
+                            retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
+                }
+            } catch (Exception e) {
+                log.error(
+                        "Email sending failed for {}: {}", registration.getEmail(), e.getMessage());
+                failQueue.add(registration);
+                retryCounts.put(
+                        registration,
+                        retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
+            }
+        }
+    }
+
+    private void failOver(Queue<Registration> failQueue, Map<Registration, Integer> retryCounts)
+            throws InterruptedException {
+        while (!failQueue.isEmpty()) {
+            int queueSize = failQueue.size();
+            for (int i = 0; i < queueSize; i++) {
+                Registration registration = failQueue.poll();
+
+                int retryCount = retryCounts.getOrDefault(registration, 0);
+                if (retryCount >= MAX_EMAIL_SEND_RETRY) {
+                    log.error("최대 10번 retry 실패시: {}", registration.getEmail());
+                    continue;
+                }
+                try {
+                    boolean result =
+                            mailService.sendRegistrationResultMail(
+                                    registration.getEmail(),
+                                    registration.getName(),
+                                    registration.getUser().getStatus().getValue(),
+                                    registration.getUser().getSequence());
+
+                    if (!result) {
+                        retryCounts.put(registration, retryCount + 1);
+                        failQueue.add(registration);
+                        log.warn(
+                                "Retry failed for email: {} (Attempt {})",
+                                registration.getEmail(),
+                                retryCount + 1);
+                    }
+                } catch (Exception e) {
+                    log.error(
+                            "Retry exception for email {}: {}",
+                            registration.getEmail(),
+                            e.getMessage());
+                    retryCounts.put(registration, retryCount + 1);
+                    failQueue.add(registration);
+                }
+            }
+            TimeUnit.SECONDS.sleep(1);
+        }
+    }
+}
+

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
@@ -2,7 +2,7 @@ package com.jnu.ticketapi.api.council.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
 
-import com.jnu.ticketdomain.domains.events.event.EventExpiredEvent;
+import com.jnu.ticketdomain.domains.events.event.SendEmailEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketinfrastructure.service.MailService;
@@ -40,10 +40,10 @@ public class EmailSendEventHandler {
     @SneakyThrows
     @Async
     @TransactionalEventListener(
-            classes = EventExpiredEvent.class,
+            classes = SendEmailEvent.class,
             phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handle(EventExpiredEvent eventExpiredEvent) {
+    public void handle(SendEmailEvent sendEmailEvent) {
         int startIndex = 0;
         int batchSize = 14;
         Page<Registration> registrations;
@@ -53,7 +53,7 @@ public class EmailSendEventHandler {
         do {
             registrations =
                     registrationAdaptor.findByIsDeletedFalseAndIsSavedTrueByPage(
-                            eventExpiredEvent.getEventId(), startIndex);
+                            sendEmailEvent.getEventId(), startIndex);
 
             List<Registration> batch = new ArrayList<>(batchSize);
             for (Registration registration : registrations.getContent()) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
@@ -13,8 +13,8 @@ import com.jnu.ticketdomain.domains.events.event.SendEmailEvent;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.exception.NotFoundUserException;
-import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketapi.api.council.service;
 
 
+import com.jnu.ticketapi.api.council.handler.EmailSendEventHandler;
 import com.jnu.ticketapi.api.council.model.request.SignUpCouncilRequest;
 import com.jnu.ticketapi.api.council.model.response.SignUpCouncilResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
@@ -8,17 +9,25 @@ import com.jnu.ticketcommon.message.ResponseMessage;
 import com.jnu.ticketdomain.domains.council.adaptor.CouncilAdaptor;
 import com.jnu.ticketdomain.domains.council.domain.Council;
 import com.jnu.ticketdomain.domains.council.exception.AlreadyExistEmailException;
+import com.jnu.ticketdomain.domains.events.event.SendEmailEvent;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.exception.NotFoundUserException;
+import com.jnu.ticketinfrastructure.service.MailService;
+import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @UseCase
 @RequiredArgsConstructor
 public class CouncilUseCase {
     private final CouncilAdaptor councilAdaptor;
     private final UserAdaptor userAdaptor;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public User findByEmail(String email) {
@@ -36,5 +45,15 @@ public class CouncilUseCase {
         Council council = signUpCouncilRequest.toCouncilEntity(signUpCouncilRequest, jpaUser);
         councilAdaptor.save(council);
         return SignUpCouncilResponse.of(ResponseMessage.SUCCESS_SIGN_UP);
+    }
+
+    @Transactional
+    public void sendEmail(Long eventId) {
+        try {
+            eventPublisher.publishEvent(new SendEmailEvent(eventId)); // 이벤트 객체 발행
+            log.info("SendEmailEvent published for eventId: {}", eventId);
+        } catch (Exception e) {
+            log.error("Failed to publish SendEmailEvent: {}", e.getMessage());
+        }
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
@@ -1,24 +1,20 @@
 package com.jnu.ticketapi.api.council.service;
 
 
-import com.jnu.ticketapi.api.council.handler.EmailSendEventHandler;
 import com.jnu.ticketapi.api.council.model.request.SignUpCouncilRequest;
 import com.jnu.ticketapi.api.council.model.response.SignUpCouncilResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.message.ResponseMessage;
+import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.council.adaptor.CouncilAdaptor;
 import com.jnu.ticketdomain.domains.council.domain.Council;
 import com.jnu.ticketdomain.domains.council.exception.AlreadyExistEmailException;
 import com.jnu.ticketdomain.domains.events.event.SendEmailEvent;
-import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.exception.NotFoundUserException;
-import com.jnu.ticketinfrastructure.service.MailService;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -27,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouncilUseCase {
     private final CouncilAdaptor councilAdaptor;
     private final UserAdaptor userAdaptor;
-    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public User findByEmail(String email) {
@@ -50,7 +45,7 @@ public class CouncilUseCase {
     @Transactional
     public void sendEmail(Long eventId) {
         try {
-            eventPublisher.publishEvent(new SendEmailEvent(eventId)); // 이벤트 객체 발행
+            Events.raise(new SendEmailEvent(eventId));
             log.info("SendEmailEvent published for eventId: {}", eventId);
         } catch (Exception e) {
             log.error("Failed to publish SendEmailEvent: {}", e.getMessage());

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/TestUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/TestUseCase.java
@@ -9,16 +9,15 @@ import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.repository.EventRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/TestUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/TestUseCase.java
@@ -8,16 +8,17 @@ import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
-import com.jnu.ticketdomain.domains.events.exception.NotFoundEventException;
 import com.jnu.ticketdomain.domains.events.repository.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,18 +27,16 @@ public class TestUseCase {
     private final EventRepository eventRepository;
     private final EventRegisterUseCase eventRegisterUseCase;
     private final RegistrationUseCase registrationUseCase;
+    private final EventDeleteUseCase eventDeleteUseCase;
     private final AtomicInteger counter = new AtomicInteger(0);
     private static final Integer TEST_SCHEDULER_START_TIME_AFTER_NOW = 1;
-    private static final Integer TEST_SCHEDULER_END_TIME_AFTER_NOW = 2;
+    private static final Integer TEST_SCHEDULER_END_TIME_AFTER_NOW = 1000;
 
     @Transactional
     public void execute() {
-        Event event =
-                eventRepository.findAll().stream()
-                        .sorted(Comparator.comparing(Event::getId).reversed())
-                        .findFirst()
-                        .orElseThrow(() -> NotFoundEventException.EXCEPTION);
-        eventRepository.delete(event);
+        Optional<Event> event =
+                eventRepository.findAll().stream().max(Comparator.comparing(Event::getId));
+        event.ifPresent(e -> eventDeleteUseCase.deleteEvent(e.getId()));
 
         DateTimePeriod dateTimePeriod =
                 new DateTimePeriod(

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/CouncilErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/CouncilErrorCode.java
@@ -14,7 +14,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CouncilErrorCode implements BaseErrorCode {
     ALREADY_EXIST_EMAIL(BAD_REQUEST, "COUNCIL_400_1", "이미 존재하는 이메일 입니다."),
-    IS_NOT_COUNCIL(BAD_REQUEST, "COUNCIL_400_2", "권한이 학생회가 아닙니다.");
+    IS_NOT_COUNCIL(BAD_REQUEST, "COUNCIL_400_2", "권한이 학생회가 아닙니다."),
+    FAILED_TO_SEND_EMAIL(BAD_REQUEST,"COUNCIL_400_3" , "이메일 발송에 실패했습니다.");
     private final Integer status;
     private final String code;
     private final String reason;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/CouncilErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/CouncilErrorCode.java
@@ -15,7 +15,7 @@ import lombok.Getter;
 public enum CouncilErrorCode implements BaseErrorCode {
     ALREADY_EXIST_EMAIL(BAD_REQUEST, "COUNCIL_400_1", "이미 존재하는 이메일 입니다."),
     IS_NOT_COUNCIL(BAD_REQUEST, "COUNCIL_400_2", "권한이 학생회가 아닙니다."),
-    FAILED_TO_SEND_EMAIL(BAD_REQUEST,"COUNCIL_400_3" , "이메일 발송에 실패했습니다.");
+    FAILED_TO_SEND_EMAIL(BAD_REQUEST, "COUNCIL_400_3", "이메일 발송에 실패했습니다.");
     private final Integer status;
     private final String code;
     private final String reason;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/SendFailEmailException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/SendFailEmailException.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.council.exception;
 
+
 import com.jnu.ticketcommon.exception.TicketCodeException;
 
 public class SendFailEmailException extends TicketCodeException {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/SendFailEmailException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/SendFailEmailException.java
@@ -1,0 +1,11 @@
+package com.jnu.ticketdomain.domains.council.exception;
+
+import com.jnu.ticketcommon.exception.TicketCodeException;
+
+public class SendFailEmailException extends TicketCodeException {
+    public static final TicketCodeException FAIL_TO_SEND_EMAIL = new SendFailEmailException();
+
+    private SendFailEmailException() {
+        super(CouncilErrorCode.FAILED_TO_SEND_EMAIL);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/SendFailEmailException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/council/exception/SendFailEmailException.java
@@ -3,7 +3,7 @@ package com.jnu.ticketdomain.domains.council.exception;
 import com.jnu.ticketcommon.exception.TicketCodeException;
 
 public class SendFailEmailException extends TicketCodeException {
-    public static final TicketCodeException FAIL_TO_SEND_EMAIL = new SendFailEmailException();
+    public static final TicketCodeException EXCEPTION = new SendFailEmailException();
 
     private SendFailEmailException() {
         super(CouncilErrorCode.FAILED_TO_SEND_EMAIL);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/event/SendEmailEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/event/SendEmailEvent.java
@@ -1,0 +1,15 @@
+package com.jnu.ticketdomain.domains.events.event;
+
+import com.jnu.ticketdomain.common.domainEvent.DomainEvent;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class SendEmailEvent extends DomainEvent {
+    private final Long eventId;
+
+    public SendEmailEvent(Long eventId) {this.eventId = eventId; }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/event/SendEmailEvent.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/event/SendEmailEvent.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.domains.events.event;
 
+
 import com.jnu.ticketdomain.common.domainEvent.DomainEvent;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,5 +12,7 @@ import lombok.ToString;
 public class SendEmailEvent extends DomainEvent {
     private final Long eventId;
 
-    public SendEmailEvent(Long eventId) {this.eventId = eventId; }
+    public SendEmailEvent(Long eventId) {
+        this.eventId = eventId;
+    }
 }


### PR DESCRIPTION
## 주요 변경사항
CouncilController에 POST요청 API 만든 후, CouncilUseCase에서 이벤트 객체 발행하였습니다.
이메일 전송 실패시 에러 메시지 뜰 수 있게 ErrorException 구현하였고, 기존에 EventExpiredEventHandler코드를 재사용하나, 이름을 EmailSendEventHandler로 만들어 코드의 사용 의도를 명확히 하였습니다.
다만, 아직 테스트코드 작성이 안 된 상태입니다.

## 리뷰어에게...
EventExpiredEventHandler, EventExpiredEvent, EventExpiredEventRaiseGateway, BatchConfiguration을 참조하여 기능을 구현하려 했습니다. 이 때, eventId가 메일 발송 이벤트에 사용되는 것 같다고 판단했습니다. 그래서 현재 프론트에서 path variable로 받아온 eventId로 EmailSendEventHandler를 실행하는데, 이 방법이 유효한지 의문입니다.

## 관련 이슈
#456 

closes

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정