### PR TITLE
[BE-234] bug: Registration 테이블 유니크 키 제약조건 사이드 이펙터 제거

### DIFF
--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
-import java.time.LocalDateTime;
-import javax.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
@@ -15,10 +13,14 @@ import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
 @Entity
 @Table(
         name = "registration_tb",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"student_num", "event_id"})})
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"event_id", "email", "student_num",})}
+)
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @DynamicUpdate
@@ -151,7 +153,8 @@ public class Registration {
         this.eventId = eventId;
     }
 
-    public Registration() {}
+    public Registration() {
+    }
 
     public void finalSave() {
         this.isSaved = true;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import java.time.LocalDateTime;
+import javax.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicUpdate;
@@ -13,14 +15,17 @@ import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.*;
-import java.time.LocalDateTime;
-
 @Entity
 @Table(
         name = "registration_tb",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"event_id", "email", "student_num",})}
-)
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    columnNames = {
+                        "event_id",
+                        "email",
+                        "student_num",
+                    })
+        })
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @DynamicUpdate
@@ -153,8 +158,7 @@ public class Registration {
         this.eventId = eventId;
     }
 
-    public Registration() {
-    }
+    public Registration() {}
 
     public void finalSave() {
         this.isSaved = true;

--- a/initdb/init.sql
+++ b/initdb/init.sql
@@ -472,6 +472,8 @@ create table registration_tb
     constraint FK7p6t377o5h1q0bheapm2t91f5
         foreign key (sector_id) references sector (sector_id),
     constraint FKlfurts4ouptujftlouj21atoe
-        foreign key (user_id) references user_tb (user_id)
+        foreign key (user_id) references user_tb (user_id),
+    constraint uniq_event_email_student_num
+        unique (event_id, email, student_num)
 );
 

--- a/initdb/init.sql
+++ b/initdb/init.sql
@@ -467,6 +467,8 @@ create table registration_tb
     student_num varchar(255)     not null,
     sector_id   bigint           not null,
     user_id     bigint           null,
+    department  varchar(255)     null,
+    event_id    bigint           null,
     constraint FK7p6t377o5h1q0bheapm2t91f5
         foreign key (sector_id) references sector (sector_id),
     constraint FKlfurts4ouptujftlouj21atoe


### PR DESCRIPTION
## 주요 변경사항
- Registration 테이블의 유니크 제약조건에 email 컬럼을 추가 했습니다 #496 
- init sql에 누락된 ddl을 추가했습니다 #500 

## 리뷰어에게...

## 관련 이슈

closes #496, #500 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정