### PR TITLE
[BE-237] test: 주차권 신청 및 결과 확인이 이루어지는 전체적인 플로우에 대한 테스트 코드 작성

### DIFF
--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 
     //WebTestClient 사용
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-quartz'
 }
 
 jib {

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -47,8 +47,11 @@ dependencies {
     // logback json 변환 라이브러리
     implementation 'net.logstash.logback:logstash-logback-encoder:6.6'
 
+    // 테스트 컨테이너 라이브러리
+    testImplementation "org.testcontainers:testcontainers:1.21.3"
+    testImplementation "org.testcontainers:junit-jupiter:1.21.3"
+    testImplementation "org.testcontainers:mysql:1.21.3"
 }
-
 
 jib {
     def serverPort = "8080"

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.21.3"
     testImplementation "org.testcontainers:junit-jupiter:1.21.3"
     testImplementation "org.testcontainers:mysql:1.21.3"
+
+    //WebTestClient 사용
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 jib {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -28,14 +28,15 @@ import com.jnu.ticketdomain.domains.registration.exception.NotFoundRegistrationE
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.redis.RedisService;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -124,7 +125,7 @@ public class RegistrationUseCase {
         validateEventPeriod(event);
 
         validateCaptchaUseCase.execute(requestDto.captchaCode(), requestDto.captchaAnswer());
-        checkDuplicateRegistration(email, eventId, requestDto.studentNum());
+        checkDuplicateRegistration(email, eventId);
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
 
@@ -223,9 +224,8 @@ public class RegistrationUseCase {
         return GetRegistrationsResponse.of(registrations);
     }
 
-    private void checkDuplicateRegistration(String email, Long eventId, String studentNum) {
-        if (registrationAdaptor.existsByEmailAndIsSavedTrue(email, eventId)
-                || registrationAdaptor.existsByStudentNumAndIsSavedTrue(studentNum, eventId)) {
+    private void checkDuplicateRegistration(String email, Long eventId) {
+        if (registrationAdaptor.existsByEmailAndIsSavedTrue(email, eventId)) {
             throw AlreadyExistRegistrationException.EXCEPTION;
         }
     }

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -77,3 +77,25 @@ web:
   log:
     url-no-logging:
       - /api/swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: integration-test
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+captcha:
+  domain: dsrps7tt0ew8t.cloudfront.net
+
+ableDomainEvent: false
+
+web:
+  log:
+    url-no-logging:
+      - /api/swagger-ui.html

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -93,7 +93,7 @@ server:
 captcha:
   domain: dsrps7tt0ew8t.cloudfront.net
 
-ableDomainEvent: false
+ableDomainEvent: true
 
 web:
   log:

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -131,14 +131,13 @@ public class FlowTest {
                 new Setting(10, 30, 40)
         );
 
+        int resultWaitingSecond = 20;
+
         Integer capacityCountSum = settings.stream().map(Setting::capacity).reduce(0, Integer::sum);
         Integer reserveCountSum = settings.stream().map(Setting::reserve).reduce(0, Integer::sum);
         Integer userCountSum = settings.stream().map(Setting::requestCount).reduce(0, Integer::sum);
 
-        List<List<String>> userAccessTokens = settings.stream()
-                .map(Setting::requestCount)
-                .map(this::setUpUserData)
-                .toList();
+        List<List<String>> userAccessTokens = setUpAccessTokensPerSector(settings);
 
         String tempAccessToken = userAccessTokens.get(0).get(0);
         createEvent(tempAccessToken);
@@ -159,7 +158,7 @@ public class FlowTest {
             executorServiceForSector.submit(() -> finalSaveRequestToSector(sectorId, accessTokensPerSector, executorServiceInSector));
         }
 
-        Thread.sleep(30000);
+        Thread.sleep(resultWaitingSecond * 1000);
 
         // then
         List<User> usersWithResult = userRepository.findAll(Sort.by("id"));
@@ -176,6 +175,13 @@ public class FlowTest {
         assertPreparePerSector(usersWithResult, settings);
 
 
+    }
+
+    private List<List<String>> setUpAccessTokensPerSector(List<Setting> settings) {
+        return settings.stream()
+                .map(Setting::requestCount)
+                .map(this::setUpUserData)
+                .toList();
     }
 
     private void finalSaveRequestToSector(long sectorId, List<String> accessTokens, ExecutorService executorService) {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -132,12 +132,12 @@ public class FlowTest {
         Integer reserveCountSum = settings.stream().map(Setting::reserve).reduce(0, Integer::sum);
         Integer userCountSum = settings.stream().map(Setting::requestCount).reduce(0, Integer::sum);
 
-        List<Map<User, String>> usersWithToken = settings.stream()
+        List<List<String>> userAccessTokens = settings.stream()
                 .map(Setting::requestCount)
                 .map(this::setUpUserData)
                 .toList();
 
-        String tempAccessToken = usersWithToken.get(0).values().stream().findFirst().get();
+        String tempAccessToken = userAccessTokens.get(0).get(0);
         createEvent(tempAccessToken);
         createCaptcha();
         createSectors(settings);
@@ -240,7 +240,7 @@ public class FlowTest {
                 .build();
     }
 
-    private Map<User, String> setUpUserData(int userSize) {
+    private List<String> setUpUserData(int userSize) {
         List<User> users = saveUsers(userSize);
         return generateToken(users);
     }
@@ -259,13 +259,10 @@ public class FlowTest {
         return users;
     }
 
-    private Map<User, String> generateToken(List<User> users) {
-        Map<User, String> usersWithToken = new HashMap<>();
-        for (User user : users) {
-            String accessToken = jwtGenerator.generateAccessToken(user.getEmail(), user.getUserRole().name());
-            usersWithToken.put(user, accessToken);
-        }
-        return usersWithToken;
+    private List<String> generateToken(List<User> users) {
+        return users.stream()
+                .map(user -> jwtGenerator.generateAccessToken(user.getEmail(), user.getUserRole().name()))
+                .toList();
     }
 
     private void setEventPublic() {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -52,6 +52,11 @@ import static org.quartz.TriggerBuilder.newTrigger;
 @Testcontainers
 public class FlowTest {
 
+    private static final int ASYNC_CORE_POOL_SIZE = 1000;
+    private static final int ASYNC_MAX_POOL_SIZE = 1000;
+    private static final int ASYNC_QUEUE_CAPACITY = 50000;
+    private static final int HIKARI_MAXIMUM_POOL_SIZE = 2000;
+
     private static final int REDIS_PORT = 6379;
     private static final int MYSQL_PORT = 3306;
     private static final Long EVENT_VALUE = 1L;
@@ -76,6 +81,18 @@ public class FlowTest {
         );
         registry.add("spring.datasource.username", mysqlContainer::getUsername);
         registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+
+    @DynamicPropertySource
+    static void asyncTheadProperties(DynamicPropertyRegistry registry) {
+        registry.add("thread.core-pool-size", () -> ASYNC_CORE_POOL_SIZE);
+        registry.add("thread.max-pool-size", () -> ASYNC_MAX_POOL_SIZE);
+        registry.add("thread.queue-capacity", () -> ASYNC_QUEUE_CAPACITY);
+    }
+
+    @DynamicPropertySource
+    static void hikariProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.hikari.maximum-pool-size", () -> HIKARI_MAXIMUM_POOL_SIZE);
     }
 
     @Autowired

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -1,0 +1,55 @@
+package com.jnu.ticketapi;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.client.MockMvcWebTestClient;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@ActiveProfiles("integration-test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Testcontainers
+public class FlowTest {
+
+    public static final int REDIS_PORT = 6379;
+    public static final int MYSQL_PORT = 3306;
+
+    @Container
+    static MySQLContainer mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.40"))
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    static GenericContainer redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7"))
+            .withExposedPorts(REDIS_PORT);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redisContainer::getHost);
+        registry.add("spring.redis.port", () -> redisContainer.getMappedPort(REDIS_PORT));
+        registry.add("spring.datasource.url", () -> String.format(
+                "jdbc:mysql://%s:%d/%s", mysqlContainer.getHost(), mysqlContainer.getMappedPort(MYSQL_PORT), mysqlContainer.getDatabaseName())
+        );
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+
+    WebTestClient client;
+
+    @BeforeEach
+    void setup(WebApplicationContext context) {
+        client = MockMvcWebTestClient.bindToApplicationContext(context).build();
+    }
+
+}
+
+

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -53,8 +53,7 @@ import static org.quartz.TriggerBuilder.newTrigger;
 @Slf4j
 @ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
-public class FlowTest {
+public class FlowTest implements UsingContainers {
 
     private static final int ASYNC_CORE_POOL_SIZE = 1000;
     private static final int ASYNC_MAX_POOL_SIZE = 1000;

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/UsingContainers.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/UsingContainers.java
@@ -1,0 +1,37 @@
+package com.jnu.ticketapi;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public interface UsingContainers {
+
+    int REDIS_PORT = 6379;
+    int MYSQL_PORT = 3306;
+
+    @Container
+    MySQLContainer mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.40"))
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    GenericContainer redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7"))
+            .withExposedPorts(REDIS_PORT);
+
+    @DynamicPropertySource
+    static void containerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redisContainer::getHost);
+        registry.add("spring.redis.port", () -> redisContainer.getMappedPort(REDIS_PORT));
+        registry.add("spring.datasource.url", () -> String.format(
+                "jdbc:mysql://%s:%d/%s", mysqlContainer.getHost(), mysqlContainer.getMappedPort(MYSQL_PORT), mysqlContainer.getDatabaseName())
+        );
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/config/DatabaseCleaner.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/config/DatabaseCleaner.java
@@ -1,31 +1,68 @@
 package com.jnu.ticketapi.config;
 
 
-import java.util.ArrayList;
-import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
 import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Component
 public class DatabaseCleaner {
 
     private final List<String> tableNames = new ArrayList<>();
 
-    @PersistenceContext private EntityManager entityManager;
+    @PersistenceContext
+    private final EntityManager entityManager;
+    private final DataSource dataSource;
+
+    public DatabaseCleaner(DataSource dataSource, EntityManager entityManager) {
+        this.dataSource = dataSource;
+        this.entityManager = entityManager;
+    }
 
     // 바뀐부분 : 의존성 주입이후 초기화 수행 시 Table을 조회한다.
     @PostConstruct
     @SuppressWarnings("unchecked")
-    private void findDatabaseTableNames() {
-        List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
-        for (Object[] tableInfo : tableInfos) {
-            String tableName = (String) tableInfo[0];
-            tableNames.add(tableName);
+    private void findDatabaseTableNames() throws SQLException {
+        List<?> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
+        String databaseVendor = getDatabaseVendor();
+        if (databaseVendor.equals("MySQL")) {
+            extractFromMysql(tableInfos);
+        }
+
+        if (databaseVendor.equals("H2")) {
+            extractFromH2(tableInfos);
         }
     }
+
+    private String getDatabaseVendor() throws SQLException {
+        Connection connection = dataSource.getConnection();
+        DatabaseMetaData metaData = connection.getMetaData();
+        return metaData.getDatabaseProductName();
+    }
+
+    private void extractFromMysql(List<?> tableInfos) {
+        Object tableInfo = tableInfos.get(0);
+        String tableNames = (String) tableInfo;
+        this.tableNames.addAll(Arrays.stream(tableNames.split(",")).toList());
+    }
+
+    private void extractFromH2(List<?> tableInfos) {
+        for (Object tableInfo : tableInfos) {
+            Object[] tableNames = (Object[]) tableInfo;
+            this.tableNames.add((String) tableNames[0]);
+        }
+    }
+
 
     private void truncate() {
         entityManager

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -31,7 +31,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @DynamicUpdate
 @AllArgsConstructor(access = AccessLevel.PUBLIC) // 생성자를 public으로 변경
 @Where(clause = "is_deleted = false")
-@ToString
 public class Registration {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -179,6 +178,28 @@ public class Registration {
         this.isLight = registration.isLight();
         this.phoneNum = registration.getPhoneNum();
         this.sector = registration.getSector();
+    }
+
+    @Override
+    public String toString() {
+        return "Registration{" +
+                "id=" + id +
+                ", email='" + email + '\'' +
+                ", name='" + name + '\'' +
+                ", studentNum='" + studentNum + '\'' +
+                ", affiliation='" + affiliation + '\'' +
+                ", department='" + department + '\'' +
+                ", carNum='" + carNum + '\'' +
+                ", isLight=" + isLight +
+                ", phoneNum='" + phoneNum + '\'' +
+                ", createdAt=" + createdAt +
+                ", isSaved=" + isSaved +
+                ", isDeleted=" + isDeleted +
+                ", savedAt=" + savedAt +
+                ", user=" + user.getId() +
+                ", sector=" + sector.getId() +
+                ", eventId=" + eventId +
+                '}';
     }
 
     public void setSector(Sector sector) {

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -101,7 +101,6 @@ spring:
   quartz:
     jdbc:
       initialize-schema: always
-
 ---
 
 spring:
@@ -207,3 +206,17 @@ management:
     redis:
       enabled: ${ABLE_REDIS:true}
 
+---
+spring:
+  config:
+    activate:
+      on-profile: integration-test
+  jpa:
+    show-sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: create-drop
+
+  quartz:
+    jdbc:
+      initialize-schema: always

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -220,3 +220,8 @@ spring:
   quartz:
     jdbc:
       initialize-schema: always
+
+thread:
+  core-pool-size: 10
+  max-pool-size: 20
+  queue-capacity: 100

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
@@ -13,7 +13,7 @@ import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-@Profile("!test")
+@Profile({"!test","integration-test"})
 @EnableAsync
 @Configuration
 @RequiredArgsConstructor


### PR DESCRIPTION
## 주요 변경사항
- 주차권 최종 신청 -> 데이터 처리 -> 결과 확인 플로우에 대한 테스트코드를 작성했습니다
  - 테스트 컨테이너를 사용하여 mysql, redis 테스트 환경을 구축
  - 스프링부트 랜덤포트를 사용하여 통합테스트를 진행(WebTestClient 사용)
  - databasecleaner 에서 벤더에 따른 값 파싱 문제 수정 (3fda05656032947ebfb2b5347a6822ad3581b98c)
  - 주차권 중복검사 로직 수정(email, event_id, student_num이 식별키이므로) (ad4ae4bacf8b42bfff666d7349c9ac03437b7676)

- 테스트 시나리오
  1. 이벤트 생성 및 구간 여석 설정 (given ~)
  2. 이벤트 게시 + 스케쥴러 Job 수동 설정
  3. 전체 최종 신청 요청의 90%는 임시저장
  4. 최종 신청 동시 요청 보내기 (when)
  5. 전체 합격자 수, 예비자 수, 불합격자 수 검증 (then ~)
  6. 구간 별 합격자 수, 예비자 수, 불합격자 수 및 예비번호 순번 검증
  


## 리뷰어에게...

## 관련 이슈

closes #499

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정