### PR TITLE
[BE-244] bug: 신청 결과를 실시간으로 계산하는 과정에서 발생하는 예비번호 중복 문제를 해결

### DIFF
--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 
     //WebTestClient 사용
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-quartz'
 }
 
 jib {

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -47,8 +47,11 @@ dependencies {
     // logback json 변환 라이브러리
     implementation 'net.logstash.logback:logstash-logback-encoder:6.6'
 
+    // 테스트 컨테이너 라이브러리
+    testImplementation "org.testcontainers:testcontainers:1.21.3"
+    testImplementation "org.testcontainers:junit-jupiter:1.21.3"
+    testImplementation "org.testcontainers:mysql:1.21.3"
 }
-
 
 jib {
     def serverPort = "8080"

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.21.3"
     testImplementation "org.testcontainers:junit-jupiter:1.21.3"
     testImplementation "org.testcontainers:mysql:1.21.3"
+
+    //WebTestClient 사용
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 jib {

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -47,6 +47,11 @@ dependencies {
     // logback json 변환 라이브러리
     implementation 'net.logstash.logback:logstash-logback-encoder:6.6'
 
+    // 테스트 컨테이너 라이브러리
+    testImplementation "org.testcontainers:testcontainers:1.21.3"
+    testImplementation "org.testcontainers:junit-jupiter:1.21.3"
+    testImplementation "org.testcontainers:mysql:1.21.3"
+
 }
 
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -1,7 +1,5 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
-
 import com.jnu.ticketapi.api.event.model.response.GetEventPeriodResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.utils.Result;
@@ -12,6 +10,7 @@ import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.*;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketinfrastructure.service.RedisStreamRegistrationBroker;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +26,8 @@ public class EventWithDrawUseCase {
 
     @Autowired(required = false)
     private WaitingQueueService waitingQueueService;
+
+    private final RedisStreamRegistrationBroker redisStreamRegistrationBroker;
 
     private final EventAdaptor eventAdaptor;
 
@@ -51,7 +52,7 @@ public class EventWithDrawUseCase {
                 (error) -> {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
-        waitingQueueService.registerToStream(registration, userId, sectorId, eventId);
+        redisStreamRegistrationBroker.send(registration, userId, sectorId, eventId);
     }
 
     public GetEventPeriodResponse getEventPeriod() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -51,8 +51,7 @@ public class EventWithDrawUseCase {
                 (error) -> {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
-        waitingQueueService.registerQueue(
-                REDIS_EVENT_ISSUE_STORE, registration, userId, sectorId, eventId);
+        waitingQueueService.registerToStream(registration, userId, sectorId, eventId);
     }
 
     public GetEventPeriodResponse getEventPeriod() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -9,7 +9,7 @@ import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.*;
-import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import com.jnu.ticketinfrastructure.service.RedisStreamRegistrationBroker;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import java.util.List;
@@ -31,7 +31,9 @@ public class EventWithDrawUseCase {
 
     private final EventAdaptor eventAdaptor;
 
-    /** 재고 감소 */
+    /**
+     * 재고 감소
+     */
     //    @RedissonLock(
     //            LockName = "주차권_발급",
     //            identifier = "userId",
@@ -39,7 +41,7 @@ public class EventWithDrawUseCase {
     //            leaseTime = 10000,
     //            timeUnit = TimeUnit.MILLISECONDS)
     @SneakyThrows
-    public void issueEvent(Registration registration, Long userId, Long sectorId, Long eventId) {
+    public void issueEvent(RegistrationInfo registrationDto) {
         // 재고 감소 로직 구현
         Result<Event, Object> readyEvent = eventAdaptor.findReadyOrOpenEvent();
         readyEvent.fold(
@@ -52,7 +54,7 @@ public class EventWithDrawUseCase {
                 (error) -> {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
-        redisStreamRegistrationBroker.send(registration, userId, sectorId, eventId);
+        redisStreamRegistrationBroker.send(registrationDto);
     }
 
     public GetEventPeriodResponse getEventPeriod() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationProcessorImp.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationProcessorImp.java
@@ -1,13 +1,12 @@
 package com.jnu.ticketapi.api.flow;
 
 import com.jnu.ticketbatch.flow.RegistrationProcessor;
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Component
@@ -19,9 +18,9 @@ public class RegistrationProcessorImp implements RegistrationProcessor {
     private final RedisRepository redisRepository;
 
 
-    public boolean process(Map<String, String> registration) {
+    public boolean process(RegistrationInfo registrationInfo) {
         try {
-            registrationSavingProcessor.process(registration);
+            registrationSavingProcessor.process(registrationInfo);
         } catch (DataIntegrityViolationException e) {
             log.error("중복 키 에러", e);
             return true;
@@ -30,10 +29,10 @@ public class RegistrationProcessorImp implements RegistrationProcessor {
             return false;
         }
 
-        long sectorId = Long.parseLong(registration.get("sectorId"));
+        Long sectorId = registrationInfo.getSectorId();
         int position = Math.toIntExact(redisRepository.increment("구간-" + sectorId));
 
-        Long userId = Long.valueOf(registration.get("userId"));
+        Long userId = registrationInfo.getUserId();
         userStatusProcessor.applyStatus(userId, sectorId, position);
 
         return true;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationProcessorImp.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationProcessorImp.java
@@ -1,0 +1,42 @@
+package com.jnu.ticketapi.api.flow;
+
+import com.jnu.ticketbatch.flow.RegistrationProcessor;
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class RegistrationProcessorImp implements RegistrationProcessor {
+
+    private final RegistrationSavingProcessor registrationSavingProcessor;
+    private final UserStatusProcessor userStatusProcessor;
+    private final RedisRepository redisRepository;
+
+
+    public boolean process(Map<String, String> registration) {
+        try {
+            registrationSavingProcessor.process(registration);
+        } catch (DataIntegrityViolationException e) {
+            log.error("중복 키 에러", e);
+            return true;
+        } catch (Exception e) {
+            log.error("알수 없는 에러", e);
+            return false;
+        }
+
+        long sectorId = Long.parseLong(registration.get("sectorId"));
+        int position = Math.toIntExact(redisRepository.increment("구간-" + sectorId));
+
+        Long userId = Long.valueOf(registration.get("userId"));
+        userStatusProcessor.applyStatus(userId, sectorId, position);
+
+        return true;
+    }
+
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationSavingProcessor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationSavingProcessor.java
@@ -5,17 +5,17 @@ import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -34,37 +34,40 @@ public class RegistrationSavingProcessor {
     )
 
     @Transactional
-    public void process(Map<String, String> RegistrationDto) {
-        long sectorId = Long.parseLong(RegistrationDto.get("sectorId"));
+    public void process(RegistrationInfo registrationInfo) {
+        Long sectorId = registrationInfo.getSectorId();
         Sector sector = sectorAdaptor.findById(sectorId);
-        Registration registration = Registration.builder()
-                .eventId(Long.valueOf(RegistrationDto.get("eventId")))
-                .email(RegistrationDto.get("email"))
-                .name(RegistrationDto.get("name"))
-                .studentNum(RegistrationDto.get("studentNum"))
-                .affiliation(RegistrationDto.get("affiliation"))
-                .department(RegistrationDto.get("department"))
-                .carNum(RegistrationDto.get("carNum"))
-                .phoneNum(RegistrationDto.get("phoneNum"))
-                .isLight(Boolean.parseBoolean(RegistrationDto.get("isLight")))
-                .isSaved(Boolean.parseBoolean(RegistrationDto.get("isSaved")))
-                .savedAt(Long.valueOf(RegistrationDto.get("savedAt")))
-                .build();
-        String registrationId = RegistrationDto.get("id");
-        registration.setSector(sector);
+        User user = userAdaptor.findById(registrationInfo.getUserId());
 
-        String createAt = RegistrationDto.get("createAt");
-        if (createAt != null) {
-            registration.setCreatedAt(LocalDateTime.parse(createAt));
-        }
-        if (registrationId != null) {
-            registration.setId(Long.valueOf(registrationId));
-        }
-        registration.setUser(userAdaptor.findById(Long.valueOf(RegistrationDto.get("userId"))));
+        Registration registration = createRegistration(registrationInfo, sector, user);
         registration.finalSave();
 
         registrationAdaptor.save(registration);
         registrationAdaptor.updateSavedAt(registration);
+    }
+
+    private Registration createRegistration(RegistrationInfo registrationInfo, Sector sector, User user) {
+        Registration registration = Registration.builder()
+                .eventId(registrationInfo.getEventId())
+                .email(registrationInfo.getEmail())
+                .name(registrationInfo.getName())
+                .studentNum(registrationInfo.getStudentNum())
+                .affiliation(registrationInfo.getAffiliation())
+                .department(registrationInfo.getDepartment())
+                .carNum(registrationInfo.getCarNum())
+                .phoneNum(registrationInfo.getPhoneNum())
+                .isLight(registrationInfo.isLight())
+                .isSaved(registrationInfo.isSaved())
+                .savedAt(registrationInfo.getSavedAt())
+                .build();
+        String createdAt = registrationInfo.getCreatedAt();
+        if (createdAt != null) {
+            registration.setCreatedAt(LocalDateTime.parse(createdAt));
+        }
+        registration.setId(registrationInfo.getId());
+        registration.setSector(sector);
+        registration.setUser(user);
+        return registration;
     }
 
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationSavingProcessor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationSavingProcessor.java
@@ -1,0 +1,71 @@
+package com.jnu.ticketapi.api.flow;
+
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RegistrationSavingProcessor {
+
+    private final SectorAdaptor sectorAdaptor;
+    private final UserAdaptor userAdaptor;
+    private final RegistrationAdaptor registrationAdaptor;
+
+    @Retryable(
+            retryFor = {Exception.class},
+            noRetryFor = {DataIntegrityViolationException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500)
+    )
+
+    @Transactional
+    public void process(Map<String, String> RegistrationDto) {
+        long sectorId = Long.parseLong(RegistrationDto.get("sectorId"));
+        Sector sector = sectorAdaptor.findById(sectorId);
+        Registration registration = Registration.builder()
+                .eventId(Long.valueOf(RegistrationDto.get("eventId")))
+                .email(RegistrationDto.get("email"))
+                .name(RegistrationDto.get("name"))
+                .studentNum(RegistrationDto.get("studentNum"))
+                .affiliation(RegistrationDto.get("affiliation"))
+                .department(RegistrationDto.get("department"))
+                .carNum(RegistrationDto.get("carNum"))
+                .phoneNum(RegistrationDto.get("phoneNum"))
+                .isLight(Boolean.parseBoolean(RegistrationDto.get("isLight")))
+                .isSaved(Boolean.parseBoolean(RegistrationDto.get("isSaved")))
+                .savedAt(Long.valueOf(RegistrationDto.get("savedAt")))
+                .build();
+        String registrationId = RegistrationDto.get("id");
+        registration.setSector(sector);
+
+        String createAt = RegistrationDto.get("createAt");
+        if (createAt != null) {
+            registration.setCreatedAt(LocalDateTime.parse(createAt));
+        }
+        if (registrationId != null) {
+            registration.setId(Long.valueOf(registrationId));
+        }
+        registration.setUser(userAdaptor.findById(Long.valueOf(RegistrationDto.get("userId"))));
+        registration.finalSave();
+
+        registrationAdaptor.save(registration);
+        registrationAdaptor.updateSavedAt(registration);
+    }
+
+}
+

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationSavingProcessor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/RegistrationSavingProcessor.java
@@ -43,7 +43,6 @@ public class RegistrationSavingProcessor {
         registration.finalSave();
 
         registrationAdaptor.save(registration);
-        registrationAdaptor.updateSavedAt(registration);
     }
 
     private Registration createRegistration(RegistrationInfo registrationInfo, Sector sector, User user) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/UserStatusProcess.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/UserStatusProcess.java
@@ -1,0 +1,34 @@
+package com.jnu.ticketapi.api.flow;
+
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class UserStatusProcess {
+
+    private final SectorAdaptor sectorAdaptor;
+    private final UserAdaptor userAdaptor;
+
+    @Transactional
+    public void process(Long userId, Long sectorId, int position) {
+        Sector sector = sectorAdaptor.findById(sectorId);
+        User user = userAdaptor.findById(userId);
+        Integer sectorCapacity = sector.getInitSectorCapacity();
+        Integer issueAmount = sector.getIssueAmount();
+        if (position <= sectorCapacity) {
+            user.success();
+        } else if (position <= issueAmount) {
+            user.prepare(position - sectorCapacity);
+        } else {
+            user.fail();
+        }
+
+        userAdaptor.save(user);
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/UserStatusProcessor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/flow/UserStatusProcessor.java
@@ -4,19 +4,20 @@ import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-public class UserStatusProcess {
+public class UserStatusProcessor {
 
     private final SectorAdaptor sectorAdaptor;
     private final UserAdaptor userAdaptor;
 
     @Transactional
-    public void process(Long userId, Long sectorId, int position) {
+    public void applyStatus(Long userId, Long sectorId, int position) {
         Sector sector = sectorAdaptor.findById(sectorId);
         User user = userAdaptor.findById(userId);
         Integer sectorCapacity = sector.getInitSectorCapacity();
@@ -28,7 +29,6 @@ public class UserStatusProcess {
         } else {
             user.fail();
         }
-
         userAdaptor.save(user);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -28,14 +28,15 @@ import com.jnu.ticketdomain.domains.registration.exception.NotFoundRegistrationE
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.redis.RedisService;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -124,7 +125,7 @@ public class RegistrationUseCase {
         validateEventPeriod(event);
 
         validateCaptchaUseCase.execute(requestDto.captchaCode(), requestDto.captchaAnswer());
-        checkDuplicateRegistration(email, eventId, requestDto.studentNum());
+        checkDuplicateRegistration(email, eventId);
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
 
@@ -223,9 +224,8 @@ public class RegistrationUseCase {
         return GetRegistrationsResponse.of(registrations);
     }
 
-    private void checkDuplicateRegistration(String email, Long eventId, String studentNum) {
-        if (registrationAdaptor.existsByEmailAndIsSavedTrue(email, eventId)
-                || registrationAdaptor.existsByStudentNumAndIsSavedTrue(studentNum, eventId)) {
+    private void checkDuplicateRegistration(String email, Long eventId) {
+        if (registrationAdaptor.existsByEmailAndIsSavedTrue(email, eventId)) {
             throw AlreadyExistRegistrationException.EXCEPTION;
         }
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -27,6 +27,7 @@ import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrat
 import com.jnu.ticketdomain.domains.registration.exception.NotFoundRegistrationException;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import com.jnu.ticketinfrastructure.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -134,61 +135,43 @@ public class RegistrationUseCase {
         return findResultByEmail(email, false, eventId)
                 .fold(
                         tempRegistration ->
-                                reFinalRegister(
-                                        tempRegistration,
-                                        registration,
-                                        sector,
-                                        user,
-                                        email,
-                                        eventId),
+                                reFinalRegister(tempRegistration, registration),
                         emptyCase ->
-                                saveRegistration(
-                                        registration, sector, currentUserId, email, eventId));
+                                saveRegistration(registration));
     }
 
-    private FinalSaveResponse reFinalRegister(
-            Registration tempRegistration,
-            Registration registration,
-            Sector sector,
-            User user,
-            String email,
-            Long eventId) {
+    private FinalSaveResponse reFinalRegister(Registration tempRegistration, Registration registration) {
+        Sector sector = registration.getSector();
         sector.checkEventLeft();
         registration.setId(tempRegistration.getId()); // update 치기 위해 Id 값을 채워줌
         registration.setCreatedAt(
                 tempRegistration.getCreatedAt()); // create_at이 null이 들어가지 않게 하기 위해 값을 채워줌
-        reFinalRegisterProcess(registration, user, email, sector.getId(), eventId);
+        RegistrationInfo registrationInfo = new RegistrationInfo(registration);
+
+
+        reFinalRegisterProcess(registrationInfo);
         return FinalSaveResponse.from(registration);
     }
 
-    private void reFinalRegisterProcess(
-            Registration registration, User user, String email, Long sectorId, Long eventId) {
-        eventWithDrawUseCase.issueEvent(registration, user.getId(), sectorId, eventId);
+    private void reFinalRegisterProcess(RegistrationInfo registrationInfo) {
+        eventWithDrawUseCase.issueEvent(registrationInfo);
         if (ableRedis) {
-            redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);
+            redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + registrationInfo.getEmail());
         }
     }
 
-    private FinalSaveResponse saveRegistration(
-            Registration registration,
-            Sector sector,
-            Long currentUserId,
-            String email,
-            Long eventId) {
+    private FinalSaveResponse saveRegistration(Registration registration){
+        Sector sector = registration.getSector();
         sector.checkEventLeft();
-        return saveRegistrationProcess(registration, sector, currentUserId, email, eventId);
+        return saveRegistrationProcess(registration);
     }
 
-    private FinalSaveResponse saveRegistrationProcess(
-            Registration registration,
-            Sector sector,
-            Long currentUserId,
-            String email,
-            Long eventId) {
+    private FinalSaveResponse saveRegistrationProcess(Registration registration) {
         //        Registration saveReg = saveAndFlush(registration);
-        eventWithDrawUseCase.issueEvent(registration, currentUserId, sector.getId(), eventId);
+        RegistrationInfo registrationInfo = new RegistrationInfo(registration);
+        eventWithDrawUseCase.issueEvent(registrationInfo);
         if (ableRedis) {
-            redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);
+            redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + registrationInfo.getEmail());
         }
         //        Events.raise(new EventIssuedEvent())
         return FinalSaveResponse.from(registration);

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -77,3 +77,25 @@ web:
   log:
     url-no-logging:
       - /api/swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: integration-test
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+captcha:
+  domain: dsrps7tt0ew8t.cloudfront.net
+
+ableDomainEvent: false
+
+web:
+  log:
+    url-no-logging:
+      - /api/swagger-ui.html

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -93,7 +93,7 @@ server:
 captcha:
   domain: dsrps7tt0ew8t.cloudfront.net
 
-ableDomainEvent: false
+ableDomainEvent: true
 
 web:
   log:

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -131,14 +131,13 @@ public class FlowTest {
                 new Setting(10, 30, 40)
         );
 
+        int resultWaitingSecond = 20;
+
         Integer capacityCountSum = settings.stream().map(Setting::capacity).reduce(0, Integer::sum);
         Integer reserveCountSum = settings.stream().map(Setting::reserve).reduce(0, Integer::sum);
         Integer userCountSum = settings.stream().map(Setting::requestCount).reduce(0, Integer::sum);
 
-        List<List<String>> userAccessTokens = settings.stream()
-                .map(Setting::requestCount)
-                .map(this::setUpUserData)
-                .toList();
+        List<List<String>> userAccessTokens = setUpAccessTokensPerSector(settings);
 
         String tempAccessToken = userAccessTokens.get(0).get(0);
         createEvent(tempAccessToken);
@@ -159,7 +158,7 @@ public class FlowTest {
             executorServiceForSector.submit(() -> finalSaveRequestToSector(sectorId, accessTokensPerSector, executorServiceInSector));
         }
 
-        Thread.sleep(30000);
+        Thread.sleep(resultWaitingSecond * 1000);
 
         // then
         List<User> usersWithResult = userRepository.findAll(Sort.by("id"));
@@ -176,6 +175,13 @@ public class FlowTest {
         assertPreparePerSector(usersWithResult, settings);
 
 
+    }
+
+    private List<List<String>> setUpAccessTokensPerSector(List<Setting> settings) {
+        return settings.stream()
+                .map(Setting::requestCount)
+                .map(this::setUpUserData)
+                .toList();
     }
 
     private void finalSaveRequestToSector(long sectorId, List<String> accessTokens, ExecutorService executorService) {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -132,12 +132,12 @@ public class FlowTest {
         Integer reserveCountSum = settings.stream().map(Setting::reserve).reduce(0, Integer::sum);
         Integer userCountSum = settings.stream().map(Setting::requestCount).reduce(0, Integer::sum);
 
-        List<Map<User, String>> usersWithToken = settings.stream()
+        List<List<String>> userAccessTokens = settings.stream()
                 .map(Setting::requestCount)
                 .map(this::setUpUserData)
                 .toList();
 
-        String tempAccessToken = usersWithToken.get(0).values().stream().findFirst().get();
+        String tempAccessToken = userAccessTokens.get(0).get(0);
         createEvent(tempAccessToken);
         createCaptcha();
         createSectors(settings);
@@ -240,7 +240,7 @@ public class FlowTest {
                 .build();
     }
 
-    private Map<User, String> setUpUserData(int userSize) {
+    private List<String> setUpUserData(int userSize) {
         List<User> users = saveUsers(userSize);
         return generateToken(users);
     }
@@ -259,13 +259,10 @@ public class FlowTest {
         return users;
     }
 
-    private Map<User, String> generateToken(List<User> users) {
-        Map<User, String> usersWithToken = new HashMap<>();
-        for (User user : users) {
-            String accessToken = jwtGenerator.generateAccessToken(user.getEmail(), user.getUserRole().name());
-            usersWithToken.put(user, accessToken);
-        }
-        return usersWithToken;
+    private List<String> generateToken(List<User> users) {
+        return users.stream()
+                .map(user -> jwtGenerator.generateAccessToken(user.getEmail(), user.getUserRole().name()))
+                .toList();
     }
 
     private void setEventPublic() {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -52,6 +52,11 @@ import static org.quartz.TriggerBuilder.newTrigger;
 @Testcontainers
 public class FlowTest {
 
+    private static final int ASYNC_CORE_POOL_SIZE = 1000;
+    private static final int ASYNC_MAX_POOL_SIZE = 1000;
+    private static final int ASYNC_QUEUE_CAPACITY = 50000;
+    private static final int HIKARI_MAXIMUM_POOL_SIZE = 2000;
+
     private static final int REDIS_PORT = 6379;
     private static final int MYSQL_PORT = 3306;
     private static final Long EVENT_VALUE = 1L;
@@ -76,6 +81,18 @@ public class FlowTest {
         );
         registry.add("spring.datasource.username", mysqlContainer::getUsername);
         registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+
+    @DynamicPropertySource
+    static void asyncTheadProperties(DynamicPropertyRegistry registry) {
+        registry.add("thread.core-pool-size", () -> ASYNC_CORE_POOL_SIZE);
+        registry.add("thread.max-pool-size", () -> ASYNC_MAX_POOL_SIZE);
+        registry.add("thread.queue-capacity", () -> ASYNC_QUEUE_CAPACITY);
+    }
+
+    @DynamicPropertySource
+    static void hikariProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.hikari.maximum-pool-size", () -> HIKARI_MAXIMUM_POOL_SIZE);
     }
 
     @Autowired

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -1,0 +1,55 @@
+package com.jnu.ticketapi;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.client.MockMvcWebTestClient;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@ActiveProfiles("integration-test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Testcontainers
+public class FlowTest {
+
+    public static final int REDIS_PORT = 6379;
+    public static final int MYSQL_PORT = 3306;
+
+    @Container
+    static MySQLContainer mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.40"))
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    static GenericContainer redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7"))
+            .withExposedPorts(REDIS_PORT);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redisContainer::getHost);
+        registry.add("spring.redis.port", () -> redisContainer.getMappedPort(REDIS_PORT));
+        registry.add("spring.datasource.url", () -> String.format(
+                "jdbc:mysql://%s:%d/%s", mysqlContainer.getHost(), mysqlContainer.getMappedPort(MYSQL_PORT), mysqlContainer.getDatabaseName())
+        );
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+
+    WebTestClient client;
+
+    @BeforeEach
+    void setup(WebApplicationContext context) {
+        client = MockMvcWebTestClient.bindToApplicationContext(context).build();
+    }
+
+}
+
+

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -53,8 +53,7 @@ import static org.quartz.TriggerBuilder.newTrigger;
 @Slf4j
 @ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
-public class FlowTest {
+public class FlowTest implements UsingContainers {
 
     private static final int ASYNC_CORE_POOL_SIZE = 1000;
     private static final int ASYNC_MAX_POOL_SIZE = 1000;

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -9,11 +9,12 @@ import com.jnu.ticketapi.api.sector.model.request.SectorRegisterRequest;
 import com.jnu.ticketapi.registration.FinalSaveRequestTestDataBuilder;
 import com.jnu.ticketapi.registration.TemporarySaveRequestTestDataBuilder;
 import com.jnu.ticketapi.security.JwtGenerator;
-import com.jnu.ticketbatch.config.ProcessQueueDataJob;
-import com.jnu.ticketbatch.config.QuartzJobLauncher;
 import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.repository.CaptchaRepository;
+import com.jnu.ticketdomain.domains.events.domain.Event;
+import com.jnu.ticketdomain.domains.events.domain.EventStatus;
+import com.jnu.ticketdomain.domains.events.out.EventLoadPort;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.repository.RegistrationRepository;
 import com.jnu.ticketdomain.domains.user.domain.User;
@@ -23,7 +24,7 @@ import com.jnu.ticketdomain.domains.user.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.quartz.*;
+import org.quartz.Scheduler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Sort;
@@ -42,8 +43,6 @@ import java.util.stream.IntStream;
 
 import static com.jnu.ticketdomain.domains.user.domain.UserStatus.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.quartz.JobBuilder.newJob;
-import static org.quartz.TriggerBuilder.newTrigger;
 
 @Slf4j
 @ActiveProfiles("integration-test")
@@ -75,9 +74,6 @@ public class FlowTest implements UsingContainers {
     WebTestClient client;
 
     @Autowired
-    Scheduler scheduler;
-
-    @Autowired
     JwtGenerator jwtGenerator;
 
     @Autowired
@@ -89,6 +85,9 @@ public class FlowTest implements UsingContainers {
     @Autowired
     RegistrationRepository registrationRepository;
 
+    @Autowired
+    EventLoadPort eventLoadPort;
+
     private record Setting(int capacity, int reserve, int requestCount) {
     }
 
@@ -96,19 +95,21 @@ public class FlowTest implements UsingContainers {
 
 
     /**
-     *  Setting record 통해서 구간별 여석, 예비, 요청 수 설정 가능
+     * Setting record 통해서 구간별 여석, 예비, 요청 수 설정 가능
      */
     @Test
     @DisplayName("여러 사용자의 최종 저장 요청 신청시, 여석에 맞게 합격, 예비, 불합격 수와 각 구간별 예비번호를 검증한다.")
     void flowTest() throws Exception {
         // given
         List<Setting> settings = List.of(
-                new Setting(10, 30, 40),
-                new Setting(10, 30, 40),
-                new Setting(10, 30, 40)
+                new Setting(10, 30, 80),
+                new Setting(10, 30, 80),
+                new Setting(10, 30, 80),
+                new Setting(10, 30, 80),
+                new Setting(10, 30, 80)
         );
 
-        int resultWaitingSecond = 20;
+        int resultWaitingSecond = 25;
 
         Integer capacityCountSum = settings.stream().map(Setting::capacity).reduce(0, Integer::sum);
         Integer reserveCountSum = settings.stream().map(Setting::reserve).reduce(0, Integer::sum);
@@ -117,15 +118,16 @@ public class FlowTest implements UsingContainers {
         List<List<String>> userAccessTokens = setUpAccessTokensPerSector(settings);
 
         String tempAccessToken = userAccessTokens.get(0).get(0);
-        createEvent(tempAccessToken);
+        int startAfterSec = 7;
+
+        createEvent(tempAccessToken, startAfterSec);
         createCaptcha();
         createSectors(settings);
         setEventPublic();
 
         temporalSaveRequest(userAccessTokens);
 
-        rescheduleJob();
-        Thread.sleep(1000);
+        waitingForEventOpen();
 
         // when
         ExecutorService executorServiceForSector = Executors.newFixedThreadPool(settings.size());
@@ -154,6 +156,19 @@ public class FlowTest implements UsingContainers {
         });
 
         assertPerSector(usersWithResult, settings);
+    }
+
+    private void waitingForEventOpen() throws InterruptedException {
+        while (true) {
+            try {
+                Event event = eventLoadPort.findById(EVENT_VALUE);
+                if (event.getEventStatus().equals(EventStatus.OPEN)) {
+                    break;
+                }
+            } catch (Exception e) {
+            }
+            Thread.sleep(5000);
+        }
     }
 
     private void temporalSaveRequest(List<List<String>> userAccessTokens) {
@@ -256,54 +271,6 @@ public class FlowTest implements UsingContainers {
         return usersGroupBySector;
     }
 
-    private void rescheduleJob() throws SchedulerException {
-        scheduler.clear();
-
-        JobDetail openJob = createEventOpenJob();
-        Trigger openTrigger = createEventOpenTrigger(openJob);
-
-        JobDetail processJob = createRegistrationProcessingJob();
-        Trigger processTrigger = createRegistrationProcessingTrigger(processJob);
-
-        scheduler.scheduleJob(processJob, processTrigger);
-        scheduler.scheduleJob(openJob, openTrigger);
-        scheduler.start();
-    }
-
-    private SimpleTrigger createRegistrationProcessingTrigger(JobDetail processJob) {
-        return newTrigger()
-                .withIdentity("REGISTRATION_PROCESSING_TRIGGER" + EVENT_VALUE, "testGroup")
-                .startNow()
-                .withSchedule(
-                        SimpleScheduleBuilder.simpleSchedule()
-                                .withIntervalInMilliseconds(400)
-                                .repeatForever())
-                .forJob(processJob)
-                .build();
-    }
-
-    private JobDetail createRegistrationProcessingJob() {
-        return newJob(ProcessQueueDataJob.class)
-                .withIdentity("REGISTRATION_PROCESSING_JOB" + EVENT_VALUE, "testGroup")
-                .usingJobData("eventId", EVENT_VALUE)
-                .build();
-    }
-
-    private Trigger createEventOpenTrigger(JobDetail eventOpenJob) {
-        return newTrigger()
-                .withIdentity("EVENT_OPEN_TRIGGER" + EVENT_VALUE, "testGroup")
-                .startNow()
-                .forJob(eventOpenJob)
-                .build();
-    }
-
-    private JobDetail createEventOpenJob() {
-        return newJob(QuartzJobLauncher.class)
-                .withIdentity("EVENT_OPEN_JOB" + EVENT_VALUE, "testGroup")
-                .usingJobData("eventId", EVENT_VALUE)
-                .build();
-    }
-
     private List<String> setUpUserData(int userSize) {
         List<User> users = saveUsers(userSize);
         return generateToken(users);
@@ -335,13 +302,13 @@ public class FlowTest implements UsingContainers {
                 .exchange().expectStatus().isOk();
     }
 
-    private void createEvent(String accessToken) {
+    private void createEvent(String accessToken, int startAfterSec) {
         client = client.mutate()
                 .defaultHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken)
                 .build();
 
         LocalDateTime now = LocalDateTime.now();
-        DateTimePeriod dateTimePeriod = new DateTimePeriod(now.plusSeconds(5), now.plusMinutes(10));
+        DateTimePeriod dateTimePeriod = new DateTimePeriod(now.plusSeconds(startAfterSec), now.plusMinutes(10));
 
         EventRegisterRequest registerRequest = new EventRegisterRequest(dateTimePeriod, "주차권 이벤트");
         client.post().uri("/v1/events")

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
@@ -1,0 +1,101 @@
+package com.jnu.ticketapi;
+
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+public class RedisTest {
+
+    private static final int REDIS_PORT = 6379;
+
+    @Container
+    static GenericContainer redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7"))
+            .withExposedPorts(REDIS_PORT);
+
+    @DynamicPropertySource
+    static void containerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redisContainer::getHost);
+        registry.add("spring.redis.port", () -> redisContainer.getMappedPort(REDIS_PORT));
+    }
+
+    @Autowired
+    private RedisRepository redisRepository;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @BeforeEach
+    void clearRedis() {
+        redisTemplate.execute((RedisCallback) connection -> {
+            connection.flushDb();
+            return null;
+        });
+    }
+
+
+    @Test
+    @DisplayName("레디스 스트림에서 첫번째 데이터를 조회힌다.")
+    void readFirstRecord() {
+        // given
+        String key = "key";
+        redisRepository.streamAdd(key, Map.of("eventId", "1"));
+        redisRepository.streamAdd(key, Map.of("eventId", "2"));
+
+        // when
+        List<MapRecord<String, String, String>> mapRecords = redisRepository.streamRead(key, "0", 1);
+
+
+        // then
+        MapRecord<String, String, String> mapRecord = mapRecords.get(0);
+        Map<String, String> content = mapRecord.getValue();
+
+        assertThat(content.get("eventId")).isEqualTo("1");
+        assertThat(mapRecords).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("레디스 스트림에서 lastId로 데이터를 조회힌다.")
+    void readById() {
+        // given
+        String key = "key";
+        redisRepository.streamAdd(key, Map.of("eventId", "1"));
+        redisRepository.streamAdd(key, Map.of("eventId", "2"));
+
+        List<MapRecord<String, String, String>> mapRecords = redisRepository.streamRead(key, "0", 1);
+        RecordId lastId = mapRecords.get(0).getId();
+
+        // when
+        List<MapRecord<String, String, String>> results = redisRepository.streamRead(key, lastId.getValue(), 1);
+
+        // then
+        MapRecord<String, String, String> result = results.get(0);
+        Map<String, String> content = result.getValue();
+
+        assertThat(content.get("eventId")).isEqualTo("2");
+        assertThat(mapRecords).hasSize(1);
+    }
+
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -26,7 +25,6 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -63,48 +61,6 @@ public class RedisTest {
 
 
     @Test
-    @DisplayName("레디스 스트림에서 첫번째 데이터를 조회힌다.")
-    void readFirstRecord() {
-        // given
-        String key = "key";
-        redisRepository.streamAdd(key, Map.of("eventId", "1"));
-        redisRepository.streamAdd(key, Map.of("eventId", "2"));
-
-        // when
-        List<MapRecord<String, String, String>> mapRecords = redisRepository.streamReadAfterId(key, RecordId.of("0-0"), 1);
-
-
-        // then
-        MapRecord<String, String, String> mapRecord = mapRecords.get(0);
-        Map<String, String> content = mapRecord.getValue();
-
-        assertThat(content.get("eventId")).isEqualTo("1");
-        assertThat(mapRecords).hasSize(1);
-    }
-
-    @Test
-    @DisplayName("레디스 스트림에서 lastId로 데이터를 조회힌다.")
-    void readById() {
-        // given
-        String key = "key";
-        redisRepository.streamAdd(key, Map.of("eventId", "1"));
-        redisRepository.streamAdd(key, Map.of("eventId", "2"));
-
-        List<MapRecord<String, String, String>> mapRecords = redisRepository.streamReadAfterId(key, RecordId.of("0-0"), 1);
-        RecordId lastId = mapRecords.get(0).getId();
-
-        // when
-        List<MapRecord<String, String, String>> results = redisRepository.streamReadAfterId(key, lastId, 1);
-
-        // then
-        MapRecord<String, String, String> result = results.get(0);
-        Map<String, String> content = result.getValue();
-
-        assertThat(content.get("eventId")).isEqualTo("2");
-        assertThat(mapRecords).hasSize(1);
-    }
-
-    @Test
     @DisplayName("레디스 스트림에서 데이터를 객체형태로 조회한다.")
     void readAsObject() {
         // given
@@ -131,7 +87,7 @@ public class RedisTest {
         redisRepository.streamAdd(key, registrationDto);
 
         // when
-        List<RegistrationInFoMapRecord> mapRecords = redisRepository.streamReadAfterId1(key, RecordId.of("0-0"), 1);
+        List<RegistrationInFoMapRecord> mapRecords = redisRepository.streamReadAfterId(key, RecordId.of("0-0"), 1);
 
         // then
         RegistrationInfo registrationInfo = mapRecords.get(0).registrationInfo();

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
@@ -4,7 +4,7 @@ import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.domain.UserRole;
-import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
+import com.jnu.ticketinfrastructure.model.RegistrationInFoRecord;
 import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,7 +87,7 @@ public class RedisTest {
         redisRepository.streamAdd(key, registrationDto);
 
         // when
-        List<RegistrationInFoMapRecord> mapRecords = redisRepository.streamReadAfterId(key, RecordId.of("0-0"), 1);
+        List<RegistrationInFoRecord> mapRecords = redisRepository.streamReadAfterId(key, RecordId.of("0-0"), 1);
 
         // then
         RegistrationInfo registrationInfo = mapRecords.get(0).registrationInfo();

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
@@ -1,5 +1,11 @@
 package com.jnu.ticketapi;
 
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserRole;
+import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +24,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -97,4 +104,48 @@ public class RedisTest {
         assertThat(mapRecords).hasSize(1);
     }
 
+    @Test
+    @DisplayName("레디스 스트림에서 데이터를 객체형태로 조회한다.")
+    void readAsObject() {
+        // given
+        String key = "key";
+
+        User user = new User("test", "test1", UserRole.USER);
+        Sector sector = new Sector("1", "test2", 1, 1);
+
+        LocalDateTime now = LocalDateTime.now();
+        Registration registration = Registration.builder()
+                .email("test3")
+                .name("test4")
+                .carNum("test5")
+                .isLight(true)
+                .studentNum("test6")
+                .eventId(1L)
+                .savedAt(1L)
+                .sector(sector)
+                .createdAt(now)
+                .user(user)
+                .build();
+
+        RegistrationInfo registrationDto = new RegistrationInfo(registration);
+        redisRepository.streamAdd(key, registrationDto);
+
+        // when
+        List<RegistrationInFoMapRecord> mapRecords = redisRepository.streamReadAfterId1(key, RecordId.of("0-0"), 1);
+
+        // then
+        RegistrationInfo registrationInfo = mapRecords.get(0).registrationInfo();
+        assertThat(registrationInfo.getUserId()).isEqualTo(null);
+        assertThat(registrationInfo.getEmail()).isEqualTo("test3");
+        assertThat(registrationInfo.getName()).isEqualTo("test4");
+        assertThat(registrationInfo.getCarNum()).isEqualTo("test5");
+        assertThat(registrationInfo.isLight()).isEqualTo(true);
+        assertThat(registrationInfo.getStudentNum()).isEqualTo("test6");
+        assertThat(registrationInfo.getEventId()).isEqualTo(1L);
+        assertThat(registrationInfo.getSavedAt()).isEqualTo(1L);
+        assertThat(registrationInfo.getSectorId()).isEqualTo(null);
+        assertThat(registrationInfo.getCreatedAt()).isEqualTo(now.toString());
+        assertThat(registrationInfo.getUserId()).isEqualTo(null);
+        System.out.println("registrationInfo = " + registrationInfo);
+    }
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/RedisTest.java
@@ -1,7 +1,6 @@
 package com.jnu.ticketapi;
 
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -65,7 +64,7 @@ public class RedisTest {
         redisRepository.streamAdd(key, Map.of("eventId", "2"));
 
         // when
-        List<MapRecord<String, String, String>> mapRecords = redisRepository.streamRead(key, "0", 1);
+        List<MapRecord<String, String, String>> mapRecords = redisRepository.streamReadAfterId(key, RecordId.of("0-0"), 1);
 
 
         // then
@@ -84,11 +83,11 @@ public class RedisTest {
         redisRepository.streamAdd(key, Map.of("eventId", "1"));
         redisRepository.streamAdd(key, Map.of("eventId", "2"));
 
-        List<MapRecord<String, String, String>> mapRecords = redisRepository.streamRead(key, "0", 1);
+        List<MapRecord<String, String, String>> mapRecords = redisRepository.streamReadAfterId(key, RecordId.of("0-0"), 1);
         RecordId lastId = mapRecords.get(0).getId();
 
         // when
-        List<MapRecord<String, String, String>> results = redisRepository.streamRead(key, lastId.getValue(), 1);
+        List<MapRecord<String, String, String>> results = redisRepository.streamReadAfterId(key, lastId, 1);
 
         // then
         MapRecord<String, String, String> result = results.get(0);

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/UsingContainers.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/UsingContainers.java
@@ -1,0 +1,37 @@
+package com.jnu.ticketapi;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public interface UsingContainers {
+
+    int REDIS_PORT = 6379;
+    int MYSQL_PORT = 3306;
+
+    @Container
+    MySQLContainer mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.40"))
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    GenericContainer redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7"))
+            .withExposedPorts(REDIS_PORT);
+
+    @DynamicPropertySource
+    static void containerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redisContainer::getHost);
+        registry.add("spring.redis.port", () -> redisContainer.getMappedPort(REDIS_PORT));
+        registry.add("spring.datasource.url", () -> String.format(
+                "jdbc:mysql://%s:%d/%s", mysqlContainer.getHost(), mysqlContainer.getMappedPort(MYSQL_PORT), mysqlContainer.getDatabaseName())
+        );
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/config/DatabaseCleaner.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/config/DatabaseCleaner.java
@@ -1,31 +1,68 @@
 package com.jnu.ticketapi.config;
 
 
-import java.util.ArrayList;
-import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
 import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Component
 public class DatabaseCleaner {
 
     private final List<String> tableNames = new ArrayList<>();
 
-    @PersistenceContext private EntityManager entityManager;
+    @PersistenceContext
+    private final EntityManager entityManager;
+    private final DataSource dataSource;
+
+    public DatabaseCleaner(DataSource dataSource, EntityManager entityManager) {
+        this.dataSource = dataSource;
+        this.entityManager = entityManager;
+    }
 
     // 바뀐부분 : 의존성 주입이후 초기화 수행 시 Table을 조회한다.
     @PostConstruct
     @SuppressWarnings("unchecked")
-    private void findDatabaseTableNames() {
-        List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
-        for (Object[] tableInfo : tableInfos) {
-            String tableName = (String) tableInfo[0];
-            tableNames.add(tableName);
+    private void findDatabaseTableNames() throws SQLException {
+        List<?> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
+        String databaseVendor = getDatabaseVendor();
+        if (databaseVendor.equals("MySQL")) {
+            extractFromMysql(tableInfos);
+        }
+
+        if (databaseVendor.equals("H2")) {
+            extractFromH2(tableInfos);
         }
     }
+
+    private String getDatabaseVendor() throws SQLException {
+        Connection connection = dataSource.getConnection();
+        DatabaseMetaData metaData = connection.getMetaData();
+        return metaData.getDatabaseProductName();
+    }
+
+    private void extractFromMysql(List<?> tableInfos) {
+        Object tableInfo = tableInfos.get(0);
+        String tableNames = (String) tableInfo;
+        this.tableNames.addAll(Arrays.stream(tableNames.split(",")).toList());
+    }
+
+    private void extractFromH2(List<?> tableInfos) {
+        for (Object tableInfo : tableInfos) {
+            Object[] tableNames = (Object[]) tableInfo;
+            this.tableNames.add((String) tableNames[0]);
+        }
+    }
+
 
     private void truncate() {
         entityManager

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/EventCreationEventHandler.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/EventCreationEventHandler.java
@@ -32,7 +32,7 @@ public class EventCreationEventHandler {
         try {
             eventRegisterJob.registerJob(event.getId(), event.getDateTimePeriod().getStartAt());
             eventRegisterJob.expiredJob(event.getId(), event.getDateTimePeriod().getEndAt());
-            eventRegisterJob.processQueueDataJob(
+            eventRegisterJob.dataProcessingJob(
                     event.getId(),
                     event.getDateTimePeriod().getStartAt(),
                     event.getDateTimePeriod().getEndAt());

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/EventUpdatedEventHandler.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/EventUpdatedEventHandler.java
@@ -38,7 +38,7 @@ public class EventUpdatedEventHandler {
                     event.getId(), eventUpdateEvent.getDateTimePeriod().getStartAt());
             eventRegisterJob.expiredJob(
                     event.getId(), eventUpdateEvent.getDateTimePeriod().getEndAt());
-            eventRegisterJob.processQueueDataJob(
+            eventRegisterJob.dataProcessingJob(
                     event.getId(),
                     event.getDateTimePeriod().getStartAt(),
                     event.getDateTimePeriod().getEndAt());

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/DataProcessingJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/DataProcessingJob.java
@@ -1,0 +1,46 @@
+package com.jnu.ticketbatch.config;
+
+import com.jnu.ticketbatch.flow.DataProcessor;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.events.repository.SectorRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@DisallowConcurrentExecution
+public class DataProcessingJob implements Job {
+
+    @Autowired
+    private SectorRepository sectorRepository;
+
+    @Autowired
+    private DataProcessor dataProcessor;
+
+    public DataProcessingJob() {
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
+        List<Sector> sectors = sectorRepository.findByEventId(eventId);
+        ExecutorService executorService = Executors.newFixedThreadPool(sectors.size());
+        for (Sector sector : sectors) {
+            executorService.submit(() -> {
+                try {
+                    dataProcessor.start(sector.getId());
+                } catch (Exception e) {
+                    log.error("에러발생", e);
+                }
+            });
+        }
+
+    }
+}

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/DataProcessor.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/DataProcessor.java
@@ -1,14 +1,14 @@
 package com.jnu.ticketbatch.flow;
 
+import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import com.jnu.ticketinfrastructure.service.RedisStreamRegistrationBroker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Component
@@ -24,12 +24,11 @@ public class DataProcessor {
         RecordId recordId = RecordId.of("0-0");
 
         while (true) {
-            List<MapRecord<String, String, String>> records = broker.readAfterId(sectorId, recordId, DATA_BATCH_SIZE);
-            for (MapRecord<String, String, String> record : records) {
-
-                Map<String, String> content = record.getValue();
-                registrationProcessor.process(content);
-                recordId = record.getId();
+            List<RegistrationInFoMapRecord> records = broker.readAfterId(sectorId, recordId, DATA_BATCH_SIZE);
+            for (RegistrationInFoMapRecord record : records) {
+                RegistrationInfo registrationInfo = record.registrationInfo();
+                registrationProcessor.process(registrationInfo);
+                recordId = record.recordId();
             }
         }
     }

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/DataProcessor.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/DataProcessor.java
@@ -1,0 +1,38 @@
+package com.jnu.ticketbatch.flow;
+
+import com.jnu.ticketinfrastructure.service.RedisStreamRegistrationBroker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class DataProcessor {
+
+    private static final int DATA_BATCH_SIZE = 10;
+
+    private final RedisStreamRegistrationBroker broker;
+    private final RegistrationProcessor registrationProcessor;
+
+    public void start(Long sectorId) {
+        RecordId recordId = RecordId.of("0-0");
+
+        while (true) {
+            List<MapRecord<String, String, String>> records = broker.readAfterId(sectorId, recordId, DATA_BATCH_SIZE);
+            for (MapRecord<String, String, String> record : records) {
+
+                Map<String, String> content = record.getValue();
+                registrationProcessor.process(content);
+                recordId = record.getId();
+            }
+        }
+    }
+
+
+}

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/DataProcessor.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/DataProcessor.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketbatch.flow;
 
-import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
+import com.jnu.ticketinfrastructure.model.RegistrationInFoRecord;
 import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import com.jnu.ticketinfrastructure.service.RedisStreamRegistrationBroker;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +24,8 @@ public class DataProcessor {
         RecordId recordId = RecordId.of("0-0");
 
         while (true) {
-            List<RegistrationInFoMapRecord> records = broker.readAfterId(sectorId, recordId, DATA_BATCH_SIZE);
-            for (RegistrationInFoMapRecord record : records) {
+            List<RegistrationInFoRecord> records = broker.readAfterId(sectorId, recordId, DATA_BATCH_SIZE);
+            for (RegistrationInFoRecord record : records) {
                 RegistrationInfo registrationInfo = record.registrationInfo();
                 registrationProcessor.process(registrationInfo);
                 recordId = record.recordId();

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/RegistrationProcessor.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/RegistrationProcessor.java
@@ -1,0 +1,8 @@
+package com.jnu.ticketbatch.flow;
+
+import java.util.Map;
+
+public interface RegistrationProcessor {
+
+    boolean process(Map<String, String> registration);
+}

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/RegistrationProcessor.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/RegistrationProcessor.java
@@ -1,8 +1,12 @@
 package com.jnu.ticketbatch.flow;
 
+
+import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
+
 import java.util.Map;
 
 public interface RegistrationProcessor {
 
-    boolean process(Map<String, String> registration);
+    boolean process(RegistrationInfo registrationInfo);
 }

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/RegistrationProcessor.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/flow/RegistrationProcessor.java
@@ -1,10 +1,7 @@
 package com.jnu.ticketbatch.flow;
 
 
-import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
 import com.jnu.ticketinfrastructure.model.RegistrationInfo;
-
-import java.util.Map;
 
 public interface RegistrationProcessor {
 

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
@@ -3,7 +3,7 @@ package com.jnu.ticketbatch.job;
 import static org.quartz.JobBuilder.newJob;
 import static org.quartz.TriggerBuilder.newTrigger;
 
-import com.jnu.ticketbatch.config.ProcessQueueDataJob;
+import com.jnu.ticketbatch.config.DataProcessingJob;
 import com.jnu.ticketbatch.config.QuartzJobLauncher;
 import com.jnu.ticketbatch.expired.BatchQuartzJob;
 import com.jnu.ticketdomain.domains.events.EventExpiredEventRaiseGateway;
@@ -104,36 +104,32 @@ public class EventRegisterJob implements Job {
         scheduler.scheduleJob(expiredEventQuartzJob, reserveTrigger);
     }
 
-    public void processQueueDataJob(Long eventId, LocalDateTime startAt, LocalDateTime endAt)
+    public void dataProcessingJob(Long eventId, LocalDateTime startAt, LocalDateTime endAt)
             throws Exception {
         scheduler.start();
 
         JobDataMap jobDataMap = new JobDataMap();
         jobDataMap.put(EVENT_ID, eventId);
 
-        JobDetail processQueueDataJob =
-                newJob(ProcessQueueDataJob.class)
-                        .withIdentity("PROCESS_QUEUE_DATA_JOB" + eventId, GROUP)
+        JobDetail dataProcessingJob =
+                newJob(DataProcessingJob.class)
+                        .withIdentity("DATA_PROCESSING_JOB" + eventId, GROUP)
                         .usingJobData(jobDataMap) // eventId만 JobDataMap에 추가
                         .build();
 
         Date start = Date.from(startAt.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
         Date end = Date.from(endAt.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
 
-        Trigger reserveTrigger =
+        Trigger dataProcessingTrigger =
                 newTrigger()
-                        .withIdentity("PROCESS_QUEUE_DATA_TRIGGER" + eventId, GROUP)
+                        .withIdentity("DATA_PROCESSING_TRIGGER" + eventId, GROUP)
                         .startAt(start)
                         .endAt(end)
-                        .withSchedule(
-                                SimpleScheduleBuilder.simpleSchedule()
-                                        .withIntervalInMilliseconds(400)
-                                        .repeatForever())
-                        .forJob(processQueueDataJob)
+                        .forJob(dataProcessingJob)
                         .build();
 
         log.info(">>>>> ProcessQueueData 스케줄링 등록");
 
-        scheduler.scheduleJob(processQueueDataJob, reserveTrigger);
+        scheduler.scheduleJob(dataProcessingJob, dataProcessingTrigger);
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -31,7 +31,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @DynamicUpdate
 @AllArgsConstructor(access = AccessLevel.PUBLIC) // 생성자를 public으로 변경
 @Where(clause = "is_deleted = false")
-@ToString
 public class Registration {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -179,6 +178,28 @@ public class Registration {
         this.isLight = registration.isLight();
         this.phoneNum = registration.getPhoneNum();
         this.sector = registration.getSector();
+    }
+
+    @Override
+    public String toString() {
+        return "Registration{" +
+                "id=" + id +
+                ", email='" + email + '\'' +
+                ", name='" + name + '\'' +
+                ", studentNum='" + studentNum + '\'' +
+                ", affiliation='" + affiliation + '\'' +
+                ", department='" + department + '\'' +
+                ", carNum='" + carNum + '\'' +
+                ", isLight=" + isLight +
+                ", phoneNum='" + phoneNum + '\'' +
+                ", createdAt=" + createdAt +
+                ", isSaved=" + isSaved +
+                ", isDeleted=" + isDeleted +
+                ", savedAt=" + savedAt +
+                ", user=" + user.getId() +
+                ", sector=" + sector.getId() +
+                ", eventId=" + eventId +
+                '}';
     }
 
     public void setSector(Sector sector) {

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -101,7 +101,6 @@ spring:
   quartz:
     jdbc:
       initialize-schema: always
-
 ---
 
 spring:
@@ -207,3 +206,17 @@ management:
     redis:
       enabled: ${ABLE_REDIS:true}
 
+---
+spring:
+  config:
+    activate:
+      on-profile: integration-test
+  jpa:
+    show-sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: create-drop
+
+  quartz:
+    jdbc:
+      initialize-schema: always

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -220,3 +220,8 @@ spring:
   quartz:
     jdbc:
       initialize-schema: always
+
+thread:
+  core-pool-size: 10
+  max-pool-size: 20
+  queue-capacity: 100

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
@@ -13,7 +13,7 @@ import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-@Profile("!test")
+@Profile({"!test","integration-test"})
 @EnableAsync
 @Configuration
 @RequiredArgsConstructor

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
@@ -3,6 +3,8 @@ package com.jnu.ticketinfrastructure.config.redis;
 
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import java.time.Duration;
+
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -68,17 +70,17 @@ public class RedisConfig {
         return redisTemplate;
     }
 
-
-    @ConditionalOnExpression("${ableRedis:true}")
-    public RedisTemplate<String, String> redisTemplate() {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    @Bean
+    public RedisTemplate<String, RegistrationInfo> redisTemplateForStream() {
+        RedisTemplate<String, RegistrationInfo> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
-        StringRedisSerializer stringSerializer = new StringRedisSerializer();
-        redisTemplate.setKeySerializer(stringSerializer);
-        redisTemplate.setValueSerializer(stringSerializer);
-        redisTemplate.setHashKeySerializer(stringSerializer);
-        redisTemplate.setHashValueSerializer(stringSerializer);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        Jackson2JsonRedisSerializer<RegistrationInfo> serializer =
+                new Jackson2JsonRedisSerializer<>(RegistrationInfo.class);
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(serializer);
         return redisTemplate;
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
@@ -47,7 +47,7 @@ public class RedisConfig {
 
         LettuceClientConfiguration clientConfig =
                 LettuceClientConfiguration.builder()
-                        .commandTimeout(Duration.ofSeconds(1))
+                        .commandTimeout(Duration.ofSeconds(10))
                         .shutdownTimeout(Duration.ZERO)
                         .build();
         return new LettuceConnectionFactory(redisConfig, clientConfig);

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
@@ -53,9 +53,9 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisConfig, clientConfig);
     }
 
-    @Bean(name = "redisTemplate")
+    @Bean(name = "customRedisTemplate")
     @ConditionalOnExpression("${ableRedis:true}")
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> customRedisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
@@ -65,6 +65,20 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(serializer);
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashValueSerializer(serializer);
+        return redisTemplate;
+    }
+
+
+    @ConditionalOnExpression("${ableRedis:true}")
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        redisTemplate.setKeySerializer(stringSerializer);
+        redisTemplate.setValueSerializer(stringSerializer);
+        redisTemplate.setHashKeySerializer(stringSerializer);
+        redisTemplate.setHashValueSerializer(stringSerializer);
         return redisTemplate;
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/RegistrationInFoMapRecord.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/RegistrationInFoMapRecord.java
@@ -1,0 +1,7 @@
+package com.jnu.ticketinfrastructure.model;
+
+import org.springframework.data.redis.connection.stream.RecordId;
+
+public record RegistrationInFoMapRecord(RecordId recordId, RegistrationInfo registrationInfo) {
+
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/RegistrationInFoRecord.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/RegistrationInFoRecord.java
@@ -2,6 +2,6 @@ package com.jnu.ticketinfrastructure.model;
 
 import org.springframework.data.redis.connection.stream.RecordId;
 
-public record RegistrationInFoMapRecord(RecordId recordId, RegistrationInfo registrationInfo) {
+public record RegistrationInFoRecord(RecordId recordId, RegistrationInfo registrationInfo) {
 
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/RegistrationInfo.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/RegistrationInfo.java
@@ -3,6 +3,7 @@ package com.jnu.ticketinfrastructure.model;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.data.redis.connection.stream.RecordId;
 
 import java.time.LocalDateTime;
 
@@ -49,10 +50,34 @@ public class RegistrationInfo {
         this.eventId = registration.getEventId();
     }
 
+    private RegistrationInfo(RegistrationInfo registrationInfo, Long savedAt) {
+        this.id = registrationInfo.getId();
+        this.email = registrationInfo.getEmail();
+        this.name = registrationInfo.getName();
+        this.studentNum = registrationInfo.getStudentNum();
+        this.affiliation = registrationInfo.getAffiliation();
+        this.department = registrationInfo.getDepartment();
+        this.carNum = registrationInfo.getCarNum();
+        this.light = registrationInfo.isLight();
+        this.phoneNum = registrationInfo.getPhoneNum();
+        this.createdAt = registrationInfo.getCreatedAt();
+        this.saved = registrationInfo.isSaved();
+        this.deleted = registrationInfo.isDeleted();
+        this.savedAt = savedAt;
+        this.userId = registrationInfo.getUserId();
+        this.sectorId = registrationInfo.getSectorId();
+        this.eventId = registrationInfo.getEventId();
+    }
+
     private String getCreatedAt(LocalDateTime localDateTime) {
         if (localDateTime == null) {
             return null;
         }
         return localDateTime.toString();
+    }
+
+    public RegistrationInfo setSavedAt(RecordId recordId) {
+        String savedAt = recordId.getValue().split("-")[0];
+        return new RegistrationInfo(this, Long.parseLong(savedAt));
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/RegistrationInfo.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/RegistrationInfo.java
@@ -1,0 +1,58 @@
+package com.jnu.ticketinfrastructure.model;
+
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+public class RegistrationInfo {
+
+    private Long id;
+    private String email;
+    private String name;
+    private String studentNum;
+    private String affiliation;
+    private String department;
+    private String carNum;
+    private boolean light;
+    private String phoneNum;
+    private String createdAt;
+    private boolean saved;
+    private boolean deleted;
+    private Long savedAt;
+    private Long userId;
+    private Long sectorId;
+    private Long eventId;
+
+    protected RegistrationInfo() {
+    }
+
+    public RegistrationInfo(Registration registration) {
+        this.id = registration.getId();
+        this.email = registration.getEmail();
+        this.name = registration.getName();
+        this.studentNum = registration.getStudentNum();
+        this.affiliation = registration.getAffiliation();
+        this.department = registration.getDepartment();
+        this.carNum = registration.getCarNum();
+        this.light = registration.isLight();
+        this.phoneNum = registration.getPhoneNum();
+        this.createdAt = getCreatedAt(registration.getCreatedAt());
+        this.saved = registration.isSaved();
+        this.deleted = registration.isDeleted();
+        this.savedAt = registration.getSavedAt();
+        this.userId = registration.getUser().getId();
+        this.sectorId = registration.getSector().getId();
+        this.eventId = registration.getEventId();
+    }
+
+    private String getCreatedAt(LocalDateTime localDateTime) {
+        if (localDateTime == null) {
+            return null;
+        }
+        return localDateTime.toString();
+    }
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,6 +3,8 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.connection.ReturnType;
@@ -21,21 +23,55 @@ import java.util.*;
 @ConditionalOnExpression("${ableRedis:true}")
 public class RedisRepository {
 
+    private static final String REGISTRATION_INFO_KEY = "registrationInfo";
+
     private final RedisTemplate<String, Object> redisTemplate;
     private final RedisTemplate<String, String> redisTemplateForStream;
+    private final RedisTemplate<String, RegistrationInfo> redisTemplateForRegistration;
     private final ObjectMapper objectMapper;
 
-    public RedisRepository(RedisTemplate<String, Object> redisTemplate, RedisTemplate<String, String> redisTemplateForStream
+    public RedisRepository(
+            RedisTemplate<String, Object> redisTemplate,
+            RedisTemplate<String, String> redisTemplateForStream,
+            RedisTemplate<String, RegistrationInfo> redisTemplateForRegistration
     ) {
         this.redisTemplate = redisTemplate;
         this.redisTemplateForStream = redisTemplateForStream;
         this.objectMapper = new ObjectMapper();
+        this.redisTemplateForRegistration = redisTemplateForRegistration;
     }
 
 
     public void streamAdd(String key, Map<?, ?> content) {
         redisTemplateForStream.opsForStream().add(key, content);
     }
+
+    public List<RegistrationInFoMapRecord> streamReadAfterId1(String key, RecordId id, int count) {
+        StreamReadOptions readOption = StreamReadOptions
+                .empty()
+                .block(Duration.ofSeconds(3))
+                .count(count);
+        StreamOffset<String> offset = StreamOffset.create(key, ReadOffset.from(id));
+
+        StreamOperations<String, String, RegistrationInfo> streamOps = redisTemplateForRegistration.opsForStream();
+        List<MapRecord<String, String, RegistrationInfo>> mapRecords = streamOps.read(readOption, offset);
+        return convertToRegistrationInfoRecord(mapRecords);
+    }
+
+    private List<RegistrationInFoMapRecord> convertToRegistrationInfoRecord(List<MapRecord<String, String, RegistrationInfo>> mapRecords) {
+        List<RegistrationInFoMapRecord> result = new ArrayList<>();
+        for (MapRecord<String, String, RegistrationInfo> mapRecord : mapRecords) {
+            RegistrationInfo registrationInfo = mapRecord.getValue().get(REGISTRATION_INFO_KEY);
+            result.add(new RegistrationInFoMapRecord(mapRecord.getId(), registrationInfo));
+        }
+        return result;
+    }
+
+    public void streamAdd(String key, RegistrationInfo registrationDto) {
+        Map<String, RegistrationInfo> content = Map.of(REGISTRATION_INFO_KEY, registrationDto);
+        redisTemplateForRegistration.opsForStream().add(key, content);
+    }
+
 
     public List<MapRecord<String, String, String>> streamReadAfterId(String key, RecordId id, int count) {
         StreamReadOptions readOption = StreamReadOptions

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -51,6 +51,14 @@ public class RedisRepository {
         return streamOps.read(readOption, offset);
     }
 
+    public Long increment(String key) {
+        return redisTemplate.opsForValue().increment(key);
+    }
+
+    public Long decrement(String key) {
+        return redisTemplate.opsForValue().decrement(key);
+    }
+
     public Boolean zAdd(String key, Object value, Double score) {
         return redisTemplate.opsForZSet().add(key, value, score);
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -43,7 +43,7 @@ public class RedisRepository {
     public List<MapRecord<String, String, String>> streamRead(String key, String lastId, int count) {
         StreamReadOptions readOption = StreamReadOptions
                 .empty()
-                .block(Duration.ofMinutes(1))
+                .block(Duration.ofSeconds(3))
                 .count(count);
         StreamOffset<String> offset = StreamOffset.create(key, ReadOffset.from(lastId));
 

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -58,7 +58,8 @@ public class RedisRepository {
         List<RegistrationInFoRecord> result = new ArrayList<>();
         for (MapRecord<String, String, RegistrationInfo> mapRecord : mapRecords) {
             RegistrationInfo registrationInfo = mapRecord.getValue().get(REGISTRATION_INFO_KEY);
-            result.add(new RegistrationInFoRecord(mapRecord.getId(), registrationInfo));
+            RegistrationInfo newRegistrationInfo = registrationInfo.setSavedAt(mapRecord.getId());
+            result.add(new RegistrationInFoRecord(mapRecord.getId(), newRegistrationInfo));
         }
         return result;
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,7 +3,7 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
-import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
+import com.jnu.ticketinfrastructure.model.RegistrationInFoRecord;
 import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -42,7 +42,7 @@ public class RedisRepository {
     }
 
 
-    public List<RegistrationInFoMapRecord> streamReadAfterId(String key, RecordId id, int count) {
+    public List<RegistrationInFoRecord> streamReadAfterId(String key, RecordId id, int count) {
         StreamReadOptions readOption = StreamReadOptions
                 .empty()
                 .block(Duration.ofSeconds(3))
@@ -54,11 +54,11 @@ public class RedisRepository {
         return convertToRegistrationInfoRecord(mapRecords);
     }
 
-    private List<RegistrationInFoMapRecord> convertToRegistrationInfoRecord(List<MapRecord<String, String, RegistrationInfo>> mapRecords) {
-        List<RegistrationInFoMapRecord> result = new ArrayList<>();
+    private List<RegistrationInFoRecord> convertToRegistrationInfoRecord(List<MapRecord<String, String, RegistrationInfo>> mapRecords) {
+        List<RegistrationInFoRecord> result = new ArrayList<>();
         for (MapRecord<String, String, RegistrationInfo> mapRecord : mapRecords) {
             RegistrationInfo registrationInfo = mapRecord.getValue().get(REGISTRATION_INFO_KEY);
-            result.add(new RegistrationInFoMapRecord(mapRecord.getId(), registrationInfo));
+            result.add(new RegistrationInFoRecord(mapRecord.getId(), registrationInfo));
         }
         return result;
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,27 +3,52 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
-import java.util.LinkedList;
-import java.util.Queue;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.*;
 
 @Repository
 @Slf4j
 @ConditionalOnExpression("${ableRedis:true}")
 public class RedisRepository {
+
     private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplateForStream;
     private final ObjectMapper objectMapper;
 
-    public RedisRepository(RedisTemplate<String, Object> redisTemplate) {
+    public RedisRepository(RedisTemplate<String, Object> redisTemplate, RedisTemplate<String, String> redisTemplateForStream
+    ) {
         this.redisTemplate = redisTemplate;
+        this.redisTemplateForStream = redisTemplateForStream;
         this.objectMapper = new ObjectMapper();
+    }
+
+
+    public void streamAdd(String key, Map<?, ?> content) {
+        redisTemplateForStream.opsForStream().add(key, content);
+    }
+
+    public List<MapRecord<String, String, String>> streamRead(String key, String lastId, int count) {
+        StreamReadOptions readOption = StreamReadOptions
+                .empty()
+                .block(Duration.ofMinutes(1))
+                .count(count);
+        StreamOffset<String> offset = StreamOffset.create(key, ReadOffset.from(lastId));
+
+        StreamOperations<String, String, String> streamOps = redisTemplateForStream.opsForStream();
+        return streamOps.read(readOption, offset);
     }
 
     public Boolean zAdd(String key, Object value, Double score) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -42,11 +42,7 @@ public class RedisRepository {
     }
 
 
-    public void streamAdd(String key, Map<?, ?> content) {
-        redisTemplateForStream.opsForStream().add(key, content);
-    }
-
-    public List<RegistrationInFoMapRecord> streamReadAfterId1(String key, RecordId id, int count) {
+    public List<RegistrationInFoMapRecord> streamReadAfterId(String key, RecordId id, int count) {
         StreamReadOptions readOption = StreamReadOptions
                 .empty()
                 .block(Duration.ofSeconds(3))
@@ -70,17 +66,6 @@ public class RedisRepository {
     public void streamAdd(String key, RegistrationInfo registrationDto) {
         Map<String, RegistrationInfo> content = Map.of(REGISTRATION_INFO_KEY, registrationDto);
         redisTemplateForRegistration.opsForStream().add(key, content);
-    }
-
-
-    public List<MapRecord<String, String, String>> streamReadAfterId(String key, RecordId id, int count) {
-        StreamReadOptions readOption = StreamReadOptions
-                .empty()
-                .block(Duration.ofSeconds(3))
-                .count(count);
-        StreamOffset<String> offset = StreamOffset.create(key, ReadOffset.from(id));
-        StreamOperations<String, String, String> streamOps = redisTemplateForStream.opsForStream();
-        return streamOps.read(readOption, offset);
     }
 
     public Long increment(String key) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -6,10 +6,7 @@ import com.jnu.ticketinfrastructure.model.ChatMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.connection.ReturnType;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.StreamOffset;
-import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StreamOperations;
@@ -40,13 +37,12 @@ public class RedisRepository {
         redisTemplateForStream.opsForStream().add(key, content);
     }
 
-    public List<MapRecord<String, String, String>> streamRead(String key, String lastId, int count) {
+    public List<MapRecord<String, String, String>> streamReadAfterId(String key, RecordId id, int count) {
         StreamReadOptions readOption = StreamReadOptions
                 .empty()
                 .block(Duration.ofSeconds(3))
                 .count(count);
-        StreamOffset<String> offset = StreamOffset.create(key, ReadOffset.from(lastId));
-
+        StreamOffset<String> offset = StreamOffset.create(key, ReadOffset.from(id));
         StreamOperations<String, String, String> streamOps = redisTemplateForStream.opsForStream();
         return streamOps.read(readOption, offset);
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/RedisStreamRegistrationBroker.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/RedisStreamRegistrationBroker.java
@@ -4,6 +4,7 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -14,7 +15,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
-public class RedisStreamRegistrationBroker  {
+public class RedisStreamRegistrationBroker {
 
     public static final String STREAM_KEY_SECTOR = "stream-key-sector-";
 
@@ -26,8 +27,8 @@ public class RedisStreamRegistrationBroker  {
         redisRepository.streamAdd(streamKey, content);
     }
 
-    public List<MapRecord<String, String, String>> read(Long sectorId, String lastId, int count) {
-        return redisRepository.streamRead(STREAM_KEY_SECTOR + sectorId, lastId, count);
+    public List<MapRecord<String, String, String>> readAfterId(Long sectorId, RecordId id, int count) {
+        return redisRepository.streamReadAfterId(STREAM_KEY_SECTOR + sectorId, id, count);
     }
 
     private Map<String, String> createRegistrationContent(Registration registration, Long userId, Long sectorId, Long eventId) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/RedisStreamRegistrationBroker.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/RedisStreamRegistrationBroker.java
@@ -1,0 +1,59 @@
+package com.jnu.ticketinfrastructure.service;
+
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+@Service
+@RequiredArgsConstructor
+public class RedisStreamRegistrationBroker  {
+
+    public static final String STREAM_KEY_SECTOR = "stream-key-sector-";
+
+    private final RedisRepository redisRepository;
+
+    public void send(Registration registration, Long userId, Long sectorId, Long eventId) {
+        String streamKey = STREAM_KEY_SECTOR + sectorId;
+        Map<String, String> content = createRegistrationContent(registration, userId, sectorId, eventId);
+        redisRepository.streamAdd(streamKey, content);
+    }
+
+    public List<MapRecord<String, String, String>> read(Long sectorId, String lastId, int count) {
+        return redisRepository.streamRead(STREAM_KEY_SECTOR + sectorId, lastId, count);
+    }
+
+    private Map<String, String> createRegistrationContent(Registration registration, Long userId, Long sectorId, Long eventId) {
+        Map<String, String> content = new HashMap<>();
+        content.put("userId", String.valueOf(userId));
+        content.put("eventId", String.valueOf(eventId));
+        content.put("sectorId", String.valueOf(sectorId));
+        content.put("email", registration.getEmail());
+        content.put("name", registration.getName());
+        content.put("studentNum", registration.getStudentNum());
+        content.put("affiliation", registration.getAffiliation());
+        content.put("department", registration.getDepartment());
+        content.put("carNum", registration.getCarNum());
+        content.put("phoneNum", registration.getPhoneNum());
+        content.put("isDeleted", String.valueOf(registration.isDeleted()));
+        content.put("isLight", String.valueOf(registration.isLight()));
+        content.put("isSaved", String.valueOf(registration.isSaved()));
+        content.put("savedAt", String.valueOf(registration.getSavedAt()));
+        Long id = registration.getId();
+        if (id != null) {
+            content.put("id", String.valueOf(id));
+        }
+        LocalDateTime createdAt = registration.getCreatedAt();
+        if (createdAt != null) {
+            content.put("createdAt", createdAt.toString());
+        }
+        return content;
+    }
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/RedisStreamRegistrationBroker.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/RedisStreamRegistrationBroker.java
@@ -1,7 +1,7 @@
 package com.jnu.ticketinfrastructure.service;
 
 
-import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
+import com.jnu.ticketinfrastructure.model.RegistrationInFoRecord;
 import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public class RedisStreamRegistrationBroker {
         redisRepository.streamAdd(streamKey, registrationDto);
     }
 
-    public List<RegistrationInFoMapRecord> readAfterId(Long sectorId, RecordId id, int count) {
+    public List<RegistrationInFoRecord> readAfterId(Long sectorId, RecordId id, int count) {
         return redisRepository.streamReadAfterId(STREAM_KEY_SECTOR + sectorId, id, count);
     }
 

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/RedisStreamRegistrationBroker.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/RedisStreamRegistrationBroker.java
@@ -1,17 +1,14 @@
 package com.jnu.ticketinfrastructure.service;
 
-import com.jnu.ticketdomain.domains.registration.domain.Registration;
+
+import com.jnu.ticketinfrastructure.model.RegistrationInFoMapRecord;
+import com.jnu.ticketinfrastructure.model.RegistrationInfo;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
 
 @Service
 @RequiredArgsConstructor
@@ -21,40 +18,13 @@ public class RedisStreamRegistrationBroker {
 
     private final RedisRepository redisRepository;
 
-    public void send(Registration registration, Long userId, Long sectorId, Long eventId) {
-        String streamKey = STREAM_KEY_SECTOR + sectorId;
-        Map<String, String> content = createRegistrationContent(registration, userId, sectorId, eventId);
-        redisRepository.streamAdd(streamKey, content);
+    public void send(RegistrationInfo registrationDto) {
+        String streamKey = STREAM_KEY_SECTOR + registrationDto.getSectorId();
+        redisRepository.streamAdd(streamKey, registrationDto);
     }
 
-    public List<MapRecord<String, String, String>> readAfterId(Long sectorId, RecordId id, int count) {
+    public List<RegistrationInFoMapRecord> readAfterId(Long sectorId, RecordId id, int count) {
         return redisRepository.streamReadAfterId(STREAM_KEY_SECTOR + sectorId, id, count);
     }
 
-    private Map<String, String> createRegistrationContent(Registration registration, Long userId, Long sectorId, Long eventId) {
-        Map<String, String> content = new HashMap<>();
-        content.put("userId", String.valueOf(userId));
-        content.put("eventId", String.valueOf(eventId));
-        content.put("sectorId", String.valueOf(sectorId));
-        content.put("email", registration.getEmail());
-        content.put("name", registration.getName());
-        content.put("studentNum", registration.getStudentNum());
-        content.put("affiliation", registration.getAffiliation());
-        content.put("department", registration.getDepartment());
-        content.put("carNum", registration.getCarNum());
-        content.put("phoneNum", registration.getPhoneNum());
-        content.put("isDeleted", String.valueOf(registration.isDeleted()));
-        content.put("isLight", String.valueOf(registration.isLight()));
-        content.put("isSaved", String.valueOf(registration.isSaved()));
-        content.put("savedAt", String.valueOf(registration.getSavedAt()));
-        Long id = registration.getId();
-        if (id != null) {
-            content.put("id", String.valueOf(id));
-        }
-        LocalDateTime createdAt = registration.getCreatedAt();
-        if (createdAt != null) {
-            content.put("createdAt", createdAt.toString());
-        }
-        return content;
-    }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -27,7 +27,6 @@ import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
 public class WaitingQueueService {
 
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
-    public static final String STREAM_KEY_SECTOR = "stream-key-sector-";
 
     private final RedisRepository redisRepository;
     @Autowired
@@ -48,42 +47,6 @@ public class WaitingQueueService {
         tracker.info("Added to the queue, score:{}", score);
     }
 
-    public void registerToStream(Registration registration, Long userId, Long sectorId, Long eventId) {
-        String streamKey = STREAM_KEY_SECTOR + sectorId;
-        Map<String, String> content = createRegistrationContent(registration, userId, sectorId, eventId);
-        redisRepository.streamAdd(streamKey, content);
-    }
-
-    public List<MapRecord<String, String, String>> readFromStream(String key, String lastId, int count) {
-        return redisRepository.streamRead(key, lastId, count);
-    }
-
-    private Map<String, String> createRegistrationContent(Registration registration, Long userId, Long sectorId, Long eventId) {
-        Map<String, String> content = new HashMap<>();
-        content.put("userId", String.valueOf(userId));
-        content.put("eventId", String.valueOf(eventId));
-        content.put("sectorId", String.valueOf(sectorId));
-        content.put("email", registration.getEmail());
-        content.put("name", registration.getName());
-        content.put("studentNum", registration.getStudentNum());
-        content.put("affiliation", registration.getAffiliation());
-        content.put("department", registration.getDepartment());
-        content.put("carNum", registration.getCarNum());
-        content.put("phoneNum", registration.getPhoneNum());
-        content.put("isDeleted", String.valueOf(registration.isDeleted()));
-        content.put("isLight", String.valueOf(registration.isLight()));
-        content.put("isSaved", String.valueOf(registration.isSaved()));
-        content.put("savedAt", String.valueOf(registration.getSavedAt()));
-        Long id = registration.getId();
-        if (id != null) {
-            content.put("id", String.valueOf(id));
-        }
-        LocalDateTime createdAt = registration.getCreatedAt();
-        if (createdAt != null) {
-            content.put("createdAt", createdAt.toString());
-        }
-        return content;
-    }
 
     public String convertRegistrationJSON(Registration registration) {
         JSONObject registrationJson = new JSONObject();

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -1,24 +1,24 @@
 package com.jnu.ticketinfrastructure.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
-import java.util.LinkedList;
-import java.util.Queue;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
 
 @Service
 @Slf4j
@@ -26,9 +26,11 @@ import org.springframework.stereotype.Service;
 public class WaitingQueueService {
 
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
+    public static final String STREAM_KEY_SECTOR = "stream-key-sector-";
 
     private final RedisRepository redisRepository;
-    @Autowired private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     public WaitingQueueService(RedisRepository redisRepository) {
         this.redisRepository = redisRepository;
@@ -43,6 +45,37 @@ public class WaitingQueueService {
         checkDuplicateData(key, message);
         redisRepository.zAddIfAbsent(key, message, score);
         tracker.info("Added to the queue, score:{}", score);
+    }
+
+    public void registerToStream(Registration registration, Long userId, Long sectorId, Long eventId) {
+        String streamKey = STREAM_KEY_SECTOR + sectorId;
+        Map<String, String> content = createRegistrationContent(registration, userId, sectorId, eventId);
+        redisRepository.streamAdd(streamKey, content);
+    }
+
+    public List<MapRecord<String, String, String>> readFromStream(String key, String lastId, int count) {
+        return redisRepository.streamRead(key, lastId, count);
+    }
+
+    private Map<String, String> createRegistrationContent(Registration registration, Long userId, Long sectorId, Long eventId) {
+        Map<String, String> content = new HashMap<>();
+        content.put("userId", String.valueOf(userId));
+        content.put("eventId", String.valueOf(eventId));
+        content.put("sectorId", String.valueOf(sectorId));
+        content.put("email", registration.getEmail());
+        content.put("name", registration.getName());
+        content.put("studentNum", registration.getStudentNum());
+        content.put("affiliation", registration.getAffiliation());
+        content.put("department", registration.getDepartment());
+        content.put("carNum", registration.getCarNum());
+        content.put("phoneNum", registration.getPhoneNum());
+        content.put("isDeleted", String.valueOf(registration.isDeleted()));
+        content.put("isLight", String.valueOf(registration.isLight()));
+        content.put("isSaved", String.valueOf(registration.isSaved()));
+        content.put("savedAt", String.valueOf(registration.getSavedAt()));
+        content.put("id", String.valueOf(registration.getId()));
+        content.put("createdAt", String.valueOf(registration.getCreatedAt()));
+        return content;
     }
 
     public String convertRegistrationJSON(Registration registration) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -16,6 +16,7 @@ import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
@@ -73,8 +74,14 @@ public class WaitingQueueService {
         content.put("isLight", String.valueOf(registration.isLight()));
         content.put("isSaved", String.valueOf(registration.isSaved()));
         content.put("savedAt", String.valueOf(registration.getSavedAt()));
-        content.put("id", String.valueOf(registration.getId()));
-        content.put("createdAt", String.valueOf(registration.getCreatedAt()));
+        Long id = registration.getId();
+        if (id != null) {
+            content.put("id", String.valueOf(id));
+        }
+        LocalDateTime createdAt = registration.getCreatedAt();
+        if (createdAt != null) {
+            content.put("createdAt", createdAt.toString());
+        }
         return content;
     }
 


### PR DESCRIPTION
# 주요 변경사항

## 비동기 작업 대신 동기 작업으로 변경
이전 방식에서 처리되는 주차권 신청 처리 플로우는 다음과 같은데요

1. 주차권 이벤트 open 시 사용자의 신청정보를 받아 들어온 모든 요청을 redis sorted set에 저장한다.
2. sorted set에 저장된 신청정보를 하나씩 꺼내어 데이터베이스에 신청정보를 저장한다.
3. 정상적으로 신청정보가 저장이 된다면 유저정보 반영을 진행한다. 
 유저 정보를 반영하는 로직은 데이터베이스에 신청서가 최종 저장된 시각 기준으로 신청서의 순번을 산출하여
  여석비교를 통해 함께 합,불,예비 상태를 정한다. 

**이때 신청정보 저장 및 유저정보 반영 작업은 비동기 이벤트를 발행해서 진행이 됩니다.**
따라서 2,3번 과정인 신청정보 저장과 유저 정보 반영 작업이 비동기적으로 진행되기 때문에 순서 및 결과를 집계하는 과정에서
예비번호 중복 버그가 발생했습니다. (늦게 저장된 신청정보가 먼저 저장된 신청정보 보다 더 빠르게 유저 정보 반영 작업이 진행되는 경우)

해당 문제를 해결하기위해 메시지 브로커로 부터 신청정보를 하나씩 꺼내서 비동기 이벤트 방식이 아닌 동기적으로 처리하였습니다.
이때 메시지 브로커는 구간별로 개별 사용이 되며 현재 주차권에서는 총 5개 구간이 존재하므로 5개의 쓰레드가 작업을 병렬처리 하게됩니다.
구간이 줄어들거나 늘어나는 경우는 거의 발생하지 않겠지만 **구간이 줄어들게 된다면 병목현상이 발생할수 있어 다른 대처가 필요할것 같습니다.**


### 해당 방법으로 문제를 해결한 이유
비동기방식으로 신청정보를 저장하고 지정된 시간에 한꺼번에 최종결과를 집계하는 방식을 택할수도 있었지만
최종결과 집계 시각을 언제로 정할지에 대한 문제와 집계 전 까지 사용자는 최종 결과를 알지 못하는 문제가 있었습니다.
보다 사용자에게 빠른 결과를 알려주기위해 해당 방식인 동기방식으로 문제를 해결하기로 했고  300~400건의 신청 규모와 서버 사양을 고려했을때 크게 문제되는 부분은 보이지 않았습니다. 

## 메시지 브로커 변경
현재 메시지 브로커로 redis sorted set을 사용하였지만 성능이점과 순서 및 메시지 관리가 용이하여 redis stream으로 변경하였습니다.


## 남은 문제
PR 단위가 너무 커져서 남은 문제는 새로 이슈 파고 PR 작성 진행해야할것 같습니다
- 해결해야하는 남은 문제는 다음과 같습니다.
  - 신청서 처리 중 중복된 신청서 인경우 무시되는 시나리오의 테스트코드 추가
  - 신청서 처리 중 예상치 못한 에러 발생시 재시도하는 로직 추가 혹은 pending list 추가 후 재처리 하는 기능과 같은 후처리 기능 추가 
  - 신청서 처리 후 유저 정보를 갱신하는 로직 실패시 재시도 및 recover 로직 추가 
  - 각 processor 별 로그 기록 추가 
  - 사용하지 않는 클래스 제거 및 작성된 코드 관련 리펙터링
  - redis stream 에 쌓이게되는 신청정보 관리 방식 필요 (메모리 문제)

## 리뷰어에게...

해당 PR 커밋 히스토리에 이전 PR(#512) 에서 작성한 테스트코드 커밋기록이 섞여있습니다... (한꺼버에 합치려다 꼬여버렸습니다)
8026bd60d656ad6ddd3bf920dd97b02becd4eb67 까지 작성한 테스트코드 관련 기록은 무시하고 
이전 PR(#512) 커밋 히스토리로 보면 편할것 같습니다


## 관련 이슈
closes #513 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정