### PR TITLE
[BE-228] bug: 에러 시 응답코드가 200이 뜨는 메일 수동전송 api 수정

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
@@ -51,14 +51,13 @@ public class CouncilUseCase {
     @Transactional
     public SendEmailManuallyResponse sendEmail(Long eventId) {
 
-            Event event = eventAdaptor.findById(eventId);
+        Event event = eventAdaptor.findById(eventId);
 
-            if (event.getEventStatus() != EventStatus.CLOSED) {
-                throw StillOpenEventException.EXCEPTION;
-            }
-            Events.raise(new SendEmailEvent(eventId));
-            log.info("SendEmailEvent published for eventId: {}", eventId);
-            return SendEmailManuallyResponse.of(ResponseMessage.SUCCESS_SEND_EMAIL_MANUALLY);
-
+        if (event.getEventStatus() != EventStatus.CLOSED) {
+            throw StillOpenEventException.EXCEPTION;
+        }
+        Events.raise(new SendEmailEvent(eventId));
+        log.info("SendEmailEvent published for eventId: {}", eventId);
+        return SendEmailManuallyResponse.of(ResponseMessage.SUCCESS_SEND_EMAIL_MANUALLY);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
@@ -51,19 +51,14 @@ public class CouncilUseCase {
     @Transactional
     public SendEmailManuallyResponse sendEmail(Long eventId) {
 
-        try {
             Event event = eventAdaptor.findById(eventId);
 
             if (event.getEventStatus() != EventStatus.CLOSED) {
                 throw StillOpenEventException.EXCEPTION;
             }
-
             Events.raise(new SendEmailEvent(eventId));
             log.info("SendEmailEvent published for eventId: {}", eventId);
             return SendEmailManuallyResponse.of(ResponseMessage.SUCCESS_SEND_EMAIL_MANUALLY);
-        } catch (Exception e) {
-            log.error("Failed to publish SendEmailEvent: {}", e.getMessage());
-            return SendEmailManuallyResponse.of(ResponseMessage.FAIL_SEND_EMAIL_MANUALLY);
-        }
+
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -17,7 +17,6 @@ import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import com.zaxxer.hikari.HikariDataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.joda.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
@@ -82,7 +81,7 @@ public class EventIssuedEventHandler {
         }
 
         if (!registration.isSaved()) {
-            //if문 사용 안됨.
+            // if문 사용 안됨.
             registration.finalSave();
             registration.setSector(sector);
             registration.setUser(user);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -3,15 +3,14 @@ package com.jnu.ticketdomain.domains.registration.repository;
 
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface RegistrationRepository
         extends JpaRepository<Registration, Long>, RegistrationRepositoryCustom {
@@ -40,9 +39,9 @@ public interface RegistrationRepository
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
-            value = "update registration_tb set saved_at = (UNIX_TIMESTAMP(NOW(6))*1000000) where id = :id",
-            nativeQuery = true
-    )
+            value =
+                    "update registration_tb set saved_at = (UNIX_TIMESTAMP(NOW(6))*1000000) where id = :id",
+            nativeQuery = true)
     void updateSavedAt(@Param("id") Long registrationId);
 
     @Query(


### PR DESCRIPTION
## 주요 변경사항
이메일 전송 실패시 의도된 에러 메시지가 뜨지 않던 오류.
try - catch 구문을 삭제했습니다.
API 테스트 시 올바르게 에러 메시지가 뜨는 걸 확인했습니다.
다만, 추후 스웨거 수정 필요.

## 리뷰어에게...

## 관련 이슈

closes

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정