### PR TITLE
[BE-226] bug: 주차권 이벤트가 끝나지 않았을 때 이메일 전송 api 요청이 성공하는 오류

### DIFF
--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
@@ -39,7 +39,7 @@ public enum EventErrorCode implements BaseErrorCode {
     CANNOT_UPDATE_CLOSED_EVENT(BAD_REQUEST, "EVENT_400_21", "종료된 이벤트는 수정할 수 없습니다."),
     ALREADY_PUBLISHED_EVENT(BAD_REQUEST, "EVENT_400_22", "이미 게시된 이벤트입니다."),
     NOT_PUBLISH_EVENT(BAD_REQUEST, "EVENT_400_23", "게시되지 않는 이벤트입니다."),
-    STILL_OPEN_EVENT(BAD_REQUEST,"EVENT_400_24", "주차권 이벤트가 진행중입니다."),
+    STILL_OPEN_EVENT(BAD_REQUEST, "EVENT_400_24", "주차권 이벤트가 진행중입니다."),
     ;
     private final Integer status;
     private final String code;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
@@ -39,7 +39,7 @@ public enum EventErrorCode implements BaseErrorCode {
     CANNOT_UPDATE_CLOSED_EVENT(BAD_REQUEST, "EVENT_400_21", "종료된 이벤트는 수정할 수 없습니다."),
     ALREADY_PUBLISHED_EVENT(BAD_REQUEST, "EVENT_400_22", "이미 게시된 이벤트입니다."),
     NOT_PUBLISH_EVENT(BAD_REQUEST, "EVENT_400_23", "게시되지 않는 이벤트입니다."),
-    STILL_OPEN_EVENT(BAD_REQUEST, "EVENT_400_24", "주차권 이벤트가 진행중입니다."),
+    STILL_OPEN_EVENT(BAD_REQUEST, "EVENT_400_24", "주차권 이벤트가 만료된 상태에서만 메일 발송이 가능합니다."),
     ;
     private final Integer status;
     private final String code;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/EventErrorCode.java
@@ -39,6 +39,7 @@ public enum EventErrorCode implements BaseErrorCode {
     CANNOT_UPDATE_CLOSED_EVENT(BAD_REQUEST, "EVENT_400_21", "종료된 이벤트는 수정할 수 없습니다."),
     ALREADY_PUBLISHED_EVENT(BAD_REQUEST, "EVENT_400_22", "이미 게시된 이벤트입니다."),
     NOT_PUBLISH_EVENT(BAD_REQUEST, "EVENT_400_23", "게시되지 않는 이벤트입니다."),
+    STILL_OPEN_EVENT(BAD_REQUEST,"EVENT_400_24", "주차권 이벤트가 진행중입니다."),
     ;
     private final Integer status;
     private final String code;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/StillOpenEventException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/StillOpenEventException.java
@@ -1,9 +1,12 @@
 package com.jnu.ticketdomain.domains.events.exception;
 
+
 import com.jnu.ticketcommon.exception.TicketCodeException;
 
 public class StillOpenEventException extends TicketCodeException {
     public static final TicketCodeException EXCEPTION = new StillOpenEventException();
 
-    private StillOpenEventException() {super(EventErrorCode.STILL_OPEN_EVENT);}
+    private StillOpenEventException() {
+        super(EventErrorCode.STILL_OPEN_EVENT);
+    }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/StillOpenEventException.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/exception/StillOpenEventException.java
@@ -1,0 +1,9 @@
+package com.jnu.ticketdomain.domains.events.exception;
+
+import com.jnu.ticketcommon.exception.TicketCodeException;
+
+public class StillOpenEventException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new StillOpenEventException();
+
+    private StillOpenEventException() {super(EventErrorCode.STILL_OPEN_EVENT);}
+}


### PR DESCRIPTION
## 주요 변경사항
현재 주차권 이벤트가 `CLOSED `상태가 아님에도 수동으로 메일 전송 버튼을 눌렀을 때, 전송을 성공했습니다.
이를 주차권 이벤트가 `CLOSED `상태에만 수동으로 이메일 전송 요청을 보낼 수 있게 수정했습니다.
`CLOSED `상태가 아닐경우 에러를 던지게 끔 수정했습니다.

## 리뷰어에게...
`eventId`에 해당하는 `EventStatus`가 `CLOSED`일 때만 요청이 가게끔 코드를 수정하려했습니다.
이를 위해 `eventId`로 해당 `EventStatus`를 가져오려 했는데, 이 때 `eventAdaptor`에 `findById`를 사용했습니다.
이 방법이 유효한지 확인부탁드립니다.

## 관련 이슈

closes #474 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정