### PR TITLE
[BE-229] fix: registration table에 중복 row 생성되는 버그 수정

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/FinalSaveRequest.java
@@ -48,7 +48,7 @@ public record FinalSaveRequest(
                 String captchaAnswer) {
 
     public Registration toEntity(
-            FinalSaveRequest requestDto, Sector sector, String email, User user) {
+            FinalSaveRequest requestDto, Sector sector, String email, User user, Long eventId) {
         return Registration.builder()
                 .email(email)
                 .name(requestDto.name())
@@ -62,6 +62,7 @@ public record FinalSaveRequest(
                 .isSaved(true)
                 .user(user)
                 .savedAt(System.nanoTime())
+                .eventId(eventId)
                 .build();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/TemporarySaveRequest.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/request/TemporarySaveRequest.java
@@ -40,7 +40,7 @@ public record TemporarySaveRequest(
 
     ///
     public Registration toEntity(
-            TemporarySaveRequest requestDto, Sector sector, String email, User user) {
+            TemporarySaveRequest requestDto, Sector sector, String email, User user, Long eventId) {
         return Registration.builder()
                 .email(email)
                 .name(requestDto.name())
@@ -53,6 +53,7 @@ public record TemporarySaveRequest(
                 .sector(sector)
                 .isSaved(false)
                 .user(user)
+                .eventId(eventId)
                 .build();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -103,7 +103,7 @@ public class RegistrationUseCase {
         validateEventStatusIsClosed(event);
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
-        Registration registration = requestDto.toEntity(requestDto, sector, email, user); // 등록을 만듦
+        Registration registration = requestDto.toEntity(requestDto, sector, email, user, event.getId()); // 등록을 만듦
         return findResultByEmail(email, false, eventId)
                 .fold(
                         tempRegistration -> {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -129,7 +129,7 @@ public class RegistrationUseCase {
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
 
-        Registration registration = requestDto.toEntity(requestDto, sector, email, user);
+        Registration registration = requestDto.toEntity(requestDto, sector, email, user, event.getId());
         return findResultByEmail(email, false, eventId)
                 .fold(
                         tempRegistration ->

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -6,30 +6,21 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
-import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
 @Entity
-@Table(name = "registration_tb")
+@Table(
+        name = "registration_tb",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"student_num", "event_id"})}
+)
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @DynamicUpdate
@@ -88,8 +79,11 @@ public class Registration {
 
     @JsonBackReference(value = "sector-registration")
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sectorId", nullable = false)
+    @JoinColumn(name = "sector_id", nullable = false)
     private Sector sector;
+
+    @Column(name = "event_id")
+    private Long eventId;
 
     @Builder
     private Registration(
@@ -105,7 +99,8 @@ public class Registration {
             boolean isSaved,
             Long savedAt,
             User user,
-            Sector sector) {
+            Sector sector,
+            Long eventId) {
         this.email = email;
         this.name = name;
         this.studentNum = studentNum;
@@ -119,6 +114,7 @@ public class Registration {
         this.savedAt = savedAt;
         this.user = user;
         this.sector = sector;
+        this.eventId = eventId;
     }
 
     @JsonCreator
@@ -137,7 +133,8 @@ public class Registration {
             @JsonProperty("savedAt") Long savedAt,
             @JsonProperty("user") User user,
             @JsonProperty("sector") Sector sector,
-            @JsonProperty("id") Long id) {
+            @JsonProperty("id") Long id,
+            @JsonProperty("eventId") Long eventId) {
         this.email = email;
         this.name = name;
         this.studentNum = studentNum;
@@ -153,9 +150,11 @@ public class Registration {
         this.user = user;
         this.sector = sector;
         this.id = id;
+        this.eventId = eventId;
     }
 
-    public Registration() {}
+    public Registration() {
+    }
 
     public void finalSave() {
         this.isSaved = true;

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -54,6 +54,7 @@ public class WaitingQueueService {
         registrationJson.put("savedAt", registration.getSavedAt());
         registrationJson.put("id", registration.getId());
         registrationJson.put("createdAt", registration.getCreatedAt());
+        registrationJson.put("eventId", registration.getEventId());
         return registrationJson.toString();
     }
 


### PR DESCRIPTION
## 주요 변경사항
db 레벨에서 유니키 제약 조건을 통해 registration의 중복 row를 방어하고자 했습니다.
기존 registration에 존재하는 학번과 구간을 유니크 키로 설정할려하였으나 기존에 존재하는 데이터로 인해 불가능하여
eventId 컬럼을 새롭게 추가하여 학번과 eventId 컬럼을 유니크 키로 설정하였습니다.

- registration 테이블에 eventId 컬럼 추가
- (eventId + 학번)을 유니크 키 제약조건으로 추가
- 임시 저장 및 1차 신청시 신청서에 eventId 정보 추가

## 리뷰어에게...

## 관련 이슈

closes484

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정