### PR TITLE
[BE-243] bug: 데이터 유실 문제 해결

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -2,6 +2,7 @@ package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
@@ -22,12 +23,12 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @RequiredArgsConstructor
@@ -48,86 +49,168 @@ public class EventIssuedEventHandler {
 
     @Async
     @EventListener(classes = EventIssuedEvent.class)
-    @Retryable(
-            retryFor = {Exception.class},
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 2000))
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(EventIssuedEvent eventIssuedEvent) {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
-            if (isIdleConnectionAvailable()) {
-                Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
+            tracker.info("이벤트 처리 시작 - 사용자Id: {}, 구간Id: {}",
+                    eventIssuedEvent.getMessage().getUserId(),
+                    eventIssuedEvent.getMessage().getSectorId());
 
-                try {
-                    Registration registration =
-                            objectMapper.readValue(
-                                    eventIssuedEvent.getMessage().getRegistration(),
-                                    Registration.class);
-
-                    if (Boolean.TRUE.equals(
-                            registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
-                        tracker.info("Already saved, ignored");
-                        return;
-                    }
-                    tracker.info(
-                            "현재구간 정보, sectorId: {}, 정원여석: {}, 예비여석: {}, 총 여석: {},",
-                            sector.getId(),
-                            sector.getSectorCapacity(),
-                            sector.getReserve(),
-                            sector.getRemainingAmount());
-
-                    processQueueData(
-                            sector, registration, eventIssuedEvent.getMessage().getUserId());
-                    waitingQueueService.remove(
-                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-                    sector.decreaseEventStock();
-
-                    // sectorAdaptor.save(sector); 데드락 문제 임시 해결
-                } catch (NoEventStockLeftException e) {
-                    tracker.info("해당 구간 잔여 여석이 없습니다.", e);
-                    waitingQueueService.remove(
-                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-                } catch (Exception e) {
-                    // 에러가 났을 때 redis에 데이터를 재등록 한다.(Not Waiting 상태로)
-                    tracker.error("EventIssuedEventHandler Exception: ", e);
-                }
+            // 1. 데이터베이스 연결 풀 확인
+            if (!isIdleConnectionAvailable()) {
+                tracker.warn("사용 가능한 DB 연결이 없어 현재 처리를 건너뜀");
+                return; // 스케줄러가 다시 처리하도록 Redis에서 제거하지 않음
             }
+
+            // 2. JSON 파싱 시도
+            Registration registration;
+            try {
+                registration = objectMapper.readValue(
+                        eventIssuedEvent.getMessage().getRegistration(),
+                        Registration.class);
+            } catch (JsonProcessingException e) {
+                tracker.error("등록 JSON 파싱 실패 (서버 문제일 수 있음), 재처리를 위해 큐에 유지: {}",
+                        eventIssuedEvent.getMessage().getRegistration(), e);
+                return; // 파싱 실패 시에도 Redis에서 제거하지 않음 (서버 문제일 수 있음)
+            }
+
+            // 3. 중복 처리 확인
+            if (Boolean.TRUE.equals(registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
+                tracker.info("이미 저장된 등록정보, 큐에서 제거 - RegistrationId: {}",
+                        registration.getId());
+                registerTransactionSynchronization(eventIssuedEvent, true);
+                return;
+            }
+
+            // 4. 섹터 정보 조회
+            Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
+
+            tracker.info("구간 정보 - 구간Id: {}, 정원: {}, 예비: {}, 잔여: {}",
+                    sector.getId(),
+                    sector.getSectorCapacity(),
+                    sector.getReserve(),
+                    sector.getRemainingAmount());
+
+            // 5. 등록 처리
+            processQueueData(sector, registration, eventIssuedEvent.getMessage().getUserId());
+            sector.decreaseEventStock();
+
+            // 6. 성공적으로 처리된 경우 트랜잭션 커밋 후 Redis에서 제거
+            registerTransactionSynchronization(eventIssuedEvent, true);
+            tracker.info("등록 처리 완료 - RegistrationId: {}", registration.getId());
+
+        } catch (NoEventStockLeftException e) {
+            // 좌석 부족은 정상적인 비즈니스 로직이므로 Redis에서 제거
+            tracker.info("잔여 좌석 없음, 큐에서 제거 - SectorId: {}",
+                    eventIssuedEvent.getMessage().getSectorId());
+            registerTransactionSynchronization(eventIssuedEvent, true);
+
+        } catch (Exception e) {
+            // 시스템 예외 발생 시 로깅만 하고 Redis에서 제거하지 않음
+            // 다음 스케줄러 실행 시 재처리됨
+            tracker.error("시스템 예외 발생, 다음 스케줄러 실행시 재처리를 위해 큐에 유지 - UserId: {}, 오류: {}",
+                    eventIssuedEvent.getMessage().getUserId(), e.getMessage(), e);
+            // Redis에서 제거하지 않으므로 registerTransactionSynchronization 호출하지 않음
+
         } finally {
             MDC.clear();
         }
     }
 
-    /** 대기열에서 pop한 registration을 저장하고 유저 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다. */
+    /**
+     * 트랜잭션 커밋/롤백 후 Redis 큐 처리를 위한 콜백 등록
+     * @param eventIssuedEvent 처리할 이벤트
+     * @param removeOnSuccess 성공 시 제거 여부
+     */
+    private void registerTransactionSynchronization(EventIssuedEvent eventIssuedEvent, boolean removeOnSuccess) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            if (removeOnSuccess) {
+                                tracker.info("트랜잭션 커밋 성공, Redis 큐에서 제거 - UserId: {}",
+                                        eventIssuedEvent.getMessage().getUserId());
+                                try {
+                                    waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
+                                } catch (Exception e) {
+                                    tracker.error("커밋 성공 후 Redis 큐 제거 실패 - UserId: {}",
+                                            eventIssuedEvent.getMessage().getUserId(), e);
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void afterCompletion(int status) {
+                            if (status == STATUS_ROLLED_BACK) {
+                                tracker.error("트랜잭션 롤백됨, 재시도를 위해 Redis 큐에 데이터 유지 - UserId: {}",
+                                        eventIssuedEvent.getMessage().getUserId());
+                            }
+                        }
+                    }
+            );
+        } else {
+            tracker.error("트랜잭션 롤백됨, 재시도를 위해 Redis 큐에 데이터 유지 - UserId: {}",
+                    eventIssuedEvent.getMessage().getUserId());
+        }
+    }
+
+    /**
+     * 대기열에서 추출한 등록정보를 저장하고 사용자 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
+     */
     public void processQueueData(Sector sector, Registration registration, Long userId) {
         User user = userAdaptor.findById(userId);
         saveRegistration(sector, user, registration);
         Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
     }
 
+    /**
+     * 등록 정보를 데이터베이스에 저장
+     */
     private void saveRegistration(Sector sector, User user, Registration registration) {
         if (!sector.isRemainingAmount()) {
-            tracker.info("[No seats remaining]. Registration: {}", registration);
+            tracker.info("[잔여 좌석 없음]. RegistrationId: {}", registration.getId());
             throw NoEventStockLeftException.EXCEPTION;
         }
 
         if (!registration.isSaved()) {
-            // if문 사용 안됨.
             registration.finalSave();
             registration.setSector(sector);
             registration.setUser(user);
             registrationAdaptor.save(registration);
+            tracker.info("신규 등록 저장 완료 - RegistrationId: {}", registration.getId());
             return;
         }
+
         registration.setSector(sector);
         registration.setUser(user);
         registrationAdaptor.saveAndFlush(registration);
         registrationAdaptor.updateSavedAt(registration);
-        tracker.info("Registration saved");
+        tracker.info("기존 등록 정보 업데이트 완료 - RegistrationId: {}", registration.getId());
     }
 
+    /**
+     * 데이터베이스 연결 풀에 여유 연결이 있는지 확인
+     * @return 여유 연결이 2개 이상 있으면 true
+     */
     private boolean isIdleConnectionAvailable() {
-        int idleConnections = hikariDataSource.getHikariPoolMXBean().getIdleConnections();
-        return idleConnections > 0;
+        try {
+            int idleConnections = hikariDataSource.getHikariPoolMXBean().getIdleConnections();
+            int minimumIdle = hikariDataSource.getHikariConfigMXBean().getMinimumIdle();
+
+            // 최소 2개 이상의 여유 연결 확보
+            boolean available = idleConnections >= Math.max(2, minimumIdle);
+
+            if (!available) {
+                tracker.warn("DB 연결 부족 - 현재: {}, 최소 필요: {}",
+                        idleConnections, Math.max(2, minimumIdle));
+            }
+
+            return available;
+        } catch (Exception e) {
+            tracker.error("DB 연결 상태 확인 실패, 처리 진행으로 가정", e);
+            return true; // 확인 실패 시 기본적으로 처리 진행
+        }
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -94,7 +94,7 @@ public class EventIssuedEventHandler {
 
             // 5. 등록 처리
             processQueueData(sector, registration, eventIssuedEvent.getMessage().getUserId());
-            sector.decreaseEventStock();
+            sectorAdaptor.decreaseRemainingAmount(sector.getId());
 
             // 6. 성공적으로 처리된 경우 트랜잭션 커밋 후 Redis에서 제거
             registerTransactionSynchronization(eventIssuedEvent, true);
@@ -197,14 +197,12 @@ public class EventIssuedEventHandler {
     private boolean isIdleConnectionAvailable() {
         try {
             int idleConnections = hikariDataSource.getHikariPoolMXBean().getIdleConnections();
-            int minimumIdle = hikariDataSource.getHikariConfigMXBean().getMinimumIdle();
 
             // 최소 2개 이상의 여유 연결 확보
-            boolean available = idleConnections >= Math.max(2, minimumIdle);
+            boolean available = idleConnections >= 2;
 
             if (!available) {
-                tracker.warn("DB 연결 부족 - 현재: {}, 최소 필요: {}",
-                        idleConnections, Math.max(2, minimumIdle));
+                tracker.warn("DB 연결 부족 - 현재: {}", idleConnections);
             }
 
             return available;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -77,7 +77,7 @@ public class EventIssuedEventHandler {
                 String registrationMessage = eventIssuedEvent.getMessage().getRegistration();
                 String key = JSON_PARSE_FAIL_COUNT_KEY + userId;
                 int failCount = waitingQueueService.incrementFailCount(key);
-                if(failCount >= MAX_JSON_PARSE_FAIL_COUNT) {
+                if (failCount >= MAX_JSON_PARSE_FAIL_COUNT) {
                     tracker.error(
                             "JSON 파싱 {}회 연속 실패, 큐에서 제거 - UserId: {}, 데이터: {}",
                             failCount, userId, eventIssuedEvent.getMessage().getRegistration());
@@ -85,8 +85,7 @@ public class EventIssuedEventHandler {
                     waitingQueueService.remove(
                             REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage()); // 큐에서 제거
                     return;
-                }
-                else {
+                } else {
                     tracker.error(
                             "JSON 파싱 실패 ({}/{}회), 재처리를 위해 큐에 유지 - UserId: {}, 데이터: {}",
                             failCount, MAX_JSON_PARSE_FAIL_COUNT, userId,
@@ -98,7 +97,7 @@ public class EventIssuedEventHandler {
             // 3. 중복 처리 확인
             if (Boolean.TRUE.equals(
                     registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
-                tracker.info("이미 저장된 등록정보, 큐에서 제거 - RegistrationId: {}", registration.getId());
+                tracker.info("이미 저장된 등록정보, 큐에서 제거 시작 - RegistrationId: {}", registration.getId());
                 registerTransactionSynchronization(eventIssuedEvent, true);
                 return;
             }
@@ -146,7 +145,7 @@ public class EventIssuedEventHandler {
      * 트랜잭션 커밋/롤백 후 Redis 큐 처리를 위한 콜백 등록
      *
      * @param eventIssuedEvent 처리할 이벤트
-     * @param removeOnSuccess 성공 시 제거 여부
+     * @param removeOnSuccess  성공 시 제거 여부
      */
     private void registerTransactionSynchronization(
             EventIssuedEvent eventIssuedEvent, boolean removeOnSuccess) {
@@ -187,7 +186,9 @@ public class EventIssuedEventHandler {
         }
     }
 
-    /** 대기열에서 추출한 등록정보를 저장하고 사용자 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다. */
+    /**
+     * 대기열에서 추출한 등록정보를 저장하고 사용자 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
+     */
     public void processQueueData(Sector sector, Registration registration, EventIssuedEvent event) {
         Long userId = event.getMessage().getUserId();
         User user = userAdaptor.findById(userId);
@@ -195,7 +196,9 @@ public class EventIssuedEventHandler {
         Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
     }
 
-    /** 등록 정보를 데이터베이스에 저장 */
+    /**
+     * 등록 정보를 데이터베이스에 저장
+     */
     private void saveRegistration(
             Sector sector, User user, Registration registration, Double score) {
         if (!sector.isRemainingAmount()) {
@@ -207,7 +210,6 @@ public class EventIssuedEventHandler {
         registration.setUser(user);
         registration.setSavedAt(score.longValue());
         registrationAdaptor.saveAndFlush(registration);
-        tracker.info("기존 등록 정보 업데이트 완료 - RegistrationId: {}", registration.getId());
     }
 
     /**

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -46,11 +46,15 @@ public class EventIssuedEventHandler {
     private final ObjectMapper objectMapper;
     private final HikariDataSource hikariDataSource;
 
+    private static final String JSON_PARSE_FAIL_COUNT_KEY = "json_parse_fail_count:";
+    private static final int MAX_JSON_PARSE_FAIL_COUNT = 3;
+
     @EventListener(classes = EventIssuedEvent.class)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(EventIssuedEvent eventIssuedEvent) {
+        Long userId = eventIssuedEvent.getMessage().getUserId();
         try {
-            MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
+            MDC.put("userId", String.valueOf(userId));
             tracker.info(
                     "이벤트 처리 시작 - 사용자Id: {}, 구간Id: {}",
                     eventIssuedEvent.getMessage().getUserId(),
@@ -70,11 +74,25 @@ public class EventIssuedEventHandler {
                                 eventIssuedEvent.getMessage().getRegistration(),
                                 Registration.class);
             } catch (JsonProcessingException e) {
-                tracker.error(
-                        "등록 JSON 파싱 실패 (서버 문제일 수 있음), 재처리를 위해 큐에 유지: {}",
-                        eventIssuedEvent.getMessage().getRegistration(),
-                        e);
-                return; // 파싱 실패 시에도 Redis에서 제거하지 않음 (서버 문제일 수 있음)
+                String registrationMessage = eventIssuedEvent.getMessage().getRegistration();
+                String key = JSON_PARSE_FAIL_COUNT_KEY + userId;
+                int failCount = waitingQueueService.incrementFailCount(key);
+                if(failCount >= MAX_JSON_PARSE_FAIL_COUNT) {
+                    tracker.error(
+                            "JSON 파싱 {}회 연속 실패, 큐에서 제거 - UserId: {}, 데이터: {}",
+                            failCount, userId, eventIssuedEvent.getMessage().getRegistration());
+                    waitingQueueService.clearFailCount(key); // 실패 횟수 초기화
+                    waitingQueueService.remove(
+                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage()); // 큐에서 제거
+                    return;
+                }
+                else {
+                    tracker.error(
+                            "JSON 파싱 실패 ({}/{}회), 재처리를 위해 큐에 유지 - UserId: {}, 데이터: {}",
+                            failCount, MAX_JSON_PARSE_FAIL_COUNT, userId,
+                            eventIssuedEvent.getMessage().getRegistration(), e);
+                    return;
+                }
             }
 
             // 3. 중복 처리 확인

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,5 +1,7 @@
 package com.jnu.ticketapi.api.event.handler;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.common.domainEvent.Events;
@@ -27,8 +29,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
-
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -45,7 +45,6 @@ public class EventIssuedEventHandler {
     private final SectorAdaptor sectorAdaptor;
     private final ObjectMapper objectMapper;
     private final HikariDataSource hikariDataSource;
-
 
     @EventListener(classes = EventIssuedEvent.class)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -179,7 +178,8 @@ public class EventIssuedEventHandler {
     }
 
     /** 등록 정보를 데이터베이스에 저장 */
-    private void saveRegistration(Sector sector, User user, Registration registration, Double score) {
+    private void saveRegistration(
+            Sector sector, User user, Registration registration, Double score) {
         if (!sector.isRemainingAmount()) {
             tracker.info("[잔여 좌석 없음]. RegistrationId: {}", registration.getId());
             throw NoEventStockLeftException.EXCEPTION;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -155,18 +155,11 @@ public class EventIssuedEventHandler {
                         @Override
                         public void afterCommit() {
                             if (removeOnSuccess) {
+                                waitingQueueService.remove(
+                                        REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
                                 tracker.info(
                                         "트랜잭션 커밋 성공, Redis 큐에서 제거 - UserId: {}",
                                         eventIssuedEvent.getMessage().getUserId());
-                                try {
-                                    waitingQueueService.remove(
-                                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-                                } catch (Exception e) {
-                                    tracker.error(
-                                            "커밋 성공 후 Redis 큐 제거 실패 - UserId: {}",
-                                            eventIssuedEvent.getMessage().getUserId(),
-                                            e);
-                                }
                             }
                         }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -95,7 +95,8 @@ public class EventIssuedEventHandler {
 
             // 3. 중복 처리 확인
             if (Boolean.TRUE.equals(
-                    registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
+                    registrationAdaptor.existsByEmailAndIsSavedTrue(
+                            registration.getEmail(), eventIssuedEvent.getMessage().getEventId()))) {
                 tracker.info("이미 저장된 등록정보, 큐에서 제거 시작 - RegistrationId: {}", registration.getId());
                 waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
                 return;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -185,15 +185,6 @@ public class EventIssuedEventHandler {
             throw NoEventStockLeftException.EXCEPTION;
         }
 
-        if (!registration.isSaved()) {
-            registration.finalSave();
-            registration.setSector(sector);
-            registration.setUser(user);
-            registrationAdaptor.save(registration);
-            tracker.info("신규 등록 저장 완료 - RegistrationId: {}", registration.getId());
-            return;
-        }
-
         registration.setSector(sector);
         registration.setUser(user);
         registrationAdaptor.saveAndFlush(registration);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -26,8 +26,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @RequiredArgsConstructor
@@ -74,7 +72,6 @@ public class EventIssuedEventHandler {
                                 eventIssuedEvent.getMessage().getRegistration(),
                                 Registration.class);
             } catch (JsonProcessingException e) {
-                String registrationMessage = eventIssuedEvent.getMessage().getRegistration();
                 String key = JSON_PARSE_FAIL_COUNT_KEY + userId;
                 int failCount = waitingQueueService.incrementFailCount(key);
                 if (failCount >= MAX_JSON_PARSE_FAIL_COUNT) {
@@ -103,7 +100,7 @@ public class EventIssuedEventHandler {
             if (Boolean.TRUE.equals(
                     registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
                 tracker.info("이미 저장된 등록정보, 큐에서 제거 시작 - RegistrationId: {}", registration.getId());
-                registerTransactionSynchronization(eventIssuedEvent, true);
+                waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
                 return;
             }
 
@@ -122,14 +119,14 @@ public class EventIssuedEventHandler {
             sectorAdaptor.decreaseRemainingAmount(sector.getId());
 
             // 6. 성공적으로 처리된 경우 트랜잭션 커밋 후 Redis에서 제거
-            registerTransactionSynchronization(eventIssuedEvent, true);
+            waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
             tracker.info("등록 처리 완료 - RegistrationId: {}", registration.getId());
 
         } catch (NoEventStockLeftException e) {
             // 좌석 부족은 정상적인 비즈니스 로직이므로 Redis에서 제거
             tracker.info(
                     "잔여 좌석 없음, 큐에서 제거 - SectorId: {}", eventIssuedEvent.getMessage().getSectorId());
-            registerTransactionSynchronization(eventIssuedEvent, true);
+            waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
 
         } catch (Exception e) {
             // 시스템 예외 발생 시 로깅만 하고 Redis에서 제거하지 않음
@@ -143,40 +140,6 @@ public class EventIssuedEventHandler {
 
         } finally {
             MDC.clear();
-        }
-    }
-
-    /**
-     * 트랜잭션 커밋/롤백 후 Redis 큐 처리를 위한 콜백 등록
-     *
-     * @param eventIssuedEvent 처리할 이벤트
-     * @param removeOnSuccess 성공 시 제거 여부
-     */
-    private void registerTransactionSynchronization(
-            EventIssuedEvent eventIssuedEvent, boolean removeOnSuccess) {
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
-            TransactionSynchronizationManager.registerSynchronization(
-                    new TransactionSynchronization() {
-                        @Override
-                        public void afterCommit() {
-                            if (removeOnSuccess) {
-                                waitingQueueService.remove(
-                                        REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-                                tracker.info(
-                                        "트랜잭션 커밋 성공, Redis 큐에서 제거 - UserId: {}",
-                                        eventIssuedEvent.getMessage().getUserId());
-                            }
-                        }
-
-                        @Override
-                        public void afterCompletion(int status) {
-                            if (status == STATUS_ROLLED_BACK) {
-                                tracker.error(
-                                        "트랜잭션 롤백됨, 재시도를 위해 Redis 큐에 데이터 유지 - UserId: {}",
-                                        eventIssuedEvent.getMessage().getUserId());
-                            }
-                        }
-                    });
         }
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -177,10 +177,6 @@ public class EventIssuedEventHandler {
                             }
                         }
                     });
-        } else {
-            tracker.error(
-                    "트랜잭션 롤백됨, 재시도를 위해 Redis 큐에 데이터 유지 - UserId: {}",
-                    eventIssuedEvent.getMessage().getUserId());
         }
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -53,7 +53,8 @@ public class EventIssuedEventHandler {
     public void handle(EventIssuedEvent eventIssuedEvent) {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
-            tracker.info("이벤트 처리 시작 - 사용자Id: {}, 구간Id: {}",
+            tracker.info(
+                    "이벤트 처리 시작 - 사용자Id: {}, 구간Id: {}",
                     eventIssuedEvent.getMessage().getUserId(),
                     eventIssuedEvent.getMessage().getSectorId());
 
@@ -66,19 +67,22 @@ public class EventIssuedEventHandler {
             // 2. JSON 파싱 시도
             Registration registration;
             try {
-                registration = objectMapper.readValue(
-                        eventIssuedEvent.getMessage().getRegistration(),
-                        Registration.class);
+                registration =
+                        objectMapper.readValue(
+                                eventIssuedEvent.getMessage().getRegistration(),
+                                Registration.class);
             } catch (JsonProcessingException e) {
-                tracker.error("등록 JSON 파싱 실패 (서버 문제일 수 있음), 재처리를 위해 큐에 유지: {}",
-                        eventIssuedEvent.getMessage().getRegistration(), e);
+                tracker.error(
+                        "등록 JSON 파싱 실패 (서버 문제일 수 있음), 재처리를 위해 큐에 유지: {}",
+                        eventIssuedEvent.getMessage().getRegistration(),
+                        e);
                 return; // 파싱 실패 시에도 Redis에서 제거하지 않음 (서버 문제일 수 있음)
             }
 
             // 3. 중복 처리 확인
-            if (Boolean.TRUE.equals(registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
-                tracker.info("이미 저장된 등록정보, 큐에서 제거 - RegistrationId: {}",
-                        registration.getId());
+            if (Boolean.TRUE.equals(
+                    registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
+                tracker.info("이미 저장된 등록정보, 큐에서 제거 - RegistrationId: {}", registration.getId());
                 registerTransactionSynchronization(eventIssuedEvent, true);
                 return;
             }
@@ -86,7 +90,8 @@ public class EventIssuedEventHandler {
             // 4. 섹터 정보 조회
             Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
-            tracker.info("구간 정보 - 구간Id: {}, 정원: {}, 예비: {}, 잔여: {}",
+            tracker.info(
+                    "구간 정보 - 구간Id: {}, 정원: {}, 예비: {}, 잔여: {}",
                     sector.getId(),
                     sector.getSectorCapacity(),
                     sector.getReserve(),
@@ -102,15 +107,18 @@ public class EventIssuedEventHandler {
 
         } catch (NoEventStockLeftException e) {
             // 좌석 부족은 정상적인 비즈니스 로직이므로 Redis에서 제거
-            tracker.info("잔여 좌석 없음, 큐에서 제거 - SectorId: {}",
-                    eventIssuedEvent.getMessage().getSectorId());
+            tracker.info(
+                    "잔여 좌석 없음, 큐에서 제거 - SectorId: {}", eventIssuedEvent.getMessage().getSectorId());
             registerTransactionSynchronization(eventIssuedEvent, true);
 
         } catch (Exception e) {
             // 시스템 예외 발생 시 로깅만 하고 Redis에서 제거하지 않음
             // 다음 스케줄러 실행 시 재처리됨
-            tracker.error("시스템 예외 발생, 다음 스케줄러 실행시 재처리를 위해 큐에 유지 - UserId: {}, 오류: {}",
-                    eventIssuedEvent.getMessage().getUserId(), e.getMessage(), e);
+            tracker.error(
+                    "시스템 예외 발생, 다음 스케줄러 실행시 재처리를 위해 큐에 유지 - UserId: {}, 오류: {}",
+                    eventIssuedEvent.getMessage().getUserId(),
+                    e.getMessage(),
+                    e);
             // Redis에서 제거하지 않으므로 registerTransactionSynchronization 호출하지 않음
 
         } finally {
@@ -120,23 +128,29 @@ public class EventIssuedEventHandler {
 
     /**
      * 트랜잭션 커밋/롤백 후 Redis 큐 처리를 위한 콜백 등록
+     *
      * @param eventIssuedEvent 처리할 이벤트
      * @param removeOnSuccess 성공 시 제거 여부
      */
-    private void registerTransactionSynchronization(EventIssuedEvent eventIssuedEvent, boolean removeOnSuccess) {
+    private void registerTransactionSynchronization(
+            EventIssuedEvent eventIssuedEvent, boolean removeOnSuccess) {
         if (TransactionSynchronizationManager.isActualTransactionActive()) {
             TransactionSynchronizationManager.registerSynchronization(
                     new TransactionSynchronization() {
                         @Override
                         public void afterCommit() {
                             if (removeOnSuccess) {
-                                tracker.info("트랜잭션 커밋 성공, Redis 큐에서 제거 - UserId: {}",
+                                tracker.info(
+                                        "트랜잭션 커밋 성공, Redis 큐에서 제거 - UserId: {}",
                                         eventIssuedEvent.getMessage().getUserId());
                                 try {
-                                    waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
+                                    waitingQueueService.remove(
+                                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
                                 } catch (Exception e) {
-                                    tracker.error("커밋 성공 후 Redis 큐 제거 실패 - UserId: {}",
-                                            eventIssuedEvent.getMessage().getUserId(), e);
+                                    tracker.error(
+                                            "커밋 성공 후 Redis 큐 제거 실패 - UserId: {}",
+                                            eventIssuedEvent.getMessage().getUserId(),
+                                            e);
                                 }
                             }
                         }
@@ -144,30 +158,27 @@ public class EventIssuedEventHandler {
                         @Override
                         public void afterCompletion(int status) {
                             if (status == STATUS_ROLLED_BACK) {
-                                tracker.error("트랜잭션 롤백됨, 재시도를 위해 Redis 큐에 데이터 유지 - UserId: {}",
+                                tracker.error(
+                                        "트랜잭션 롤백됨, 재시도를 위해 Redis 큐에 데이터 유지 - UserId: {}",
                                         eventIssuedEvent.getMessage().getUserId());
                             }
                         }
-                    }
-            );
+                    });
         } else {
-            tracker.error("트랜잭션 롤백됨, 재시도를 위해 Redis 큐에 데이터 유지 - UserId: {}",
+            tracker.error(
+                    "트랜잭션 롤백됨, 재시도를 위해 Redis 큐에 데이터 유지 - UserId: {}",
                     eventIssuedEvent.getMessage().getUserId());
         }
     }
 
-    /**
-     * 대기열에서 추출한 등록정보를 저장하고 사용자 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
-     */
+    /** 대기열에서 추출한 등록정보를 저장하고 사용자 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다. */
     public void processQueueData(Sector sector, Registration registration, Long userId) {
         User user = userAdaptor.findById(userId);
         saveRegistration(sector, user, registration);
         Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
     }
 
-    /**
-     * 등록 정보를 데이터베이스에 저장
-     */
+    /** 등록 정보를 데이터베이스에 저장 */
     private void saveRegistration(Sector sector, User user, Registration registration) {
         if (!sector.isRemainingAmount()) {
             tracker.info("[잔여 좌석 없음]. RegistrationId: {}", registration.getId());
@@ -192,6 +203,7 @@ public class EventIssuedEventHandler {
 
     /**
      * 데이터베이스 연결 풀에 여유 연결이 있는지 확인
+     *
      * @return 여유 연결이 2개 이상 있으면 true
      */
     private boolean isIdleConnectionAvailable() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -4,6 +4,8 @@ import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketapi.common.aop.QueueFailureHandling;
+import com.jnu.ticketcommon.exception.JsonProcessErrorException;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
@@ -44,11 +46,9 @@ public class EventIssuedEventHandler {
     private final ObjectMapper objectMapper;
     private final HikariDataSource hikariDataSource;
 
-    private static final String JSON_PARSE_FAIL_COUNT_KEY = "json_parse_fail_count:";
-    private static final int MAX_JSON_PARSE_FAIL_COUNT = 3;
-
     @EventListener(classes = EventIssuedEvent.class)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @QueueFailureHandling(removeImmediatelyExceptions = NoEventStockLeftException.class)
     public void handle(EventIssuedEvent eventIssuedEvent) {
         Long userId = eventIssuedEvent.getMessage().getUserId();
         try {
@@ -69,28 +69,8 @@ public class EventIssuedEventHandler {
                                 eventIssuedEvent.getMessage().getRegistration(),
                                 Registration.class);
             } catch (JsonProcessingException e) {
-                String key = JSON_PARSE_FAIL_COUNT_KEY + userId;
-                int failCount = waitingQueueService.incrementFailCount(key);
-                if (failCount >= MAX_JSON_PARSE_FAIL_COUNT) {
-                    tracker.error(
-                            "JSON 파싱 {}회 연속 실패, 큐에서 제거 - UserId: {}, 데이터: {}",
-                            failCount,
-                            userId,
-                            eventIssuedEvent.getMessage().getRegistration());
-                    waitingQueueService.clearFailCount(key); // 실패 횟수 초기화
-                    waitingQueueService.remove(
-                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage()); // 큐에서 제거
-                    return;
-                } else {
-                    tracker.error(
-                            "JSON 파싱 실패 ({}/{}회), 재처리를 위해 큐에 유지 - UserId: {}, 데이터: {}",
-                            failCount,
-                            MAX_JSON_PARSE_FAIL_COUNT,
-                            userId,
-                            eventIssuedEvent.getMessage().getRegistration(),
-                            e);
-                    return;
-                }
+                tracker.error("등록정보 JSON 파싱 실패 - UserId: {}, 오류: {}", userId, e.getMessage());
+                throw JsonProcessErrorException.EXCEPTION;
             }
 
             // 3. 중복 처리 확인
@@ -119,22 +99,6 @@ public class EventIssuedEventHandler {
             // 6. 성공적으로 처리된 경우 트랜잭션 커밋 후 Redis에서 제거
             waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
             tracker.info("등록 처리 완료 - RegistrationId: {}", registration.getId());
-
-        } catch (NoEventStockLeftException e) {
-            // 좌석 부족은 정상적인 비즈니스 로직이므로 Redis에서 제거
-            waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-            tracker.info(
-                    "잔여 좌석 없음, 큐에서 제거 - SectorId: {}", eventIssuedEvent.getMessage().getSectorId());
-
-        } catch (Exception e) {
-            // 시스템 예외 발생 시 로깅만 하고 Redis에서 제거하지 않음
-            // 다음 스케줄러 실행 시 재처리됨
-            tracker.error(
-                    "시스템 예외 발생, 다음 스케줄러 실행시 재처리를 위해 큐에 유지 - UserId: {}, 오류: {}",
-                    eventIssuedEvent.getMessage().getUserId(),
-                    e.getMessage(),
-                    e);
-            // Redis에서 제거하지 않으므로 registerTransactionSynchronization 호출하지 않음
 
         } finally {
             MDC.clear();

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -210,12 +210,14 @@ public class EventIssuedEventHandler {
     private boolean isIdleConnectionAvailable() {
         try {
             int idleConnections = hikariDataSource.getHikariPoolMXBean().getIdleConnections();
+            int minimumIdle = hikariDataSource.getHikariConfigMXBean().getMinimumIdle();
 
             // 최소 2개 이상의 여유 연결 확보
-            boolean available = idleConnections >= 2;
+            boolean available = idleConnections >= Math.max(2, minimumIdle);
 
             if (!available) {
-                tracker.warn("DB 연결 부족 - 현재: {}", idleConnections);
+                tracker.warn(
+                        "DB 연결 부족 - 현재: {}, 최소 필요: {}", idleConnections, Math.max(2, minimumIdle));
             }
 
             return available;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -210,14 +210,12 @@ public class EventIssuedEventHandler {
     private boolean isIdleConnectionAvailable() {
         try {
             int idleConnections = hikariDataSource.getHikariPoolMXBean().getIdleConnections();
-            int minimumIdle = hikariDataSource.getHikariConfigMXBean().getMinimumIdle();
 
             // 최소 2개 이상의 여유 연결 확보
-            boolean available = idleConnections >= Math.max(2, minimumIdle);
+            boolean available = idleConnections >= 2;
 
             if (!available) {
-                tracker.warn(
-                        "DB 연결 부족 - 현재: {}, 최소 필요: {}", idleConnections, Math.max(2, minimumIdle));
+                tracker.warn("DB 연결 부족 - 현재: {}", idleConnections);
             }
 
             return available;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -98,7 +98,7 @@ public class EventIssuedEventHandler {
                     sector.getRemainingAmount());
 
             // 5. 등록 처리
-            processQueueData(sector, registration, eventIssuedEvent.getMessage().getUserId());
+            processQueueData(sector, registration, eventIssuedEvent);
             sectorAdaptor.decreaseRemainingAmount(sector.getId());
 
             // 6. 성공적으로 처리된 경우 트랜잭션 커밋 후 Redis에서 제거
@@ -172,14 +172,15 @@ public class EventIssuedEventHandler {
     }
 
     /** 대기열에서 추출한 등록정보를 저장하고 사용자 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다. */
-    public void processQueueData(Sector sector, Registration registration, Long userId) {
+    public void processQueueData(Sector sector, Registration registration, EventIssuedEvent event) {
+        Long userId = event.getMessage().getUserId();
         User user = userAdaptor.findById(userId);
-        saveRegistration(sector, user, registration);
+        saveRegistration(sector, user, registration, event.getScore());
         Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
     }
 
     /** 등록 정보를 데이터베이스에 저장 */
-    private void saveRegistration(Sector sector, User user, Registration registration) {
+    private void saveRegistration(Sector sector, User user, Registration registration, Double score) {
         if (!sector.isRemainingAmount()) {
             tracker.info("[잔여 좌석 없음]. RegistrationId: {}", registration.getId());
             throw NoEventStockLeftException.EXCEPTION;
@@ -187,8 +188,8 @@ public class EventIssuedEventHandler {
 
         registration.setSector(sector);
         registration.setUser(user);
+        registration.setSavedAt(score.longValue());
         registrationAdaptor.saveAndFlush(registration);
-        registrationAdaptor.updateSavedAt(registration);
         tracker.info("기존 등록 정보 업데이트 완료 - RegistrationId: {}", registration.getId());
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,7 +1,5 @@
 package com.jnu.ticketapi.api.event.handler;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.common.domainEvent.Events;
@@ -23,12 +21,13 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @Component
 @RequiredArgsConstructor
@@ -47,7 +46,7 @@ public class EventIssuedEventHandler {
     private final ObjectMapper objectMapper;
     private final HikariDataSource hikariDataSource;
 
-    @Async
+
     @EventListener(classes = EventIssuedEvent.class)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(EventIssuedEvent eventIssuedEvent) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -80,7 +80,9 @@ public class EventIssuedEventHandler {
                 if (failCount >= MAX_JSON_PARSE_FAIL_COUNT) {
                     tracker.error(
                             "JSON 파싱 {}회 연속 실패, 큐에서 제거 - UserId: {}, 데이터: {}",
-                            failCount, userId, eventIssuedEvent.getMessage().getRegistration());
+                            failCount,
+                            userId,
+                            eventIssuedEvent.getMessage().getRegistration());
                     waitingQueueService.clearFailCount(key); // 실패 횟수 초기화
                     waitingQueueService.remove(
                             REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage()); // 큐에서 제거
@@ -88,8 +90,11 @@ public class EventIssuedEventHandler {
                 } else {
                     tracker.error(
                             "JSON 파싱 실패 ({}/{}회), 재처리를 위해 큐에 유지 - UserId: {}, 데이터: {}",
-                            failCount, MAX_JSON_PARSE_FAIL_COUNT, userId,
-                            eventIssuedEvent.getMessage().getRegistration(), e);
+                            failCount,
+                            MAX_JSON_PARSE_FAIL_COUNT,
+                            userId,
+                            eventIssuedEvent.getMessage().getRegistration(),
+                            e);
                     return;
                 }
             }
@@ -145,7 +150,7 @@ public class EventIssuedEventHandler {
      * 트랜잭션 커밋/롤백 후 Redis 큐 처리를 위한 콜백 등록
      *
      * @param eventIssuedEvent 처리할 이벤트
-     * @param removeOnSuccess  성공 시 제거 여부
+     * @param removeOnSuccess 성공 시 제거 여부
      */
     private void registerTransactionSynchronization(
             EventIssuedEvent eventIssuedEvent, boolean removeOnSuccess) {
@@ -179,9 +184,7 @@ public class EventIssuedEventHandler {
         }
     }
 
-    /**
-     * 대기열에서 추출한 등록정보를 저장하고 사용자 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
-     */
+    /** 대기열에서 추출한 등록정보를 저장하고 사용자 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다. */
     public void processQueueData(Sector sector, Registration registration, EventIssuedEvent event) {
         Long userId = event.getMessage().getUserId();
         User user = userAdaptor.findById(userId);
@@ -189,9 +192,7 @@ public class EventIssuedEventHandler {
         Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
     }
 
-    /**
-     * 등록 정보를 데이터베이스에 저장
-     */
+    /** 등록 정보를 데이터베이스에 저장 */
     private void saveRegistration(
             Sector sector, User user, Registration registration, Double score) {
         if (!sector.isRemainingAmount()) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -53,10 +53,7 @@ public class EventIssuedEventHandler {
         Long userId = eventIssuedEvent.getMessage().getUserId();
         try {
             MDC.put("userId", String.valueOf(userId));
-            tracker.info(
-                    "이벤트 처리 시작 - 사용자Id: {}, 구간Id: {}",
-                    eventIssuedEvent.getMessage().getUserId(),
-                    eventIssuedEvent.getMessage().getSectorId());
+            tracker.info("이벤트 처리 시작 - SectorId: {}", eventIssuedEvent.getMessage().getSectorId());
 
             // 1. 데이터베이스 연결 풀 확인
             if (!isIdleConnectionAvailable()) {
@@ -124,9 +121,9 @@ public class EventIssuedEventHandler {
 
         } catch (NoEventStockLeftException e) {
             // 좌석 부족은 정상적인 비즈니스 로직이므로 Redis에서 제거
+            waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
             tracker.info(
                     "잔여 좌석 없음, 큐에서 제거 - SectorId: {}", eventIssuedEvent.getMessage().getSectorId());
-            waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
 
         } catch (Exception e) {
             // 시스템 예외 발생 시 로깅만 하고 Redis에서 제거하지 않음
@@ -155,7 +152,6 @@ public class EventIssuedEventHandler {
     private void saveRegistration(
             Sector sector, User user, Registration registration, Double score) {
         if (!sector.isRemainingAmount()) {
-            tracker.info("[잔여 좌석 없음]. RegistrationId: {}", registration.getId());
             throw NoEventStockLeftException.EXCEPTION;
         }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/common/aop/QueueFailureHandling.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/common/aop/QueueFailureHandling.java
@@ -1,0 +1,20 @@
+package com.jnu.ticketapi.common.aop;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface QueueFailureHandling {
+    /** 최대 재시도 횟수 */
+    int maxRetries() default 3;
+
+    /** 즉시 제거 대상 예외 클래스들 (재시도하지 않고 바로 큐에서 제거) 정상적인 비즈니스 로직으로 인한 예외들 */
+    Class<? extends Throwable>[] removeImmediatelyExceptions();
+
+    /** 실패 카운트 키 생성 전략 */
+    String failCountKeyPrefix() default "fail_count:";
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/common/aop/QueueFailureHandlingAspect.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/common/aop/QueueFailureHandlingAspect.java
@@ -1,0 +1,109 @@
+package com.jnu.ticketapi.common.aop;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_FAILURE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+
+import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class QueueFailureHandlingAspect {
+
+    private final WaitingQueueService waitingQueueService;
+    private static final Logger tracker = LoggerFactory.getLogger("processTracker");
+
+    @Around("@annotation(queueFailureHandling)")
+    public Object handleQueueFailures(
+            ProceedingJoinPoint joinPoint, QueueFailureHandling queueFailureHandling)
+            throws Throwable {
+
+        // 메서드 파라미터에서 EventIssuedEvent 추출
+        EventIssuedEvent event = extractEventFromArgs(joinPoint.getArgs());
+        if (event == null) {
+            return joinPoint.proceed();
+        }
+
+        Long userId = event.getMessage().getUserId();
+        String failCountKey = queueFailureHandling.failCountKeyPrefix() + userId;
+
+        try {
+            // 실제 비즈니스 로직 실행
+            return joinPoint.proceed();
+
+        } catch (Exception e) {
+            handleException(e, event, queueFailureHandling, failCountKey);
+            return null;
+        }
+    }
+
+    private void handleException(
+            Exception e,
+            EventIssuedEvent event,
+            QueueFailureHandling annotation,
+            String failCountKey) {
+
+        Long userId = event.getMessage().getUserId();
+        Class<? extends Throwable> exceptionClass = e.getClass();
+
+        // 1. 즉시 제거 대상 예외 확인 (정상적인 비즈니스 로직)
+        if (isImmediateRemovalException(exceptionClass, annotation.removeImmediatelyExceptions())) {
+            waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, event.getMessage());
+            tracker.info(
+                    "비즈니스 로직 예외, 큐에서 제거 - UserId: {}, 예외: {}",
+                    userId,
+                    e.getClass().getSimpleName());
+            return; // failCount 증가 없이 종료
+        }
+
+        // 2. 즉시 제거 대상 예외가 아닌 예외는 failCount 증가
+        int failCount = waitingQueueService.incrementFailCount(failCountKey);
+
+        if (failCount > annotation.maxRetries()) {
+            waitingQueueService.clearFailCount(failCountKey);
+            waitingQueueService.remove(REDIS_EVENT_ISSUE_STORE, event.getMessage());
+            waitingQueueService.registerQueue(
+                    REDIS_EVENT_FAILURE_STORE, event.getMessage(), event.getScore());
+            tracker.error(
+                    "재시도 한계 초과 ({}회), 큐에서 제거 및 실패 큐에 저장 - UserId: {}, 예외: {}",
+                    failCount,
+                    userId,
+                    e.getMessage(),
+                    e);
+        } else {
+            tracker.error(
+                    "재시도 가능 예외 발생 ({}/{}회) - UserId: {}, 예외타입: {}, 메시지: {}",
+                    failCount,
+                    annotation.maxRetries(),
+                    userId,
+                    e.getClass().getSimpleName(),
+                    e.getMessage());
+        }
+    }
+
+    private boolean isImmediateRemovalException(
+            Class<? extends Throwable> exceptionClass,
+            Class<? extends Throwable>[] removeExceptions) {
+        return Arrays.stream(removeExceptions)
+                .anyMatch(remove -> remove.isAssignableFrom(exceptionClass));
+    }
+
+    private EventIssuedEvent extractEventFromArgs(Object[] args) {
+        return Arrays.stream(args)
+                .filter(EventIssuedEvent.class::isInstance)
+                .map(EventIssuedEvent.class::cast)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/RetryConfig.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/RetryConfig.java
@@ -1,9 +1,9 @@
 package com.jnu.ticketapi.config;
 
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;
 
 @Configuration
 @EnableRetry
-public class RetryConfig {
-}
+public class RetryConfig {}

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -29,7 +29,6 @@ public class ProcessQueueDataJob implements Job {
     @Autowired private SectorThreadPoolManager sectorThreadPoolManager;
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
 
-
     private final int batchSize = 10;
 
     @Override

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -1,10 +1,13 @@
 package com.jnu.ticketbatch.config;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import com.jnu.ticketinfrastructure.service.queue.SectorThreadPoolManager;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
@@ -14,21 +17,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
-import java.util.List;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
-
 @Slf4j
 @DisallowConcurrentExecution
 public class ProcessQueueDataJob implements Job {
-    @Autowired
-    private ApplicationEventPublisher publisher;
+    @Autowired private ApplicationEventPublisher publisher;
 
-    @Autowired
-    private WaitingQueueService waitingQueueService;
+    @Autowired private WaitingQueueService waitingQueueService;
 
-    @Autowired
-    private SectorThreadPoolManager sectorThreadPoolManager;
+    @Autowired private SectorThreadPoolManager sectorThreadPoolManager;
 
     private final int batchSize = 10;
 
@@ -37,7 +33,7 @@ public class ProcessQueueDataJob implements Job {
         try {
 
             // 1. Redis에서 배치로 데이터 가져오기 (제거하지 않음)
-            List<TypedTuple<Object>> batch = 
+            List<TypedTuple<Object>> batch =
                     waitingQueueService.peekBatch(REDIS_EVENT_ISSUE_STORE, batchSize);
 
             if (batch.isEmpty()) {
@@ -54,11 +50,13 @@ public class ProcessQueueDataJob implements Job {
                 Double score = messageWithScore.getScore();
 
                 // 해당 구간의 미리 생성된 스레드풀에 개별 작업 제출
-                sectorThreadPoolManager.submitToSector(sectorId, () -> {
-                    // 각 스레드에서 Publisher 설정
-                    Events.setPublisher(publisher);
-                    Events.raise(EventIssuedEvent.from(message, score));
-                });
+                sectorThreadPoolManager.submitToSector(
+                        sectorId,
+                        () -> {
+                            // 각 스레드에서 Publisher 설정
+                            Events.setPublisher(publisher);
+                            Events.raise(EventIssuedEvent.from(message, score));
+                        });
             }
 
             log.info("All {} messages distributed to sector thread pools", batch.size());
@@ -68,4 +66,3 @@ public class ProcessQueueDataJob implements Job {
         }
     }
 }
-

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -1,43 +1,71 @@
 package com.jnu.ticketbatch.config;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
-
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
-import java.util.Set;
+import com.jnu.ticketinfrastructure.service.queue.SectorThreadPoolManager;
 import lombok.extern.slf4j.Slf4j;
-import org.quartz.*;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
+import java.util.List;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+
 @Slf4j
 @DisallowConcurrentExecution
 public class ProcessQueueDataJob implements Job {
-    @Autowired private ApplicationEventPublisher publisher;
+    @Autowired
+    private ApplicationEventPublisher publisher;
 
-    @Autowired private WaitingQueueService waitingQueueService;
+    @Autowired
+    private WaitingQueueService waitingQueueService;
+
+    @Autowired
+    private SectorThreadPoolManager sectorThreadPoolManager;
+
+    private final int batchSize = 10;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         try {
-            // 현재 쓰레드에 ApplicationEventPublisher를 설정
-            Events.setPublisher(publisher);
 
-            Set<TypedTuple<Object>> messagesWithScores =
-                    waitingQueueService.findAllWithScore(REDIS_EVENT_ISSUE_STORE);
+            // 1. Redis에서 배치로 데이터 가져오기 (제거하지 않음)
+            List<TypedTuple<Object>> batch = 
+                    waitingQueueService.peekBatch(REDIS_EVENT_ISSUE_STORE, batchSize);
 
-            if (!messagesWithScores.isEmpty()) {
-                for (TypedTuple<Object> messageWithScore : messagesWithScores) {
-                    Double score = messageWithScore.getScore();
-                    ChatMessage message = (ChatMessage) messageWithScore.getValue();
-                    Events.raise(EventIssuedEvent.from(message, score));
-                }
+            if (batch.isEmpty()) {
+                log.info("No messages in the queue to process.");
+                return;
             }
+
+            log.info("Found {} messages to process", batch.size());
+
+            // 2. 각 메시지를 해당하는 구간의 미리 생성된 스레드풀에 개별 분배
+            for (TypedTuple<Object> messageWithScore : batch) {
+                ChatMessage message = (ChatMessage) messageWithScore.getValue();
+                Long sectorId = message.getSectorId();
+                Double score = messageWithScore.getScore();
+
+                // 해당 구간의 미리 생성된 스레드풀에 개별 작업 제출
+                sectorThreadPoolManager.submitToSector(sectorId, () -> {
+                    // 각 스레드에서 Publisher 설정
+                    Events.setPublisher(publisher);
+                    Events.raise(EventIssuedEvent.from(message, score));
+                });
+            }
+
+            log.info("All {} messages distributed to sector thread pools", batch.size());
+
         } catch (Exception e) {
-            log.error("ProcessQueueDataJob Exception: {}", e.getMessage());
+            log.error("ProcessQueueDataJob Exception: {}", e.getMessage(), e);
         }
     }
 }
+

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -13,6 +13,8 @@ import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
@@ -25,6 +27,8 @@ public class ProcessQueueDataJob implements Job {
     @Autowired private WaitingQueueService waitingQueueService;
 
     @Autowired private SectorThreadPoolManager sectorThreadPoolManager;
+    private static final Logger tracker = LoggerFactory.getLogger("processTracker");
+
 
     private final int batchSize = 10;
 
@@ -37,11 +41,8 @@ public class ProcessQueueDataJob implements Job {
                     waitingQueueService.peekBatch(REDIS_EVENT_ISSUE_STORE, batchSize);
 
             if (batch.isEmpty()) {
-                log.info("No messages in the queue to process.");
                 return;
             }
-
-            log.info("Found {} messages to process", batch.size());
 
             // 2. 각 메시지를 해당하는 구간의 미리 생성된 스레드풀에 개별 분배
             for (TypedTuple<Object> messageWithScore : batch) {
@@ -59,10 +60,10 @@ public class ProcessQueueDataJob implements Job {
                         });
             }
 
-            log.info("All {} messages distributed to sector thread pools", batch.size());
+            tracker.info("{} 개의 메시지를 처리 대기열에 제출함", batch.size());
 
         } catch (Exception e) {
-            log.error("ProcessQueueDataJob Exception: {}", e.getMessage(), e);
+            log.error("ProcessQueueDataJob 실행 중 오류 발생", e);
         }
     }
 }

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/QuartzJobLauncher.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/QuartzJobLauncher.java
@@ -4,6 +4,7 @@ package com.jnu.ticketbatch.config;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
+import com.jnu.ticketinfrastructure.service.queue.SectorThreadPoolManager;
 import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
@@ -14,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 @RequiredArgsConstructor
 public class QuartzJobLauncher implements Job {
     @Autowired private EventAdaptor eventAdaptor;
+    @Autowired private SectorThreadPoolManager sectorThreadPoolManager;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -21,5 +23,6 @@ public class QuartzJobLauncher implements Job {
         Long eventId = jobDataMap.getLong("eventId");
         Event event = eventAdaptor.findById(eventId);
         eventAdaptor.updateEventStatus(event, EventStatus.OPEN);
+        sectorThreadPoolManager.initializeSectorThreadPools(eventId);
     }
 }

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -8,6 +8,7 @@ import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import com.jnu.ticketinfrastructure.service.queue.SectorThreadPoolManager;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -30,6 +31,7 @@ public class BatchQuartzJob extends QuartzJobBean {
     @Autowired RedisRepository redisRepository;
     @Autowired RegistrationAdaptor registrationAdaptor;
     @Autowired EventExpiredEventRaiseGateway eventExpiredEventRaiseGateway;
+    @Autowired private SectorThreadPoolManager sectorThreadPoolManager;
 
     @Override
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
@@ -38,6 +40,7 @@ public class BatchQuartzJob extends QuartzJobBean {
         Event event = eventAdaptor.findById(eventId);
         redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
+        sectorThreadPoolManager.shutdownSectorThreadPools(eventId);
 
         JobParameters jobParameters =
                 new JobParametersBuilder(this.jobExplorer)

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
@@ -30,6 +30,7 @@ public class TicketStatic {
 
     public static final String REDIS_EVENT_CHANNEL = "쿠폰 발급 채널";
     public static final String REDIS_EVENT_ISSUE_STORE = "쿠폰 발급 저장소";
+    public static final String REDIS_EVENT_FAILURE_STORE = "쿠폰 발급 실패 저장소";
 
     public static final Integer REGISTRATION_SIZE = 14;
     public static final Integer MAX_EMAIL_SEND_RETRY = 10;

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/GlobalErrorCode.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/GlobalErrorCode.java
@@ -80,7 +80,7 @@ public enum GlobalErrorCode implements BaseErrorCode {
     TOO_MANY_REQUEST(TOO_MANY_REQUESTS, "GLOBAL_429_1", "과도한 요청을 보내셨습니다. 잠시 기다려 주세요."),
     INVALID_PASSWORD(BAD_REQUEST, "GLOBAL_400_4", "비밀번호는 10자 이상 숫자, 특수문자를 포함해야 합니다."),
     GLOBAL_FORBIDDEN(FORBIDDEN, "GLOBAL_403_1", "Global Forbidden"),
-    ;
+    JSON_PROCESSING_ERROR(INTERNAL_SERVER, "GLOBAL_500_4", "JSON 객체 변환중 오류가 발생했습니다.");
     private Integer status;
     private String code;
     private String reason;

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/JsonProcessErrorException.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/exception/JsonProcessErrorException.java
@@ -1,0 +1,9 @@
+package com.jnu.ticketcommon.exception;
+
+public class JsonProcessErrorException extends TicketCodeException {
+    public static final TicketCodeException EXCEPTION = new JsonProcessErrorException();
+
+    private JsonProcessErrorException() {
+        super(GlobalErrorCode.JSON_PROCESSING_ERROR);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -127,4 +127,9 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
     public void deleteByEvent(Long eventId) {
         sectorRepository.deleteByEventId(eventId);
     }
+
+    @Override
+    public void decreaseRemainingAmount(Long sectorId) {
+        sectorRepository.decreaseRemainingAmount(sectorId);
+    }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -61,7 +61,6 @@ public class Event {
     @Column(name = "is_deleted")
     private boolean isDeleted;
 
-
     @Builder
     public Event(DateTimePeriod dateTimePeriod, List<Sector> sector, String title) {
         this.eventCode = UUID.randomUUID().toString().substring(0, 6);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorRecordPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorRecordPort.java
@@ -16,4 +16,6 @@ public interface SectorRecordPort {
     void delete(Long sectorId);
 
     void deleteByEvent(Long eventId);
+
+    void decreaseRemainingAmount(Long sectorId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -31,4 +31,8 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
     @Query("update Sector s SET s.isDeleted = true where s.id = :sectorId")
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     void delete(Long sectorId);
+
+    @Modifying
+    @Query("UPDATE Sector s SET s.remainingAmount = s.remainingAmount -1  WHERE s.id = :sectorId AND s.remainingAmount > 0 ")
+    void decreaseRemainingAmount(@Param("sectorId") Long sectorId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -33,6 +33,7 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
     void delete(Long sectorId);
 
     @Modifying
-    @Query("UPDATE Sector s SET s.remainingAmount = s.remainingAmount -1  WHERE s.id = :sectorId AND s.remainingAmount > 0 ")
+    @Query(
+            "UPDATE Sector s SET s.remainingAmount = s.remainingAmount -1  WHERE s.id = :sectorId AND s.remainingAmount > 0 ")
     void decreaseRemainingAmount(@Param("sectorId") Long sectorId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -36,7 +36,6 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
         return registrationRepository.save(registration);
     }
 
-
     @Override
     public void delete(Registration registration) {
         registrationRepository.delete(registration);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -36,9 +36,6 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
         return registrationRepository.save(registration);
     }
 
-    public void updateSavedAt(Registration registration) {
-        registrationRepository.updateSavedAt(registration.getId());
-    }
 
     @Override
     public void delete(Registration registration) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -160,7 +160,6 @@ public class Registration {
 
     public Registration() {}
 
-
     public void updateIsDeleted(boolean isDeleted) {
         this.isDeleted = isDeleted;
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -160,10 +160,6 @@ public class Registration {
 
     public Registration() {}
 
-    public void finalSave() {
-        this.isSaved = true;
-        this.savedAt = System.nanoTime();
-    }
 
     public void updateIsDeleted(boolean isDeleted) {
         this.isDeleted = isDeleted;
@@ -195,5 +191,9 @@ public class Registration {
 
     public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public void setSavedAt(Long savedAt) {
+        this.savedAt = savedAt;
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -37,13 +37,6 @@ public interface RegistrationRepository
             "select r from Registration r join fetch r.sector join fetch r.user where r.isSaved = true and r.sector.event.id = :eventId")
     List<Registration> findByIsDeletedFalseAndIsSavedTrue(@Param("eventId") Long eventId);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query(
-            value =
-                    "update registration_tb set saved_at = (UNIX_TIMESTAMP(NOW(6))*1000000) where id = :id",
-            nativeQuery = true)
-    void updateSavedAt(@Param("id") Long registrationId);
-
     @Query(
             "select r from Registration r where r.isDeleted = false and r.isSaved = true and r.sector.event.id = :eventId")
     Page<Registration> findByIsDeletedFalseAndIsSavedTrueByPage(

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
@@ -1,5 +1,7 @@
 package com.jnu.ticketdomain.domains.registration.repository;
 
+import static com.jnu.ticketdomain.domains.registration.domain.QRegistration.registration;
+
 import com.jnu.ticketdomain.domains.events.domain.QSector;
 import com.jnu.ticketdomain.domains.registration.domain.QRegistration;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
@@ -8,13 +10,10 @@ import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
-import javax.persistence.EntityManager;
-import java.util.List;
-
-import static com.jnu.ticketdomain.domains.registration.domain.QRegistration.registration;
 
 @Repository
 @RequiredArgsConstructor
@@ -27,7 +26,11 @@ public class RegistrationRepositoryCustomImpl implements RegistrationRepositoryC
         return queryFactory
                         .selectOne()
                         .from(registration)
-                        .where(registration.email.eq(email).and(isSavedAndEqEvent(registration, eventId)))
+                        .where(
+                                registration
+                                        .email
+                                        .eq(email)
+                                        .and(isSavedAndEqEvent(registration, eventId)))
                         .fetchFirst()
                 != null;
     }
@@ -38,7 +41,8 @@ public class RegistrationRepositoryCustomImpl implements RegistrationRepositoryC
                         .selectOne()
                         .from(registration)
                         .where(
-                                registration.studentNum
+                                registration
+                                        .studentNum
                                         .eq(studentNum)
                                         .and(isSavedAndEqEvent(registration, eventId)))
                         .fetchFirst()

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/registration/RegistrationRepositoryTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/registration/RegistrationRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.jnu.ticketdomain.domains.registration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
@@ -7,24 +9,19 @@ import com.jnu.ticketdomain.domains.registration.repository.RegistrationReposito
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.fixture.RegistrationTestBuilder;
 import com.jnu.ticketdomain.fixture.UserTestBuilder;
+import java.util.List;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import javax.persistence.EntityManager;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DataJpaTest
 public class RegistrationRepositoryTest {
 
-    @Autowired
-    private RegistrationRepository registrationRepository;
+    @Autowired private RegistrationRepository registrationRepository;
 
-    @Autowired
-    private EntityManager em;
+    @Autowired private EntityManager em;
 
     @Test
     @DisplayName("성공 : 정렬조건대로 정상조회된다")
@@ -33,46 +30,55 @@ public class RegistrationRepositoryTest {
         Event event = Event.builder().title("이벤트").build();
         em.persist(event);
 
-        Sector sector1 = Sector.builder().sectorNumber("1구간").name("소프트웨어공학과").sectorCapacity(10).reserve(1).build();
-        Sector sector2 = Sector.builder().sectorNumber("2구간").name("전자컴퓨터공학과").sectorCapacity(10).reserve(1).build();
+        Sector sector1 =
+                Sector.builder()
+                        .sectorNumber("1구간")
+                        .name("소프트웨어공학과")
+                        .sectorCapacity(10)
+                        .reserve(1)
+                        .build();
+        Sector sector2 =
+                Sector.builder()
+                        .sectorNumber("2구간")
+                        .name("전자컴퓨터공학과")
+                        .sectorCapacity(10)
+                        .reserve(1)
+                        .build();
         sector1.setEvent(event);
         sector2.setEvent(event);
 
         em.persist(sector1);
         em.persist(sector2);
 
-        User user1 = UserTestBuilder.builder()
-                .withEmail("success1@example.com")
-                .asSuccess()
-                .build();
-        User user2 = UserTestBuilder.builder()
-                .withEmail("prepare1@example.com")
-                .asPrepare(1)
-                .build();
-        User user3 = UserTestBuilder.builder()
-                .withEmail("success2@example.com")
-                .asSuccess()
-                .build();
+        User user1 =
+                UserTestBuilder.builder().withEmail("success1@example.com").asSuccess().build();
+        User user2 =
+                UserTestBuilder.builder().withEmail("prepare1@example.com").asPrepare(1).build();
+        User user3 =
+                UserTestBuilder.builder().withEmail("success2@example.com").asSuccess().build();
 
         em.persist(user1);
         em.persist(user2);
         em.persist(user3);
 
-        Registration reg1 = RegistrationTestBuilder.builder()
-                .withUser(user1)
-                .withSector(sector1)
-                .withStudentNum("10001")
-                .build();
-        Registration reg2 = RegistrationTestBuilder.builder()
-                .withUser(user2)
-                .withSector(sector1)
-                .withStudentNum("10002")
-                .build();
-        Registration reg3 = RegistrationTestBuilder.builder()
-                .withUser(user3)
-                .withSector(sector2)
-                .withStudentNum("10003")
-                .build();
+        Registration reg1 =
+                RegistrationTestBuilder.builder()
+                        .withUser(user1)
+                        .withSector(sector1)
+                        .withStudentNum("10001")
+                        .build();
+        Registration reg2 =
+                RegistrationTestBuilder.builder()
+                        .withUser(user2)
+                        .withSector(sector1)
+                        .withStudentNum("10002")
+                        .build();
+        Registration reg3 =
+                RegistrationTestBuilder.builder()
+                        .withUser(user3)
+                        .withSector(sector2)
+                        .withStudentNum("10003")
+                        .build();
 
         em.persist(reg1);
         em.persist(reg2);
@@ -81,7 +87,8 @@ public class RegistrationRepositoryTest {
         em.clear();
 
         // when
-        List<Registration> result = registrationRepository.findSortedRegistrationsByEventId(event.getId());
+        List<Registration> result =
+                registrationRepository.findSortedRegistrationsByEventId(event.getId());
 
         // then
         assertThat(result).hasSize(3);
@@ -91,5 +98,4 @@ public class RegistrationRepositoryTest {
         assertThat(result.get(1).getUser().getEmail()).isEqualTo("prepare1@example.com");
         assertThat(result.get(2).getUser().getEmail()).isEqualTo("success2@example.com");
     }
-
 }

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/fixture/RegistrationTestBuilder.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/fixture/RegistrationTestBuilder.java
@@ -1,9 +1,9 @@
 package com.jnu.ticketdomain.fixture;
 
+
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.User;
-
 import java.time.LocalDateTime;
 
 public class RegistrationTestBuilder {

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/fixture/UserTestBuilder.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/fixture/UserTestBuilder.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketdomain.fixture;
 
+
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.domain.UserRole;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
@@ -45,11 +46,7 @@ public class UserTestBuilder {
     }
 
     public User build() {
-        User user = User.builder()
-                .email(email)
-                .pwd(pwd)
-                .userRole(userRole)
-                .build();
+        User user = User.builder().email(email).pwd(pwd).userRole(userRole).build();
 
         // 상태 세팅
         switch (status) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
@@ -65,6 +65,7 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(serializer);
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashValueSerializer(serializer);
+        redisTemplate.setEnableTransactionSupport(true);
         return redisTemplate;
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
@@ -17,9 +17,6 @@ public class EventIssuedEvent extends InfrastructureEvent {
 
     @Override
     public String toString() {
-        return "EventIssuedEvent{" +
-                "message=" + message +
-                ", score=" + score +
-                '}';
+        return "EventIssuedEvent{" + "message=" + message + ", score=" + score + '}';
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
@@ -18,11 +18,16 @@ public class ChatMessage {
 
     @Override
     public String toString() {
-        return "ChatMessage{" +
-                "registration='" + registration + '\'' +
-                ", userId=" + userId +
-                ", sectorId=" + sectorId +
-                ", eventId=" + eventId +
-                '}';
+        return "ChatMessage{"
+                + "registration='"
+                + registration
+                + '\''
+                + ", userId="
+                + userId
+                + ", sectorId="
+                + sectorId
+                + ", eventId="
+                + eventId
+                + '}';
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,9 +3,13 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.connection.ReturnType;
@@ -127,5 +131,13 @@ public class RedisRepository {
             // Set is empty, return null or handle accordingly
             return null;
         }
+    }
+
+    public Long increment(String key) {
+        return redisTemplate.opsForValue().increment(key);
+    }
+
+    public void expire(String key, Duration duration) {
+        redisTemplate.expire(key, duration);
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,13 +3,10 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
-
 import java.time.Duration;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.connection.ReturnType;

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -1,11 +1,14 @@
 package com.jnu.ticketinfrastructure.service;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -15,10 +18,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
-
 @Service
 @Slf4j
 @ConditionalOnExpression("${ableRedis:true}")
@@ -27,8 +26,7 @@ public class WaitingQueueService {
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
 
     private final RedisRepository redisRepository;
-    @Autowired
-    private ObjectMapper objectMapper;
+    @Autowired private ObjectMapper objectMapper;
 
     public WaitingQueueService(RedisRepository redisRepository) {
         this.redisRepository = redisRepository;
@@ -116,9 +114,7 @@ public class WaitingQueueService {
         return redisRepository.zRangeWithScores(key, 0L, -1L);
     }
 
-    /**
-     * 배치로 데이터를 가져오되 Redis에서 제거하지 않음 (peek)
-     */
+    /** 배치로 데이터를 가져오되 Redis에서 제거하지 않음 (peek) */
     public List<ZSetOperations.TypedTuple<Object>> peekBatch(String key, int batchSize) {
         Set<ZSetOperations.TypedTuple<Object>> batch =
                 redisRepository.zRangeWithScores(key, 0L, (long) batchSize - 1);

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -44,6 +44,10 @@ public class WaitingQueueService {
         tracker.info("Added to the queue, score:{}", score);
     }
 
+    public void registerQueue(String key, Object value, Double score) {
+        redisRepository.zAddIfAbsent(key, value, score);
+    }
+
     public String convertRegistrationJSON(Registration registration) {
         JSONObject registrationJson = new JSONObject();
         registrationJson.put("email", registration.getEmail());

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -1,16 +1,11 @@
 package com.jnu.ticketinfrastructure.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
-import java.util.LinkedList;
-import java.util.Queue;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -20,6 +15,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
+import java.util.*;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
+
 @Service
 @Slf4j
 @ConditionalOnExpression("${ableRedis:true}")
@@ -28,7 +27,8 @@ public class WaitingQueueService {
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
 
     private final RedisRepository redisRepository;
-    @Autowired private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     public WaitingQueueService(RedisRepository redisRepository) {
         this.redisRepository = redisRepository;
@@ -114,5 +114,14 @@ public class WaitingQueueService {
 
     public Set<ZSetOperations.TypedTuple<Object>> findAllWithScore(String key) {
         return redisRepository.zRangeWithScores(key, 0L, -1L);
+    }
+
+    /**
+     * 배치로 데이터를 가져오되 Redis에서 제거하지 않음 (peek)
+     */
+    public List<ZSetOperations.TypedTuple<Object>> peekBatch(String key, int batchSize) {
+        Set<ZSetOperations.TypedTuple<Object>> batch =
+                redisRepository.zRangeWithScores(key, 0L, (long) batchSize - 1);
+        return new ArrayList<>(batch);
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -8,7 +8,10 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
+
+import java.time.Duration;
 import java.util.*;
+
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -26,7 +29,9 @@ public class WaitingQueueService {
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
 
     private final RedisRepository redisRepository;
-    @Autowired private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
+
 
     public WaitingQueueService(RedisRepository redisRepository) {
         this.redisRepository = redisRepository;
@@ -114,10 +119,23 @@ public class WaitingQueueService {
         return redisRepository.zRangeWithScores(key, 0L, -1L);
     }
 
-    /** 배치로 데이터를 가져오되 Redis에서 제거하지 않음 (peek) */
+    /**
+     * 배치로 데이터를 가져오되 Redis에서 제거하지 않음 (peek)
+     */
     public List<ZSetOperations.TypedTuple<Object>> peekBatch(String key, int batchSize) {
         Set<ZSetOperations.TypedTuple<Object>> batch =
                 redisRepository.zRangeWithScores(key, 0L, (long) batchSize - 1);
         return new ArrayList<>(batch);
+    }
+
+    public int incrementFailCount(String key) {
+        Long count = redisRepository.increment(key);
+        // TTL 설정 (1시간 후 자동 삭제)
+        redisRepository.expire(key, Duration.ofHours(1));
+        return count.intValue();
+    }
+
+    public void clearFailCount(String key) {
+        redisRepository.delete(key);
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -8,10 +8,8 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
-
 import java.time.Duration;
 import java.util.*;
-
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -29,9 +27,7 @@ public class WaitingQueueService {
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
 
     private final RedisRepository redisRepository;
-    @Autowired
-    private ObjectMapper objectMapper;
-
+    @Autowired private ObjectMapper objectMapper;
 
     public WaitingQueueService(RedisRepository redisRepository) {
         this.redisRepository = redisRepository;
@@ -119,9 +115,7 @@ public class WaitingQueueService {
         return redisRepository.zRangeWithScores(key, 0L, -1L);
     }
 
-    /**
-     * 배치로 데이터를 가져오되 Redis에서 제거하지 않음 (peek)
-     */
+    /** 배치로 데이터를 가져오되 Redis에서 제거하지 않음 (peek) */
     public List<ZSetOperations.TypedTuple<Object>> peekBatch(String key, int batchSize) {
         Set<ZSetOperations.TypedTuple<Object>> batch =
                 redisRepository.zRangeWithScores(key, 0L, (long) batchSize - 1);

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/queue/SectorThreadPoolManager.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/queue/SectorThreadPoolManager.java
@@ -1,16 +1,16 @@
 package com.jnu.ticketinfrastructure.service.queue;
 
+
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import javax.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.utils.ThreadFactoryBuilder;
-
-import javax.annotation.PreDestroy;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.*;
 
 @Component
 @Slf4j
@@ -21,9 +21,7 @@ public class SectorThreadPoolManager {
     private final Map<Long, BlockingQueue<Runnable>> sectorQueues = new ConcurrentHashMap<>();
     private final SectorAdaptor sectorAdaptor;
 
-    /**
-     * Event OPEN 될 때 해당 Event의 모든 Sector에 대해 스레드풀 미리 생성
-     */
+    /** Event OPEN 될 때 해당 Event의 모든 Sector에 대해 스레드풀 미리 생성 */
     public void initializeSectorThreadPools(Long eventId) {
         List<Sector> eventSectors = sectorAdaptor.findByEventId(eventId);
 
@@ -45,27 +43,26 @@ public class SectorThreadPoolManager {
         sectorQueues.put(sectorId, sectorQueue);
 
         // 구간별 전용 스레드풀 생성 (단일 스레드로 순차 처리 보장)
-        ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .threadNamePrefix("sector-" + sectorId + "-worker-%d")
-                .build();
+        ThreadFactory threadFactory =
+                new ThreadFactoryBuilder()
+                        .threadNamePrefix("sector-" + sectorId + "-worker-%d")
+                        .build();
 
         int threadPoolSize = 1;
-        ExecutorService executor = new ThreadPoolExecutor(
-                threadPoolSize,
-                threadPoolSize,
-                0L,
-                TimeUnit.MILLISECONDS,
-                sectorQueue,
-                threadFactory
-        );
+        ExecutorService executor =
+                new ThreadPoolExecutor(
+                        threadPoolSize,
+                        threadPoolSize,
+                        0L,
+                        TimeUnit.MILLISECONDS,
+                        sectorQueue,
+                        threadFactory);
 
         sectorExecutors.put(sectorId, executor);
         log.info("Sector {} 전용 스레드풀 생성 완료", sectorId);
     }
 
-    /**
-     * 특정 구간의 스레드풀에 작업 제출
-     */
+    /** 특정 구간의 스레드풀에 작업 제출 */
     public void submitToSector(Long sectorId, Runnable task) {
         ExecutorService executor = sectorExecutors.get(sectorId);
 
@@ -79,9 +76,7 @@ public class SectorThreadPoolManager {
         executor.submit(task);
     }
 
-    /**
-     * Event 종료 시 해당 Event의 모든 Sector 스레드풀 정리
-     */
+    /** Event 종료 시 해당 Event의 모든 Sector 스레드풀 정리 */
     public void shutdownSectorThreadPools(Long eventId) {
         List<Sector> eventSectors = sectorAdaptor.findByEventId(eventId);
 
@@ -115,20 +110,22 @@ public class SectorThreadPoolManager {
     public void shutdown() {
         log.info("모든 Sector 스레드풀 종료 시작...");
 
-        sectorExecutors.forEach((sectorId, executor) -> {
-            executor.shutdown();
-        });
+        sectorExecutors.forEach(
+                (sectorId, executor) -> {
+                    executor.shutdown();
+                });
 
-        sectorExecutors.forEach((sectorId, executor) -> {
-            try {
-                if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
-                    executor.shutdownNow();
-                }
-            } catch (InterruptedException e) {
-                executor.shutdownNow();
-                Thread.currentThread().interrupt();
-            }
-        });
+        sectorExecutors.forEach(
+                (sectorId, executor) -> {
+                    try {
+                        if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+                            executor.shutdownNow();
+                        }
+                    } catch (InterruptedException e) {
+                        executor.shutdownNow();
+                        Thread.currentThread().interrupt();
+                    }
+                });
 
         sectorExecutors.clear();
         sectorQueues.clear();

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/queue/SectorThreadPoolManager.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/queue/SectorThreadPoolManager.java
@@ -1,0 +1,137 @@
+package com.jnu.ticketinfrastructure.service.queue;
+
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
+
+import javax.annotation.PreDestroy;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SectorThreadPoolManager {
+
+    private final Map<Long, ExecutorService> sectorExecutors = new ConcurrentHashMap<>();
+    private final Map<Long, BlockingQueue<Runnable>> sectorQueues = new ConcurrentHashMap<>();
+    private final SectorAdaptor sectorAdaptor;
+
+    /**
+     * Event OPEN 될 때 해당 Event의 모든 Sector에 대해 스레드풀 미리 생성
+     */
+    public void initializeSectorThreadPools(Long eventId) {
+        List<Sector> eventSectors = sectorAdaptor.findByEventId(eventId);
+
+        for (Sector sector : eventSectors) {
+            createThreadPoolForSector(sector.getId());
+        }
+
+        log.info("Event {} - 구간별 스레드풀 생성 완료: {} 개", eventId, eventSectors.size());
+    }
+
+    private void createThreadPoolForSector(Long sectorId) {
+        if (sectorExecutors.containsKey(sectorId)) {
+            log.info("Sector {} 스레드풀이 이미 존재합니다.", sectorId);
+            return;
+        }
+
+        // 구간별 전용 큐 생성
+        BlockingQueue<Runnable> sectorQueue = new LinkedBlockingQueue<>();
+        sectorQueues.put(sectorId, sectorQueue);
+
+        // 구간별 전용 스레드풀 생성 (단일 스레드로 순차 처리 보장)
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .threadNamePrefix("sector-" + sectorId + "-worker-%d")
+                .build();
+
+        int threadPoolSize = 1;
+        ExecutorService executor = new ThreadPoolExecutor(
+                threadPoolSize,
+                threadPoolSize,
+                0L,
+                TimeUnit.MILLISECONDS,
+                sectorQueue,
+                threadFactory
+        );
+
+        sectorExecutors.put(sectorId, executor);
+        log.info("Sector {} 전용 스레드풀 생성 완료", sectorId);
+    }
+
+    /**
+     * 특정 구간의 스레드풀에 작업 제출
+     */
+    public void submitToSector(Long sectorId, Runnable task) {
+        ExecutorService executor = sectorExecutors.get(sectorId);
+
+        if (executor == null) {
+            log.error("Sector {} 스레드풀이 존재하지 않습니다.", sectorId);
+            // 동적 생성 (비상용)
+            createThreadPoolForSector(sectorId);
+            executor = sectorExecutors.get(sectorId);
+        }
+
+        executor.submit(task);
+    }
+
+    /**
+     * Event 종료 시 해당 Event의 모든 Sector 스레드풀 정리
+     */
+    public void shutdownSectorThreadPools(Long eventId) {
+        List<Sector> eventSectors = sectorAdaptor.findByEventId(eventId);
+
+        for (Sector sector : eventSectors) {
+            shutdownSectorThreadPool(sector.getId());
+        }
+
+        log.info("Event {} - 모든 구간 스레드풀 종료 완료", eventId);
+    }
+
+    private void shutdownSectorThreadPool(Long sectorId) {
+        ExecutorService executor = sectorExecutors.remove(sectorId);
+        sectorQueues.remove(sectorId);
+
+        if (executor != null) {
+            executor.shutdown();
+            try {
+                if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+                    executor.shutdownNow();
+                }
+                log.info("Sector {} 스레드풀 종료 완료", sectorId);
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
+                log.warn("Sector {} 스레드풀 강제 종료", sectorId);
+            }
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        log.info("모든 Sector 스레드풀 종료 시작...");
+
+        sectorExecutors.forEach((sectorId, executor) -> {
+            executor.shutdown();
+        });
+
+        sectorExecutors.forEach((sectorId, executor) -> {
+            try {
+                if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+                    executor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        sectorExecutors.clear();
+        sectorQueues.clear();
+        log.info("모든 Sector 스레드풀 종료 완료");
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
~1. transactionsynchronization aftercommit을 이용한 데이터 유실 문제 해결~
~- 문제~
  ~- redis 같은 RDBMS가 아닌 저장소는 @Transactional로 관리가 되지 않아 @Transactional로 묶인 다른 작업은 롤백이 되어도 redis와 관련된 작업은 롤백되지 않습니다. 따라서 redis에서 데이터를 pop을 하고 트랜잭션에서 commit이 되지 않고 rollback이 되도 pop 된 것이 롤백되지 않아 데이터 유실 문제를 야기시켰습니다.~
 ~- 해결 방법~
   ~- 이를 transactionsynchronization aftercommit을 이용하여 트랜잭션이 commit이 되고 난 후 redis pop이 되도록 보장하였고 afterCompletion을 이용하여 트랜잭션 상태가 rollback 인경우 에러 로그를 남기고 redis에 데이터를 그대로 두어 다음 JOB(트랜잭션)에서 이를 수행하도록 하여 데이터 유실을 방지하였습니다.~

1. spring data redis setEnableTransactionSupport을 이용한 데이터 유실 문제 해결
- 문제
  - redis 같은 RDBMS가 아닌 저장소는 @Transactional로 관리가 되지 않아 @Transactional로 묶인 다른 작업은 롤백이 되어도 redis와 관련된 작업은 롤백되지 않습니다. 따라서 redis에서 데이터를 pop을 하고 트랜잭션에서 commit이 되지 않고 rollback이 되도 pop 된 것이 롤백되지 않아 데이터 유실 문제를 야기시켰습니다.
 - 해결방법
   - spring data redis에서 제공하는 setEnableTransactionSupport 옵션을 이용하여 @Transactional에서도 redis가 묶여 롤백되도록 하였습니다.

2. 구간 감소를 DB단 원자적 감소로 수정
- 문제 
  - 기존에는 JPA 더티체킹으로 구간을 감소
  - A, B 트랜잭션이 동시에 접근하면 예상치 못한 결과 발생
  - 예: A에서 -1 처리 후 B가 아직 반영되기 전 값을 조회 → 결과적으로 -2 대신 -1

 - 해결 방법
   - 조회 후 감소가 아니라 DB 단에서 원자적 감소 쿼리로 처리
3. 대기열(redis sorted set)의 score을 saved_at 값이 되도록 수정
- 기존 saved_at은 실제 registration이 저장(commit) 되는 시점이 아닌 updateSavedAt 쿼리가 날라갈 떄 수정되는 것임으로 정확한 순번의 기준이 될 수 없습니다
- 클라이언트에서 주차권 신청 요청을 받는 시점.. 즉, 대기열(redis sorted set)에 데이터가 들어가는 시점인 score가 순번의 기준이 되는 saved_at이 되야한다고 판단되어 이와 같이 수정하였습니다.

4. Sector별 ThreadPool 구현
- 이벤트를 OPEN 할 때 각 구간별로 ThreadPool을 두어 구간별로 병렬처리를 진행하고 구간 내에서는 동기로 처리되도록 구현하였습니다
 -  #508 와 같은 데드락 문제의 원인 같이 sector에 락이 걸린다고 하더라도 row 락이 걸리기 때문에 다른 sector끼리의 작업은 락과 관련없다고 판단하여 병렬 처리를 진행하였습니다.
 - registration이 저장이 되고 User의 합격 상태를 정하는 과정에서 중복 예비번호 및 초과된 합격자 등 오류를 방지하고자 구간 내에서의 동작은 동기처리하였습니다.
 - event가 CLOSED 될 때 ExecutorService shutdown 및 sector의 작업 큐도 제거 함으로 메모리 누수 방지

5. EventIssuedEventHandler에서 신청 중복 저장 확인 하는 쿼리 수정
 - 문제
   - objectMapper로  Registration으로 변환시켰을 뿐 아직 save 하기 전에라 registrationId가 null인 문제가 발생 따라서 registrationId로 중복 확인 하는 것은 올바르지 않다고 판단하였습니다.
  - 해결 방법
    - 기존에 존재하는 이메일로 중복 검증하는 쿼리를 적용하였습니다.

6. 실패 처리 AOP 분리
리뷰 해주신 내용을 참고하여 확인하니 EventIssuedEventHandler의 책임과 규모가 크다고 판단되어 AOP를 이용한 신청 처리와 실패 처리를 분리하였습니다.
- maxRetry를 넘은 신청은 redis 대기열에서 삭제하고 실패 큐에 저장
  - 신청 유실을 막기 위하여 peek - pop 구조를 채택한 만큼 신청 데이터를 함부로 삭제(pop)하면 안된다고 생각합니다. 알수없는 오류(사용자 잘못 or 서버 오류)의 신청 데이터를 pop을 하지 않으면 무한으로 재시도 하기 때문에 이 데이터를 redis 대기열(쿠폰 발급 저장소)에서 삭제하고 실패 큐(쿠폰 발급 실패 저장소)에 저장하도록 하였습니다. 실패큐에 저장된 신청이 서버측 오류로 인한 실패라고 판단이 되면 이를 신청기간이 끝나고 복원(끼워 맞추기)하면 될 것 같습니다.
- JoinPoint args를 EventIssuedEvent로 한정
  - @QueueFailureHandling을 EventIsseudEventHandler가 아닌 다른 곳에서 사용한다고 했을 때 JoinPoint의 args EventIssuedEvent가 아닐 수도 있습니다. 이를 고려하여 확장성 있게 코드를 작성해보았지만 오버엔지니어링이라고 판단하여 EventIssuedEvent로 한정을 지었습니다.
  - 오버엔지니어링 판단 이유 : 실패 핸들링 aspect에 필요한 데이터는 userId, key(redis key), message(redis value), score(redis score)로 총 4가지입니다. 이 메타 정보를 얻기 위하여 리플랙션을 이용해야 하는데 args에 이 4가지 정보를 다 넘겨주거나, 4가지 정보를 모두 가진 args 1개라면 그 args에서 4가지 정보를 얻을 수 있는 path도 같이 넘겨줘야 합니다. 이는 확장성의 이점보다 복잡성이 더 많다고 판단했습니다.


## 테스트...
### 테스트 상황
1구간 정원 40 예비 20
2구간 정원 30 예비 30
3구간 정원 40 예비 20
4구간 정원 5 예비 55
5구간 정원 10 예비 50
### 1. 구간별 thread pool 생성
<img width="1098" height="162" alt="스크린샷 2025-09-15 오전 12 30 18" src="https://github.com/user-attachments/assets/8784c7f5-2d6b-4e64-96e9-fc9363a676f0" />

### 2. 총 k6 부하테스트로 총 469건의 최종 신청 요청 발행
<img width="1130" height="674" alt="스크린샷 2025-09-15 오전 12 37 41" src="https://github.com/user-attachments/assets/bf814afa-96b6-47d6-9892-9d09aa4a2b06" />

### 3. 결과 - 모든 구간 잔여 여석 0
<img width="1130" height="162" alt="스크린샷 2025-09-15 오전 12 32 06" src="https://github.com/user-attachments/assets/15e204f8-240a-428b-a168-7f47407fb71d" />

### 4. 결과 - 정확히 300개 registration 저장 및 saved_at 정렬 순서에 맞는 합격 여부

[Result_4.csv](https://github.com/user-attachments/files/22321357/Result_4.csv)

시간이 부족해서 테스트 코드는 작성하지 못하고 Manual Test를 진행했는데 6번 진행 결과 6번 다 정상 결과 나왔습니다


## 관련 이슈

closes #511 

## 체크리스트

- [x] `reviewers` 설정
- [x] `label` 설정
- [ ] `milestone` 설정