### PR TITLE
[BE-227] bug : 예비 번호 중복 문제 버그 임시 해결

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -17,6 +17,7 @@ import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import com.zaxxer.hikari.HikariDataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.joda.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
@@ -81,6 +82,7 @@ public class EventIssuedEventHandler {
         }
 
         if (!registration.isSaved()) {
+            //if문 사용 안됨.
             registration.finalSave();
             registration.setSector(sector);
             registration.setUser(user);
@@ -90,6 +92,7 @@ public class EventIssuedEventHandler {
         registration.setSector(sector);
         registration.setUser(user);
         registrationAdaptor.saveAndFlush(registration);
+        registrationAdaptor.updateSavedAt(registration);
     }
 
     private boolean isIdleConnectionAvailable() {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -36,6 +36,10 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
         return registrationRepository.save(registration);
     }
 
+    public void updateSavedAt(Registration registration) {
+        registrationRepository.updateSavedAt(registration.getId());
+    }
+
     @Override
     public void delete(Registration registration) {
         registrationRepository.delete(registration);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -3,14 +3,15 @@ package com.jnu.ticketdomain.domains.registration.repository;
 
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.User;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface RegistrationRepository
         extends JpaRepository<Registration, Long>, RegistrationRepositoryCustom {
@@ -36,6 +37,13 @@ public interface RegistrationRepository
     @Query(
             "select r from Registration r join fetch r.sector join fetch r.user where r.isSaved = true and r.sector.event.id = :eventId")
     List<Registration> findByIsDeletedFalseAndIsSavedTrue(@Param("eventId") Long eventId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            value = "update registration_tb set saved_at = (UNIX_TIMESTAMP(NOW(6))*1000000) where id = :id",
+            nativeQuery = true
+    )
+    void updateSavedAt(@Param("id") Long registrationId);
 
     @Query(
             "select r from Registration r where r.isDeleted = false and r.isSaved = true and r.sector.event.id = :eventId")


### PR DESCRIPTION
## 주요 변경사항
- 예비 번호 중복 문제 버그 해결
- 최종 신청 후 saved_at을 애플리케이션이 아닌 DB가 설정하는 방식으로 수정
- native query 이용하여 mysql의 UNIX_TIMESTAMP 함수 사용

## 리뷰어에게...
- 컨펌해주세요

## 관련 이슈
closes #227

## 기타 이슈
- 예비 번호 중복 할당 문제를 임시로 해결하는 방안으로 순서보장은 되지 않으며 빠른 시일내에 수정 필요

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정