### PR TITLE
[BE-222] fix: 캡챠 답변 응답 메시지 수정

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -124,8 +124,8 @@ public class RegistrationUseCase {
         validateEventStatusIsClosed(event);
         validateEventPeriod(event);
 
-        checkDuplicateRegistration(email, eventId, requestDto.studentNum());
         validateCaptchaUseCase.execute(requestDto.captchaCode(), requestDto.captchaAnswer());
+        checkDuplicateRegistration(email, eventId, requestDto.studentNum());
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
 


### PR DESCRIPTION
## 주요 변경사항
- 1차 신청시 캡챠 검증 로직이 중복신청 검증 로직보다 앞에 있도록 수정

## 리뷰어에게...
- 뭐가 없긴합니다..

## 관련 이슈

closes : #465 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정