### PR TITLE
[BE-221] feat: feat: 이메일 수동으로 보내는 api 에서 응답 값 설정 

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/controller/CouncilController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/controller/CouncilController.java
@@ -4,6 +4,7 @@ package com.jnu.ticketapi.api.council.controller;
 import com.jnu.ticketapi.api.council.docs.CouncilSendEmailException;
 import com.jnu.ticketapi.api.council.docs.CouncilSignUpExceptionDocs;
 import com.jnu.ticketapi.api.council.model.request.SignUpCouncilRequest;
+import com.jnu.ticketapi.api.council.model.response.SendEmailManuallyResponse;
 import com.jnu.ticketapi.api.council.model.response.SignUpCouncilResponse;
 import com.jnu.ticketapi.api.council.service.CouncilUseCase;
 import com.jnu.ticketcommon.annotation.ApiErrorExceptionsExample;
@@ -35,7 +36,9 @@ public class CouncilController {
     @Operation(summary = "메일 수동전송", description = "메일 수동전송")
     @PostMapping("/council/emails/{eventId}")
     @ApiErrorExceptionsExample(CouncilSendEmailException.class)
-    public void sendEmailsByManually(@PathVariable Long eventId) {
-        councilUseCase.sendEmail(eventId);
+    public ResponseEntity<SendEmailManuallyResponse> sendEmailsByManually(
+            @PathVariable Long eventId) {
+        SendEmailManuallyResponse responseDto = councilUseCase.sendEmail(eventId);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/model/response/SendEmailManuallyResponse.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/model/response/SendEmailManuallyResponse.java
@@ -1,0 +1,11 @@
+package com.jnu.ticketapi.api.council.model.response;
+
+
+import lombok.Builder;
+
+@Builder
+public record SendEmailManuallyResponse(String message) {
+    public static SendEmailManuallyResponse of(String message) {
+        return SendEmailManuallyResponse.builder().message(message).build();
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
@@ -2,6 +2,7 @@ package com.jnu.ticketapi.api.council.service;
 
 
 import com.jnu.ticketapi.api.council.model.request.SignUpCouncilRequest;
+import com.jnu.ticketapi.api.council.model.response.SendEmailManuallyResponse;
 import com.jnu.ticketapi.api.council.model.response.SignUpCouncilResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.message.ResponseMessage;
@@ -43,12 +44,14 @@ public class CouncilUseCase {
     }
 
     @Transactional
-    public void sendEmail(Long eventId) {
+    public SendEmailManuallyResponse sendEmail(Long eventId) {
         try {
             Events.raise(new SendEmailEvent(eventId));
             log.info("SendEmailEvent published for eventId: {}", eventId);
+            return SendEmailManuallyResponse.of(ResponseMessage.SUCCESS_SEND_EMAIL_MANUALLY);
         } catch (Exception e) {
             log.error("Failed to publish SendEmailEvent: {}", e.getMessage());
+            return SendEmailManuallyResponse.of(ResponseMessage.FAIL_SEND_EMAIL_MANUALLY);
         }
     }
 }

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
@@ -21,5 +21,8 @@ public class ResponseMessage {
 
     public static final String UNPUBLISH_SUCCESS_TRUE_MESSAGE = "성공적으로 게시 해제 되었습니다.";
 
+    public static final String SUCCESS_SEND_EMAIL_MANUALLY = "메일 전송에 성공하셨습니다.";
+    public static final String FAIL_SEND_EMAIL_MANUALLY = "메일 전송에 실패했습니다.";
+
     private ResponseMessage() {}
 }

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/message/ResponseMessage.java
@@ -21,7 +21,7 @@ public class ResponseMessage {
 
     public static final String UNPUBLISH_SUCCESS_TRUE_MESSAGE = "성공적으로 게시 해제 되었습니다.";
 
-    public static final String SUCCESS_SEND_EMAIL_MANUALLY = "메일 전송에 성공하셨습니다.";
+    public static final String SUCCESS_SEND_EMAIL_MANUALLY = "메일 전송이 완료되었습니다";
     public static final String FAIL_SEND_EMAIL_MANUALLY = "메일 전송에 실패했습니다.";
 
     private ResponseMessage() {}


### PR DESCRIPTION
## 주요 변경사항
```json
{
  "message": "메일 전송에 성공하셨습니다."
}
```
위와 같은 방식으로 응답 값을 반환하는 기능을 구현했습니다.
</br>
## 리뷰어에게...
현재 ResponseMessage에서 이메일 전송 성공과 실패 메시지를 모두 관리하고 있는데,
따로 Exception으로 빼야할까요?(CouncilErrorCode처럼 따로 관리를 해야하는지 묻고싶습니다!)

## 관련 이슈

closes #463 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정