### PR TITLE
[BE-224] bug: 이메일 주소 환경변수에 의한 로컬 실행 및 테스트 에러 수정

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -33,8 +33,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/v1")
 public class EventController {
 
-    private final EventRegisterUseCase EventRegisterUseCase;
-    private final EventWithDrawUseCase EventWithDrawUseCase;
+    private final EventRegisterUseCase eventRegisterUseCase;
+    private final EventWithDrawUseCase eventWithDrawUseCase;
     private final UpdateEventStatusUseCase updateEventStatusUseCase;
     private final OpenEventUseCase openEventUseCase;
     private final GetEventDetailUseCase getEventDetailUseCase;
@@ -49,7 +49,7 @@ public class EventController {
     @ApiErrorExceptionsExample(CreateEventExceptionDocs.class)
     @PostMapping("/events")
     public SuccessResponse setEvent(@RequestBody @Valid EventRegisterRequest eventRegisterRequest) {
-        EventRegisterUseCase.registerEvent(eventRegisterRequest);
+        eventRegisterUseCase.registerEvent(eventRegisterRequest);
         return new SuccessResponse(EVENT_SUCCESS_REGISTER_MESSAGE);
     }
 
@@ -66,7 +66,7 @@ public class EventController {
     @Operation(summary = "주차권 리셋", description = "현재 활성화 및 대기중인 이벤트를")
     @DeleteMapping("/events/reset")
     public SuccessResponse resetEvent() {
-        EventWithDrawUseCase.resetEvent();
+        eventWithDrawUseCase.resetEvent();
         return new SuccessResponse(EVENT_SUCCESS_DELETE_MESSAGE);
     }
 
@@ -99,14 +99,14 @@ public class EventController {
     @ApiErrorExceptionsExample(ReadEventPeriodExceptionDocs.class)
     @GetMapping("/events/period")
     public ResponseEntity<GetEventPeriodResponse> getEventPeriod() {
-        return ResponseEntity.ok(EventWithDrawUseCase.getEventPeriod());
+        return ResponseEntity.ok(eventWithDrawUseCase.getEventPeriod());
     }
 
     @Operation(summary = "event별 주차권 신청 기간 조회", description = "event별 주차권 신청 기간 조회")
     @ApiErrorExceptionsExample(ReadEventPeriodExceptionDocs.class)
     @GetMapping("/events/{event-id}/period")
     public ResponseEntity<DateTimePeriod> getEventPeriod(@PathVariable("event-id") Long eventId) {
-        return ResponseEntity.ok(EventWithDrawUseCase.getEventPeriodByEventId(eventId));
+        return ResponseEntity.ok(eventWithDrawUseCase.getEventPeriodByEventId(eventId));
     }
 
     @Operation(

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/controller/EventController.java
@@ -45,7 +45,7 @@ public class EventController {
     private final EventUpdateUseCase eventUpdateUseCase;
     private final TestUseCase testUseCase;
 
-    @Operation(summary = "주차권 설정", description = "주차권 행사 세부 설정(시작일, 종료일, 잔고)")
+    @Operation(summary = "주차권 설정", description = "주차권 행사 세부 설정(시작일, 종료일, 제목)")
     @ApiErrorExceptionsExample(CreateEventExceptionDocs.class)
     @PostMapping("/events")
     public SuccessResponse setEvent(@RequestBody @Valid EventRegisterRequest eventRegisterRequest) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/service/CredentialCodeUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/service/CredentialCodeUseCase.java
@@ -51,8 +51,7 @@ public class CredentialCodeUseCase {
                         findPasswordRequest.toEntity(UUID.randomUUID().toString()));
 
         Context context = new Context();
-        context.setVariable(
-                MailTemplate.FIND_PASSWORD_CONTEXT, URL + credentialCode.getCode());
+        context.setVariable(MailTemplate.FIND_PASSWORD_CONTEXT, URL + credentialCode.getCode());
 
         try {
             boolean result =

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -52,21 +52,8 @@ encryption:
   length:  ${ENCRYPTION_LENGTH:16}
   salt-type: ${ENCRYPTION_TYPE:fixed}
 
----
-spring:
-  config:
-    activate:
-      on-profile: dev
 mail:
-  passwd-url: ${PASSWD-URL:https://jnu-parking.econovation.kr/password-reset/}
-  announcement-url: ${ANNOUNCEMENT_URL:https://jnu-parking.econovation.kr/announcement/}
----
-spring:
-  config:
-    activate:
-      on-profile: prod
-mail:
-  passwd-url: ${PASSWD-URL:https://apply.jnu-parking.com/password-reset/}
+  passwd-url: ${PASSWD_URL:https://apply.jnu-parking.com/password-reset/}
   announcement-url: ${ANNOUNCEMENT_URL:https://apply.jnu-parking.com/announcement/}
 
 ---

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -66,7 +66,7 @@ public class Sector {
 
     @JsonManagedReference(value = "sector-registration")
     @OneToMany(mappedBy = "sector", cascade = CascadeType.ALL)
-    private List<Registration> registrations = new ArrayList<>();
+    private final List<Registration> registrations = new ArrayList<>();
 
     @Builder
     public Sector(String sectorNumber, String name, Integer sectorCapacity, Integer reserve) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/MailService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/MailService.java
@@ -67,7 +67,9 @@ public class MailService {
     public boolean sendRegistrationResultMail(
             String email, String name, String status, Integer sequence) {
         try {
-            Context context = newRegistrationContext(name, createMailStatus(status, sequence), announcementUrl);
+            Context context =
+                    newRegistrationContext(
+                            name, createMailStatus(status, sequence), announcementUrl);
             boolean result =
                     sendMail(
                             email,
@@ -82,7 +84,8 @@ public class MailService {
         }
     }
 
-    public static Context newRegistrationContext(String userName, String pass, String announcementUrl) {
+    public static Context newRegistrationContext(
+            String userName, String pass, String announcementUrl) {
         Context context = new Context();
         context.setVariable(MailTemplate.REGISTRATION_NAME_CONTEXT, userName);
         context.setVariable(MailTemplate.REGISTRATION_PASS_CONTEXT, pass);


### PR DESCRIPTION
## 주요 변경사항

- 이메일 환경변수가 `dev`, `prod`에만 적용되어 로컬, 테스트 환경에서 실행 및 테스트가 깨지는 문제 발생
- `profile`을 구분하지 않고 해당 속성을 통일해 관리하도록 변경
- `Sector`의 `Registration`에 대한 양방향 연관관계 리스트에 `final` 키워드 적용

## 리뷰어에게...

## 관련 이슈

closes #470 

## 테스트 결과
<img width="606" alt="image" src="https://github.com/user-attachments/assets/d76e653e-0baf-4c7b-bd09-68cbcaa8534e" />

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정