### PR TITLE
[BE-234] bug: 구간 재고 감소 안되는 문제 해결

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -70,6 +70,7 @@ public class EventIssuedEventHandler {
                     processQueueData(sector, registration, eventIssuedEvent.getMessage().getUserId());
                     waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
                     sector.decreaseEventStock();
+                    sectorAdaptor.save(sector);
                 } catch (NoEventStockLeftException e) {
                     tracker.info("해당 구간 잔여 여석이 없습니다.", e);
                     waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());


### PR DESCRIPTION
## 주요 변경사항
- 임시로 더티체킹 하지 못하는 sector를 감소 하고 save 하도록 수정
## 리뷰어에게...
운영환경 DB를 보면 3월 달 부터 sector의 RemainingAmount가 단 하나도 줄지 않았는데 이런 중요한 것을 놓치면 안되죠...
주의 깊게 잘 운영 하시길 바랍니다.
추가적으로 이것은 임시 방편이니 왜 더티체킹이 안되는지 고민 해보면 좋을 것 같네요.
## 관련 이슈

closes #492 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정