### PR TITLE
[BE-245] bug: 이벤트 open 지연, 집계 처리 방식 수정

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - dev
+      - dev-test
 
 env:
   ENVIRONMENT: dev

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 
     //WebTestClient 사용
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-quartz'
 }
 
 jib {

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -47,8 +47,11 @@ dependencies {
     // logback json 변환 라이브러리
     implementation 'net.logstash.logback:logstash-logback-encoder:6.6'
 
+    // 테스트 컨테이너 라이브러리
+    testImplementation "org.testcontainers:testcontainers:1.21.3"
+    testImplementation "org.testcontainers:junit-jupiter:1.21.3"
+    testImplementation "org.testcontainers:mysql:1.21.3"
 }
-
 
 jib {
     def serverPort = "8080"

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.21.3"
     testImplementation "org.testcontainers:junit-jupiter:1.21.3"
     testImplementation "org.testcontainers:mysql:1.21.3"
+
+    //WebTestClient 사용
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 jib {

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -82,6 +82,7 @@ jib {
         jvmFlags = [
                 '-Dspring.profiles.active=' + environment,
                 '-Dserver.port=' + serverPort,
+                '-Duser.timezone=Asia/Seoul',
                 '-Xms2G', '-Xmx2G',
                 '-XX:+UseG1GC',
                 '-XX:+UseContainerSupport',

--- a/Ticket-Api/build.gradle
+++ b/Ticket-Api/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-quartz'
+    testImplementation 'org.awaitility:awaitility:4.2.2'
 }
 
 jib {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/service/CouncilUseCase.java
@@ -4,6 +4,7 @@ package com.jnu.ticketapi.api.council.service;
 import com.jnu.ticketapi.api.council.model.request.SignUpCouncilRequest;
 import com.jnu.ticketapi.api.council.model.response.SendEmailManuallyResponse;
 import com.jnu.ticketapi.api.council.model.response.SignUpCouncilResponse;
+import com.jnu.ticketapi.api.user.ResultAssignment;
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketcommon.message.ResponseMessage;
 import com.jnu.ticketdomain.common.domainEvent.Events;
@@ -29,6 +30,7 @@ public class CouncilUseCase {
     private final CouncilAdaptor councilAdaptor;
     private final UserAdaptor userAdaptor;
     private final EventAdaptor eventAdaptor;
+    private final ResultAssignment resultAssignment;
 
     @Transactional(readOnly = true)
     public User findByEmail(String email) {
@@ -50,6 +52,7 @@ public class CouncilUseCase {
 
     @Transactional
     public SendEmailManuallyResponse sendEmail(Long eventId) {
+        resultAssignment.assign(eventId);
 
         try {
             Event event = eventAdaptor.findById(eventId);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,7 +1,5 @@
 package com.jnu.ticketapi.api.event.handler;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
@@ -28,6 +26,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @Component
 @RequiredArgsConstructor
@@ -60,6 +60,8 @@ public class EventIssuedEventHandler {
                 Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
                 try {
+                    Double score = eventIssuedEvent.getScore();
+
                     Registration registration =
                             objectMapper.readValue(
                                     eventIssuedEvent.getMessage().getRegistration(),
@@ -78,10 +80,10 @@ public class EventIssuedEventHandler {
                             sector.getRemainingAmount());
 
                     processQueueData(
-                            sector, registration, eventIssuedEvent.getMessage().getUserId());
+                            sector, registration, eventIssuedEvent.getMessage().getUserId(), score);
                     waitingQueueService.remove(
                             REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-                    sector.decreaseEventStock();
+//                    sector.decreaseEventStock();
 
                     // sectorAdaptor.save(sector); 데드락 문제 임시 해결
                 } catch (NoEventStockLeftException e) {
@@ -98,14 +100,16 @@ public class EventIssuedEventHandler {
         }
     }
 
-    /** 대기열에서 pop한 registration을 저장하고 유저 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다. */
-    public void processQueueData(Sector sector, Registration registration, Long userId) {
+    /**
+     * 대기열에서 pop한 registration을 저장하고 유저 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
+     */
+    public void processQueueData(Sector sector, Registration registration, Long userId, Double score) {
         User user = userAdaptor.findById(userId);
-        saveRegistration(sector, user, registration);
-        Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
+        saveRegistration(sector, user, registration, score);
+//        Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
     }
 
-    private void saveRegistration(Sector sector, User user, Registration registration) {
+    private void saveRegistration(Sector sector, User user, Registration registration, Double score) {
         if (!sector.isRemainingAmount()) {
             tracker.info("[No seats remaining]. Registration: {}", registration);
             throw NoEventStockLeftException.EXCEPTION;
@@ -116,13 +120,17 @@ public class EventIssuedEventHandler {
             registration.finalSave();
             registration.setSector(sector);
             registration.setUser(user);
+            registration.setSavedAt(score.longValue());
             registrationAdaptor.save(registration);
             return;
         }
+
         registration.setSector(sector);
         registration.setUser(user);
+//        registrationAdaptor.updateSavedAt(registration);
+        registration.setSavedAt(score.longValue());
         registrationAdaptor.saveAndFlush(registration);
-        registrationAdaptor.updateSavedAt(registration);
+
         tracker.info("Registration saved");
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/controller/RegistrationController.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/controller/RegistrationController.java
@@ -1,6 +1,5 @@
 package com.jnu.ticketapi.api.registration.controller;
 
-
 import com.jnu.ticketapi.api.registration.docs.FinalSaveExceptionDocs;
 import com.jnu.ticketapi.api.registration.docs.TemporarySaveExceptionFDocs;
 import com.jnu.ticketapi.api.registration.model.request.FinalSaveRequest;
@@ -10,13 +9,16 @@ import com.jnu.ticketapi.api.registration.model.response.GetRegistrationResponse
 import com.jnu.ticketapi.api.registration.model.response.GetRegistrationsResponse;
 import com.jnu.ticketapi.api.registration.model.response.TemporarySaveResponse;
 import com.jnu.ticketapi.api.registration.service.RegistrationUseCase;
+import com.jnu.ticketapi.api.user.ResultAssignment;
 import com.jnu.ticketapi.common.aop.GetEmail;
 import com.jnu.ticketcommon.annotation.ApiErrorExceptionsExample;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import javax.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.*;
 public class RegistrationController {
 
     private final RegistrationUseCase registrationUseCase;
+    private final ResultAssignment resultAssignment;
 
     @Operation(
             summary = "임시 저장 조회",
@@ -69,5 +72,12 @@ public class RegistrationController {
             @PathVariable("eventId") Long eventId) {
         GetRegistrationsResponse responseDto = registrationUseCase.getRegistrations(eventId);
         return ResponseEntity.ok(responseDto);
+    }
+
+    @Operation(summary = "신청 결과 집계", description = "신청 결과 집계")
+    @PatchMapping("/registrations/assign/result/{eventId}")
+    public ResponseEntity<Void> assignResult(@PathVariable("eventId") Long eventId) {
+        resultAssignment.assign(eventId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/internal/RegistrationDto.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/model/internal/RegistrationDto.java
@@ -2,9 +2,13 @@ package com.jnu.ticketapi.api.registration.model.internal;
 
 
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import lombok.Builder;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.Builder;
 
 @Builder
 public record RegistrationDto(
@@ -17,23 +21,31 @@ public record RegistrationDto(
         String carNum,
         String affiliation,
         String department,
-        String sectorNum) {
+        String sectorNum,
+        LocalDateTime savedAt) {
     public static List<RegistrationDto> of(List<Registration> registrations) {
         return registrations.stream()
-                .map(
-                        registration ->
-                                RegistrationDto.builder()
-                                        .registrationId(registration.getId())
-                                        .name(registration.getName())
-                                        .email(registration.getEmail())
-                                        .phoneNum(registration.getPhoneNum())
-                                        .studentNum(registration.getStudentNum())
-                                        .isLight(registration.isLight())
-                                        .carNum(registration.getCarNum())
-                                        .affiliation(registration.getAffiliation())
-                                        .department(registration.getDepartment())
-                                        .sectorNum(registration.getSector().getSectorNumber())
-                                        .build())
+                .map(registration -> {
+                    Long savedAt = registration.getSavedAt();
+                    LocalDateTime localDateTime = LocalDateTime.ofInstant(
+                            Instant.ofEpochMilli(savedAt),
+                            ZoneId.systemDefault()
+                    );
+                    return RegistrationDto.builder()
+                            .registrationId(registration.getId())
+                            .name(registration.getName())
+                            .email(registration.getEmail())
+                            .phoneNum(registration.getPhoneNum())
+                            .studentNum(registration.getStudentNum())
+                            .isLight(registration.isLight())
+                            .carNum(registration.getCarNum())
+                            .affiliation(registration.getAffiliation())
+                            .department(registration.getDepartment())
+                            .sectorNum(registration.getSector().getSectorNumber())
+                            .savedAt(localDateTime)
+                            .build();
+                })
                 .collect(Collectors.toList());
+
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -28,14 +28,15 @@ import com.jnu.ticketdomain.domains.registration.exception.NotFoundRegistrationE
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.redis.RedisService;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -124,7 +125,7 @@ public class RegistrationUseCase {
         validateEventPeriod(event);
 
         validateCaptchaUseCase.execute(requestDto.captchaCode(), requestDto.captchaAnswer());
-        checkDuplicateRegistration(email, eventId, requestDto.studentNum());
+        checkDuplicateRegistration(email, eventId);
         Long currentUserId = SecurityUtils.getCurrentUserId();
         User user = findById(currentUserId);
 
@@ -223,9 +224,8 @@ public class RegistrationUseCase {
         return GetRegistrationsResponse.of(registrations);
     }
 
-    private void checkDuplicateRegistration(String email, Long eventId, String studentNum) {
-        if (registrationAdaptor.existsByEmailAndIsSavedTrue(email, eventId)
-                || registrationAdaptor.existsByStudentNumAndIsSavedTrue(studentNum, eventId)) {
+    private void checkDuplicateRegistration(String email, Long eventId) {
+        if (registrationAdaptor.existsByEmailAndIsSavedTrue(email, eventId)) {
             throw AlreadyExistRegistrationException.EXCEPTION;
         }
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -20,6 +20,7 @@ import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.AlreadyCloseStatusException;
+import com.jnu.ticketdomain.domains.events.exception.NotIssuingEventPeriodException;
 import com.jnu.ticketdomain.domains.events.exception.NotPublishEventException;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
@@ -206,8 +207,11 @@ public class RegistrationUseCase {
     }
 
     private void validateEventPeriod(Event event) {
-        if (event.getDateTimePeriod().isAfterEndAt(LocalDateTime.now())
-                && event.getDateTimePeriod().isBeforeStartAt(LocalDateTime.now())) {
+        LocalDateTime now = LocalDateTime.now();
+        if (event.getDateTimePeriod().isBeforeStartAt(now)) {
+            throw NotIssuingEventPeriodException.EXCEPTION;
+        }
+        if (event.getDateTimePeriod().isAfterEndAt(now)) {
             throw AlreadyCloseStatusException.EXCEPTION;
         }
     }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -20,7 +20,7 @@ import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.AlreadyCloseStatusException;
-import com.jnu.ticketdomain.domains.events.exception.NotIssuingEventPeriodException;
+import com.jnu.ticketdomain.domains.events.exception.NotOpenEventStatusException;
 import com.jnu.ticketdomain.domains.events.exception.NotPublishEventException;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
@@ -210,7 +210,7 @@ public class RegistrationUseCase {
     private void validateEventPeriod(Event event) {
         LocalDateTime now = LocalDateTime.now();
         if (event.getDateTimePeriod().isBeforeStartAt(now)) {
-            throw NotIssuingEventPeriodException.EXCEPTION;
+            throw NotOpenEventStatusException.EXCEPTION;
         }
         if (event.getDateTimePeriod().isAfterEndAt(now)) {
             throw AlreadyCloseStatusException.EXCEPTION;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/ResultAssignment.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/user/ResultAssignment.java
@@ -1,0 +1,50 @@
+package com.jnu.ticketapi.api.user;
+
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ResultAssignment {
+
+    private final RegistrationAdaptor registrationAdaptor;
+    private final UserAdaptor userAdaptor;
+
+    @Transactional
+    public void assign(Long eventId) {
+        List<Registration> registrations = registrationAdaptor.findSavedByEventIdOrderBySavedAt(eventId);
+
+        Map<Sector, List<Registration>> registrationsBySector = registrations.stream().collect(Collectors.groupingBy(Registration::getSector));
+        registrationsBySector.forEach(this::assignBySector);
+    }
+
+    private void assignBySector(Sector sector, List<Registration> registrations) {
+        int sectorCapacity = sector.getInitSectorCapacity();
+        int issueAmount = sector.getIssueAmount();
+
+        for (int i = 0; i < registrations.size(); i++) {
+            int position = i + 1;
+            User user = registrations.get(i).getUser();
+
+            if (position <= sectorCapacity) {
+                user.success();
+            } else if (position <= issueAmount) {
+                user.prepare(position - sectorCapacity);
+            } else {
+                user.fail();
+            }
+
+            userAdaptor.save(user);
+        }
+    }
+}

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -77,3 +77,25 @@ web:
   log:
     url-no-logging:
       - /api/swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: integration-test
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+captcha:
+  domain: dsrps7tt0ew8t.cloudfront.net
+
+ableDomainEvent: false
+
+web:
+  log:
+    url-no-logging:
+      - /api/swagger-ui.html

--- a/Ticket-Api/src/main/resources/application.yml
+++ b/Ticket-Api/src/main/resources/application.yml
@@ -93,7 +93,7 @@ server:
 captcha:
   domain: dsrps7tt0ew8t.cloudfront.net
 
-ableDomainEvent: false
+ableDomainEvent: true
 
 web:
   log:

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -131,14 +131,13 @@ public class FlowTest {
                 new Setting(10, 30, 40)
         );
 
+        int resultWaitingSecond = 20;
+
         Integer capacityCountSum = settings.stream().map(Setting::capacity).reduce(0, Integer::sum);
         Integer reserveCountSum = settings.stream().map(Setting::reserve).reduce(0, Integer::sum);
         Integer userCountSum = settings.stream().map(Setting::requestCount).reduce(0, Integer::sum);
 
-        List<List<String>> userAccessTokens = settings.stream()
-                .map(Setting::requestCount)
-                .map(this::setUpUserData)
-                .toList();
+        List<List<String>> userAccessTokens = setUpAccessTokensPerSector(settings);
 
         String tempAccessToken = userAccessTokens.get(0).get(0);
         createEvent(tempAccessToken);
@@ -159,7 +158,7 @@ public class FlowTest {
             executorServiceForSector.submit(() -> finalSaveRequestToSector(sectorId, accessTokensPerSector, executorServiceInSector));
         }
 
-        Thread.sleep(30000);
+        Thread.sleep(resultWaitingSecond * 1000);
 
         // then
         List<User> usersWithResult = userRepository.findAll(Sort.by("id"));
@@ -176,6 +175,13 @@ public class FlowTest {
         assertPreparePerSector(usersWithResult, settings);
 
 
+    }
+
+    private List<List<String>> setUpAccessTokensPerSector(List<Setting> settings) {
+        return settings.stream()
+                .map(Setting::requestCount)
+                .map(this::setUpUserData)
+                .toList();
     }
 
     private void finalSaveRequestToSector(long sectorId, List<String> accessTokens, ExecutorService executorService) {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -132,12 +132,12 @@ public class FlowTest {
         Integer reserveCountSum = settings.stream().map(Setting::reserve).reduce(0, Integer::sum);
         Integer userCountSum = settings.stream().map(Setting::requestCount).reduce(0, Integer::sum);
 
-        List<Map<User, String>> usersWithToken = settings.stream()
+        List<List<String>> userAccessTokens = settings.stream()
                 .map(Setting::requestCount)
                 .map(this::setUpUserData)
                 .toList();
 
-        String tempAccessToken = usersWithToken.get(0).values().stream().findFirst().get();
+        String tempAccessToken = userAccessTokens.get(0).get(0);
         createEvent(tempAccessToken);
         createCaptcha();
         createSectors(settings);
@@ -240,7 +240,7 @@ public class FlowTest {
                 .build();
     }
 
-    private Map<User, String> setUpUserData(int userSize) {
+    private List<String> setUpUserData(int userSize) {
         List<User> users = saveUsers(userSize);
         return generateToken(users);
     }
@@ -259,13 +259,10 @@ public class FlowTest {
         return users;
     }
 
-    private Map<User, String> generateToken(List<User> users) {
-        Map<User, String> usersWithToken = new HashMap<>();
-        for (User user : users) {
-            String accessToken = jwtGenerator.generateAccessToken(user.getEmail(), user.getUserRole().name());
-            usersWithToken.put(user, accessToken);
-        }
-        return usersWithToken;
+    private List<String> generateToken(List<User> users) {
+        return users.stream()
+                .map(user -> jwtGenerator.generateAccessToken(user.getEmail(), user.getUserRole().name()))
+                .toList();
     }
 
     private void setEventPublic() {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -52,6 +52,11 @@ import static org.quartz.TriggerBuilder.newTrigger;
 @Testcontainers
 public class FlowTest {
 
+    private static final int ASYNC_CORE_POOL_SIZE = 1000;
+    private static final int ASYNC_MAX_POOL_SIZE = 1000;
+    private static final int ASYNC_QUEUE_CAPACITY = 50000;
+    private static final int HIKARI_MAXIMUM_POOL_SIZE = 2000;
+
     private static final int REDIS_PORT = 6379;
     private static final int MYSQL_PORT = 3306;
     private static final Long EVENT_VALUE = 1L;
@@ -76,6 +81,18 @@ public class FlowTest {
         );
         registry.add("spring.datasource.username", mysqlContainer::getUsername);
         registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+
+    @DynamicPropertySource
+    static void asyncTheadProperties(DynamicPropertyRegistry registry) {
+        registry.add("thread.core-pool-size", () -> ASYNC_CORE_POOL_SIZE);
+        registry.add("thread.max-pool-size", () -> ASYNC_MAX_POOL_SIZE);
+        registry.add("thread.queue-capacity", () -> ASYNC_QUEUE_CAPACITY);
+    }
+
+    @DynamicPropertySource
+    static void hikariProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.hikari.maximum-pool-size", () -> HIKARI_MAXIMUM_POOL_SIZE);
     }
 
     @Autowired

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -1,0 +1,55 @@
+package com.jnu.ticketapi;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.client.MockMvcWebTestClient;
+import org.springframework.web.context.WebApplicationContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@ActiveProfiles("integration-test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Testcontainers
+public class FlowTest {
+
+    public static final int REDIS_PORT = 6379;
+    public static final int MYSQL_PORT = 3306;
+
+    @Container
+    static MySQLContainer mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.40"))
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    static GenericContainer redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7"))
+            .withExposedPorts(REDIS_PORT);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redisContainer::getHost);
+        registry.add("spring.redis.port", () -> redisContainer.getMappedPort(REDIS_PORT));
+        registry.add("spring.datasource.url", () -> String.format(
+                "jdbc:mysql://%s:%d/%s", mysqlContainer.getHost(), mysqlContainer.getMappedPort(MYSQL_PORT), mysqlContainer.getDatabaseName())
+        );
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+
+    WebTestClient client;
+
+    @BeforeEach
+    void setup(WebApplicationContext context) {
+        client = MockMvcWebTestClient.bindToApplicationContext(context).build();
+    }
+
+}
+
+

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -53,8 +53,7 @@ import static org.quartz.TriggerBuilder.newTrigger;
 @Slf4j
 @ActiveProfiles("integration-test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Testcontainers
-public class FlowTest {
+public class FlowTest implements UsingContainers {
 
     private static final int ASYNC_CORE_POOL_SIZE = 1000;
     private static final int ASYNC_MAX_POOL_SIZE = 1000;

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -168,12 +168,13 @@ public class FlowTest implements UsingContainers {
 
         // then
         List<User> usersWithResult = userRepository.findAll(Sort.by("id"));
-        List<Registration> registrations = registrationRepository.findSortedRegistrationsByEventId(EVENT_VALUE);
+        List<Registration> resultRegistration = registrationRepository.findSortedRegistrationsByEventId(EVENT_VALUE);
+        List<Registration> registrations = registrationRepository.findAll();
 
         Map<UserStatus, List<User>> resultByGroup = usersWithResult.stream()
                 .collect(Collectors.groupingBy(User::getStatus, Collectors.toList()));
 
-        printRegistrationsWithUserStatus(registrations, usersWithResult);
+        printRegistrationsWithUserStatus(resultRegistration, usersWithResult);
 
         assertSoftly(softly -> {
             softly.assertThat(registrations).hasSize(userCountSum);
@@ -194,6 +195,7 @@ public class FlowTest implements UsingContainers {
                 "regId", "email", "savedAt", "status", "sequence");
         System.out.println("-".repeat(95));
 
+        int i = 1;
         for (Registration r : registrations) {
             Long savedAt = r.getSavedAt();
             LocalDateTime localDateTime = LocalDateTime.ofInstant(
@@ -206,13 +208,15 @@ public class FlowTest implements UsingContainers {
             String sequence = user != null ? String.valueOf(user.getSequence()) : "N/A";
 
             // 날짜 형식이 너무 길면 칸이 깨지므로, 길이에 맞춰 너비를 조절했습니다.
-            System.out.printf("%-6d | %-35s | %-25s | %-10s | %-8s | %-10s%n",
+            System.out.printf("%-6d | %-35s | %-25s | %-10s | %-8s | %-10s| %-2d%n",
                     r.getId(),
                     r.getEmail(),
                     localDateTime,
                     status,
                     sequence,
-                    r.getSector().getId());
+                    r.getSector().getId(),
+                    i);
+            i++;
         }
         System.out.println("=".repeat(95));
     }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -6,6 +6,7 @@ import com.jnu.ticketapi.api.event.model.request.UpdateEventPublishRequest;
 import com.jnu.ticketapi.api.registration.model.request.FinalSaveRequest;
 import com.jnu.ticketapi.api.registration.model.request.TemporarySaveRequest;
 import com.jnu.ticketapi.api.sector.model.request.SectorRegisterRequest;
+import com.jnu.ticketapi.api.user.ResultAssignment;
 import com.jnu.ticketapi.registration.FinalSaveRequestTestDataBuilder;
 import com.jnu.ticketapi.registration.TemporarySaveRequestTestDataBuilder;
 import com.jnu.ticketapi.security.JwtGenerator;
@@ -14,12 +15,16 @@ import com.jnu.ticketbatch.config.QuartzJobLauncher;
 import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.repository.CaptchaRepository;
+import com.jnu.ticketdomain.domains.events.domain.Event;
+import com.jnu.ticketdomain.domains.events.domain.EventStatus;
+import com.jnu.ticketdomain.domains.events.repository.EventRepository;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.repository.RegistrationRepository;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.domain.UserRole;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketdomain.domains.user.repository.UserRepository;
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +38,9 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -41,7 +48,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.jnu.ticketdomain.domains.user.domain.UserStatus.*;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.awaitility.Awaitility.await;
 import static org.quartz.JobBuilder.newJob;
 import static org.quartz.TriggerBuilder.newTrigger;
 
@@ -89,6 +99,15 @@ public class FlowTest implements UsingContainers {
     @Autowired
     RegistrationRepository registrationRepository;
 
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    RedisRepository redisRepository;
+
+    @Autowired
+    ResultAssignment resultAssignment;
+
     private record Setting(int capacity, int reserve, int requestCount) {
     }
 
@@ -96,19 +115,22 @@ public class FlowTest implements UsingContainers {
 
 
     /**
-     *  Setting record 통해서 구간별 여석, 예비, 요청 수 설정 가능
+     * Setting record 통해서 구간별 여석, 예비, 요청 수 설정 가능
+     * user id 순으로 각 sector에 요청보냄.
+     * sector 랑 event는 새로 만들어져야함 id = 1부터 시작해야함.
      */
     @Test
     @DisplayName("여러 사용자의 최종 저장 요청 신청시, 여석에 맞게 합격, 예비, 불합격 수와 각 구간별 예비번호를 검증한다.")
     void flowTest() throws Exception {
         // given
         List<Setting> settings = List.of(
-                new Setting(10, 30, 40),
-                new Setting(10, 30, 40),
-                new Setting(10, 30, 40)
+                new Setting(50, 10, 80),
+                new Setting(25, 10, 80),
+                new Setting(55, 10, 80),
+                new Setting(80, 10, 100),
+                new Setting(40, 10, 80)
         );
 
-        int resultWaitingSecond = 20;
 
         Integer capacityCountSum = settings.stream().map(Setting::capacity).reduce(0, Integer::sum);
         Integer reserveCountSum = settings.stream().map(Setting::reserve).reduce(0, Integer::sum);
@@ -125,7 +147,7 @@ public class FlowTest implements UsingContainers {
         temporalSaveRequest(userAccessTokens);
 
         rescheduleJob();
-        Thread.sleep(1000);
+        awaitEventOpen();
 
         // when
         ExecutorService executorServiceForSector = Executors.newFixedThreadPool(settings.size());
@@ -136,8 +158,14 @@ public class FlowTest implements UsingContainers {
             List<String> accessTokensPerSector = userAccessTokens.get(i);
             executorServiceForSector.submit(() -> finalSaveRequestToSector(sectorId, accessTokensPerSector, executorServiceInSector));
         }
+        executorServiceForSector.shutdown();
+        executorServiceForSector.awaitTermination(60, SECONDS);
+        executorServiceInSector.shutdown();
+        executorServiceInSector.awaitTermination(60, SECONDS);
 
-        Thread.sleep(resultWaitingSecond * 1000);
+        awaitAllRegistrationsSaved(userCountSum);
+
+        resultAssignment.assign(EVENT_VALUE);
 
         // then
         List<User> usersWithResult = userRepository.findAll(Sort.by("id"));
@@ -145,6 +173,8 @@ public class FlowTest implements UsingContainers {
 
         Map<UserStatus, List<User>> resultByGroup = usersWithResult.stream()
                 .collect(Collectors.groupingBy(User::getStatus, Collectors.toList()));
+
+        printRegistrationsWithUserStatus(registrations, usersWithResult);
 
         assertSoftly(softly -> {
             softly.assertThat(registrations).hasSize(userCountSum);
@@ -156,8 +186,48 @@ public class FlowTest implements UsingContainers {
         assertPerSector(usersWithResult, settings);
     }
 
+    private void printRegistrationsWithUserStatus(List<Registration> registrations, List<User> usersWithResult) {
+        Map<String, User> usersByEmail = usersWithResult.stream()
+                .collect(Collectors.toMap(User::getEmail, u -> u, (a, b) -> a));
+
+        List<Registration> sorted = registrations.stream()
+                .sorted(Comparator.comparing((Registration r) -> r.getSector().getId())
+                        .thenComparing(Registration::getSavedAt))
+                .toList();
+
+        System.out.println("============ 신청서 결과 (savedAt 오름차순) ============");
+        System.out.printf("%-6s | %-30s | %-23s | %-8s | %-8s%n",
+                "regId", "email", "savedAt", "status", "sequence");
+        System.out.println("-".repeat(95));
+
+        for (Registration r : sorted) {
+            Long savedAt = r.getSavedAt();
+            LocalDateTime localDateTime = LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(savedAt),
+                    ZoneId.systemDefault()
+            );
+
+            User user = usersByEmail.get(r.getEmail());
+            String status = user != null ? String.valueOf(user.getStatus()) : "N/A";
+            String sequence = user != null ? String.valueOf(user.getSequence()) : "N/A";
+
+            // 날짜 형식이 너무 길면 칸이 깨지므로, 길이에 맞춰 너비를 조절했습니다.
+            System.out.printf("%-6d | %-35s | %-25s | %-10s | %-8s | %-10s%n",
+                    r.getId(),
+                    r.getEmail(),
+                    localDateTime,
+                    status,
+                    sequence,
+                    r.getSector().getId());
+        }
+        System.out.println("=".repeat(95));
+    }
+
     private void temporalSaveRequest(List<List<String>> userAccessTokens) {
-        int count = userAccessTokens.size() * (9 / 10);
+        List<String> flatTokens = userAccessTokens.stream()
+                .flatMap(List::stream)
+                .toList();
+        int count = (int) (flatTokens.size() * (0.9));
         Random random = new Random();
 
         for (int i = 0; i < count; i++) {
@@ -367,6 +437,28 @@ public class FlowTest implements UsingContainers {
                     .exchange().expectStatus().isOk();
             sectorIdentifier++;
         }
+    }
+
+    private void awaitAllRegistrationsSaved(int expectedSavedCount) {
+        await().atMost(60, SECONDS)
+                .pollInterval(200, MILLISECONDS)
+                .until(() -> registrationRepository.findAll().stream()
+                        .filter(Registration::isSaved)
+                        .count() == expectedSavedCount);
+        System.out.println("============데이터 처리 완료===============");
+    }
+
+    private void awaitEventOpen() {
+        await().atMost(60, SECONDS)
+                .pollInterval(1, SECONDS)
+                .until(
+                        () -> {
+                            // 매번 findById를 통해 DB를 조회 시도
+                            Event event = eventRepository.findFirstByOrderByIdDesc().orElseThrow();
+                            log.info("현재 이벤트 상태: {}", event.getEventStatus());
+                            return event.getEventStatus() == EventStatus.OPEN;
+                        });
+        System.out.println("============이벤트 오픈 완료===============");
     }
 
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -1,5 +1,4 @@
 package com.jnu.ticketapi;
-
 import com.jnu.ticketapi.api.captcha.model.response.CaptchaResponse;
 import com.jnu.ticketapi.api.event.model.request.EventRegisterRequest;
 import com.jnu.ticketapi.api.event.model.request.UpdateEventPublishRequest;
@@ -169,7 +168,7 @@ public class FlowTest implements UsingContainers {
 
         // then
         List<User> usersWithResult = userRepository.findAll(Sort.by("id"));
-        List<Registration> registrations = registrationRepository.findAll();
+        List<Registration> registrations = registrationRepository.findSortedRegistrationsByEventId(EVENT_VALUE);
 
         Map<UserStatus, List<User>> resultByGroup = usersWithResult.stream()
                 .collect(Collectors.groupingBy(User::getStatus, Collectors.toList()));
@@ -190,17 +189,12 @@ public class FlowTest implements UsingContainers {
         Map<String, User> usersByEmail = usersWithResult.stream()
                 .collect(Collectors.toMap(User::getEmail, u -> u, (a, b) -> a));
 
-        List<Registration> sorted = registrations.stream()
-                .sorted(Comparator.comparing((Registration r) -> r.getSector().getId())
-                        .thenComparing(Registration::getSavedAt))
-                .toList();
-
         System.out.println("============ 신청서 결과 (savedAt 오름차순) ============");
         System.out.printf("%-6s | %-30s | %-23s | %-8s | %-8s%n",
                 "regId", "email", "savedAt", "status", "sequence");
         System.out.println("-".repeat(95));
 
-        for (Registration r : sorted) {
+        for (Registration r : registrations) {
             Long savedAt = r.getSavedAt();
             LocalDateTime localDateTime = LocalDateTime.ofInstant(
                     Instant.ofEpochMilli(savedAt),

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/UsingContainers.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/UsingContainers.java
@@ -1,0 +1,37 @@
+package com.jnu.ticketapi;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public interface UsingContainers {
+
+    int REDIS_PORT = 6379;
+    int MYSQL_PORT = 3306;
+
+    @Container
+    MySQLContainer mysqlContainer = new MySQLContainer<>(DockerImageName.parse("mysql:8.0.40"))
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    GenericContainer redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7"))
+            .withExposedPorts(REDIS_PORT);
+
+    @DynamicPropertySource
+    static void containerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.redis.host", redisContainer::getHost);
+        registry.add("spring.redis.port", () -> redisContainer.getMappedPort(REDIS_PORT));
+        registry.add("spring.datasource.url", () -> String.format(
+                "jdbc:mysql://%s:%d/%s", mysqlContainer.getHost(), mysqlContainer.getMappedPort(MYSQL_PORT), mysqlContainer.getDatabaseName())
+        );
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/config/DatabaseCleaner.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/config/DatabaseCleaner.java
@@ -1,31 +1,68 @@
 package com.jnu.ticketapi.config;
 
 
-import java.util.ArrayList;
-import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
 import javax.annotation.PostConstruct;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Component
 public class DatabaseCleaner {
 
     private final List<String> tableNames = new ArrayList<>();
 
-    @PersistenceContext private EntityManager entityManager;
+    @PersistenceContext
+    private final EntityManager entityManager;
+    private final DataSource dataSource;
+
+    public DatabaseCleaner(DataSource dataSource, EntityManager entityManager) {
+        this.dataSource = dataSource;
+        this.entityManager = entityManager;
+    }
 
     // 바뀐부분 : 의존성 주입이후 초기화 수행 시 Table을 조회한다.
     @PostConstruct
     @SuppressWarnings("unchecked")
-    private void findDatabaseTableNames() {
-        List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
-        for (Object[] tableInfo : tableInfos) {
-            String tableName = (String) tableInfo[0];
-            tableNames.add(tableName);
+    private void findDatabaseTableNames() throws SQLException {
+        List<?> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
+        String databaseVendor = getDatabaseVendor();
+        if (databaseVendor.equals("MySQL")) {
+            extractFromMysql(tableInfos);
+        }
+
+        if (databaseVendor.equals("H2")) {
+            extractFromH2(tableInfos);
         }
     }
+
+    private String getDatabaseVendor() throws SQLException {
+        Connection connection = dataSource.getConnection();
+        DatabaseMetaData metaData = connection.getMetaData();
+        return metaData.getDatabaseProductName();
+    }
+
+    private void extractFromMysql(List<?> tableInfos) {
+        Object tableInfo = tableInfos.get(0);
+        String tableNames = (String) tableInfo;
+        this.tableNames.addAll(Arrays.stream(tableNames.split(",")).toList());
+    }
+
+    private void extractFromH2(List<?> tableInfos) {
+        for (Object tableInfo : tableInfos) {
+            Object[] tableNames = (Object[]) tableInfo;
+            this.tableNames.add((String) tableNames[0]);
+        }
+    }
+
 
     private void truncate() {
         entityManager

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -45,7 +45,7 @@ public class BatchQuartzJob extends QuartzJobBean {
                         .addLong("eventId", eventId)
                         .toJobParameters();
         log.info("EventThrow in BatchQuartzJob");
-        eventExpiredEventRaiseGateway.handle(eventId);
+//        eventExpiredEventRaiseGateway.handle(eventId);
         try {
             this.jobLauncher.run(this.job, jobParameters);
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
@@ -37,6 +37,7 @@ public class EventRegisterJob implements Job {
     private static final String EVENT_ID = "eventId";
     private static final String GROUP = "group1";
     private static final String ASIA_SEOUL = "Asia/Seoul";
+    private static final long OPEN_LEAD_SECONDS = 5L;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -64,7 +65,11 @@ public class EventRegisterJob implements Job {
                         .setJobData(jobDataMap)
                         .build();
 
-        Date date = Date.from(startAt.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
+        Date date =
+                Date.from(
+                        startAt.minusSeconds(OPEN_LEAD_SECONDS)
+                                .atZone(ZoneId.of(ASIA_SEOUL))
+                                .toInstant());
 
         Trigger reserveTrigger =
                 newTrigger()

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -92,9 +92,8 @@ public class Event {
 
     public void validateIssuePeriod() {
         LocalDateTime nowTime = LocalDateTime.now();
-        if (dateTimePeriod.getStartAt().isAfter(nowTime)) {
-            throw NotIssuingEventPeriodException.EXCEPTION;
-        }
+        // 과거 시간을 포함하기로 기획을 변경했습니다.
+        // if (dateTimePeriod.contains(nowTime)
         if (dateTimePeriod.getEndAt().isBefore(nowTime)
                 || dateTimePeriod.getEndAt().isBefore(dateTimePeriod.getStartAt())) {
             throw InvalidPeriodEventException.EXCEPTION;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Event.java
@@ -92,8 +92,9 @@ public class Event {
 
     public void validateIssuePeriod() {
         LocalDateTime nowTime = LocalDateTime.now();
-        // 과거 시간을 포함하기로 기획을 변경했습니다.
-        // if (dateTimePeriod.contains(nowTime)
+        if (dateTimePeriod.getStartAt().isAfter(nowTime)) {
+            throw NotIssuingEventPeriodException.EXCEPTION;
+        }
         if (dateTimePeriod.getEndAt().isBefore(nowTime)
                 || dateTimePeriod.getEndAt().isBefore(dateTimePeriod.getStartAt())) {
             throw InvalidPeriodEventException.EXCEPTION;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/EventRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/EventRepository.java
@@ -35,4 +35,6 @@ public interface EventRepository extends JpaRepository<Event, Long>, CustomEvent
     Page<Event> findAllByOrderByIdDesc(Pageable pageable);
 
     Boolean existsByPublishTrue();
+
+    Optional<Event> findFirstByOrderByIdDesc();
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -82,6 +82,11 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
         return registrationRepository.findByIsDeletedFalseAndIsSavedTrue(eventId);
     }
 
+    @Override
+    public List<Registration> findSavedByEventIdOrderBySavedAt(Long eventId) {
+        return registrationRepository.findSavedByEventIdOrderBySavedAt(eventId);
+    }
+
     public Page<Registration> findByIsDeletedFalseAndIsSavedTrueByPage(Long eventId, int page) {
         Pageable pageable = PageRequest.of(page, REGISTRATION_SIZE);
         return registrationRepository.findByIsDeletedFalseAndIsSavedTrueByPage(eventId, pageable);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -31,7 +31,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @DynamicUpdate
 @AllArgsConstructor(access = AccessLevel.PUBLIC) // 생성자를 public으로 변경
 @Where(clause = "is_deleted = false")
-@ToString
 public class Registration {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -179,6 +178,28 @@ public class Registration {
         this.isLight = registration.isLight();
         this.phoneNum = registration.getPhoneNum();
         this.sector = registration.getSector();
+    }
+
+    @Override
+    public String toString() {
+        return "Registration{" +
+                "id=" + id +
+                ", email='" + email + '\'' +
+                ", name='" + name + '\'' +
+                ", studentNum='" + studentNum + '\'' +
+                ", affiliation='" + affiliation + '\'' +
+                ", department='" + department + '\'' +
+                ", carNum='" + carNum + '\'' +
+                ", isLight=" + isLight +
+                ", phoneNum='" + phoneNum + '\'' +
+                ", createdAt=" + createdAt +
+                ", isSaved=" + isSaved +
+                ", isDeleted=" + isDeleted +
+                ", savedAt=" + savedAt +
+                ", user=" + user.getId() +
+                ", sector=" + sector.getId() +
+                ", eventId=" + eventId +
+                '}';
     }
 
     public void setSector(Sector sector) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -161,7 +161,7 @@ public class Registration {
 
     public void finalSave() {
         this.isSaved = true;
-        this.savedAt = System.nanoTime();
+//        this.savedAt = System.nanoTime();
     }
 
     public void updateIsDeleted(boolean isDeleted) {
@@ -216,5 +216,9 @@ public class Registration {
 
     public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public void setSavedAt(Long savedAt) {
+        this.savedAt = savedAt;
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
@@ -18,6 +18,8 @@ public interface RegistrationLoadPort {
 
     List<Registration> findByIsDeletedFalseAndIsSavedTrue(Long eventId);
 
+    List<Registration> findSavedByEventIdOrderBySavedAt(Long eventId);
+
     Boolean existsByEmailAndIsSavedTrue(String email, Long eventId);
 
     Boolean existsByStudentNumAndIsSavedTrue(String studentNum, Long eventId);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -37,6 +37,14 @@ public interface RegistrationRepository
             "select r from Registration r join fetch r.sector join fetch r.user where r.isSaved = true and r.sector.event.id = :eventId")
     List<Registration> findByIsDeletedFalseAndIsSavedTrue(@Param("eventId") Long eventId);
 
+    @Query(
+            "select r from Registration r "
+                    + "join fetch r.sector "
+                    + "join fetch r.user "
+                    + "where r.isDeleted = false and r.isSaved = true and r.eventId = :eventId "
+                    + "order by r.savedAt asc")
+    List<Registration> findSavedByEventIdOrderBySavedAt(@Param("eventId") Long eventId);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
             value =

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -42,7 +42,7 @@ public interface RegistrationRepository
                     + "join fetch r.sector "
                     + "join fetch r.user "
                     + "where r.isDeleted = false and r.isSaved = true and r.eventId = :eventId "
-                    + "order by r.savedAt asc")
+                    + "order by r.savedAt asc, r.id asc")
     List<Registration> findSavedByEventIdOrderBySavedAt(@Param("eventId") Long eventId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepositoryCustomImpl.java
@@ -60,6 +60,7 @@ public class RegistrationRepositoryCustomImpl implements RegistrationRepositoryC
                         user.status.in(UserStatus.SUCCESS, UserStatus.PREPARE))
                 .orderBy(
                         sector.sectorNumber.asc(),
+                        registration.savedAt.asc(),
                         // SUCCESS 먼저 오도록 정렬
                         new CaseBuilder()
                                 .when(user.status.eq(UserStatus.SUCCESS))

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -101,7 +101,6 @@ spring:
   quartz:
     jdbc:
       initialize-schema: always
-
 ---
 
 spring:
@@ -207,3 +206,17 @@ management:
     redis:
       enabled: ${ABLE_REDIS:true}
 
+---
+spring:
+  config:
+    activate:
+      on-profile: integration-test
+  jpa:
+    show-sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: create-drop
+
+  quartz:
+    jdbc:
+      initialize-schema: always

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -220,3 +220,8 @@ spring:
   quartz:
     jdbc:
       initialize-schema: always
+
+thread:
+  core-pool-size: 10
+  max-pool-size: 20
+  queue-capacity: 100

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/EnableAsyncConfig.java
@@ -13,7 +13,7 @@ import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-@Profile("!test")
+@Profile({"!test","integration-test"})
 @EnableAsync
 @Configuration
 @RequiredArgsConstructor


### PR DESCRIPTION
## 주요 변경사항
- 스케쥴링 지연 이슈
  - open 시간 5초 미리 동작하도록 수정 
  - 신청시 검증 로직에 현재 서버 시각 비교하는 검증 로직 추가
- 자동 메일 발송 기능 해제 -> 수동 메일 전송으로 수정
- 주차권 준비, 주차권 신청, 결과 확인 시나리오의 통합 테스트 추가 + 테스트 컨테이너 사용
- 신청서 응답 dto에 savedAt 필드 추가, savedAt으로 빠른순 정렬 설정

## 리뷰어에게...

## 관련 이슈

closes #516 

## 체크리스트

- [ ] `reviewers` 설정
- [ ] `label` 설정
- [ ] `milestone` 설정