### PR TITLE
[BE-246] feat: Redis Stream 기반 신청 대기열 처리로 전환

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -13,7 +13,6 @@ import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
-import com.zaxxer.hikari.HikariDataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -43,7 +42,6 @@ public class EventIssuedEventHandler {
 
     private final SectorAdaptor sectorAdaptor;
     private final ObjectMapper objectMapper;
-    private final HikariDataSource hikariDataSource;
 
     @Async
     @EventListener(classes = EventIssuedEvent.class)
@@ -55,9 +53,6 @@ public class EventIssuedEventHandler {
     public void handle(EventIssuedEvent eventIssuedEvent) {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
-            if (!isIdleConnectionAvailable()) {
-                return;
-            }
 
             Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
@@ -151,8 +146,4 @@ public class EventIssuedEventHandler {
         }
     }
 
-    private boolean isIdleConnectionAvailable() {
-        int idleConnections = hikariDataSource.getHikariPoolMXBean().getIdleConnections();
-        return idleConnections > 0;
-    }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,7 +1,9 @@
 package com.jnu.ticketapi.api.event.handler;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
@@ -9,7 +11,6 @@ import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
-import com.jnu.ticketdomain.domains.user.event.UserReflectStatusEvent;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import com.zaxxer.hikari.HikariDataSource;
@@ -26,8 +27,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @Component
 @RequiredArgsConstructor
@@ -56,57 +55,56 @@ public class EventIssuedEventHandler {
     public void handle(EventIssuedEvent eventIssuedEvent) {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
-            if (isIdleConnectionAvailable()) {
-                Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
+            if (!isIdleConnectionAvailable()) {
+                return;
+            }
 
-                try {
-                    Double score = eventIssuedEvent.getScore();
+            Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
-                    Registration registration =
-                            objectMapper.readValue(
-                                    eventIssuedEvent.getMessage().getRegistration(),
-                                    Registration.class);
+            try {
+                Registration registration =
+                        objectMapper.readValue(
+                                eventIssuedEvent.getMessage().getRegistration(), Registration.class);
 
-                    if (Boolean.TRUE.equals(
-                            registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
-                        tracker.info("Already saved, ignored");
-                        return;
-                    }
-                    tracker.info(
-                            "현재구간 정보, sectorId: {}, 정원여석: {}, 예비여석: {}, 총 여석: {},",
-                            sector.getId(),
-                            sector.getSectorCapacity(),
-                            sector.getReserve(),
-                            sector.getRemainingAmount());
-
-                    processQueueData(
-                            sector, registration, eventIssuedEvent.getMessage().getUserId(), score);
-                    waitingQueueService.remove(
-                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-//                    sector.decreaseEventStock();
-
-                    // sectorAdaptor.save(sector); 데드락 문제 임시 해결
-                } catch (NoEventStockLeftException e) {
-                    tracker.info("해당 구간 잔여 여석이 없습니다.", e);
-                    waitingQueueService.remove(
-                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-                } catch (Exception e) {
-                    // 에러가 났을 때 redis에 데이터를 재등록 한다.(Not Waiting 상태로)
-                    tracker.error("EventIssuedEventHandler Exception: ", e);
+                if (registration.getId() != null
+                        && Boolean.TRUE.equals(
+                                registrationAdaptor.existsByIdAndIsSavedTrue(
+                                        registration.getId()))) {
+                    tracker.info("Already saved, ignored");
+                    acknowledge(eventIssuedEvent);
+                    return;
                 }
+                tracker.info(
+                        "현재구간 정보, sectorId: {}, 정원여석: {}, 예비여석: {}, 총 여석: {},",
+                        sector.getId(),
+                        sector.getSectorCapacity(),
+                        sector.getReserve(),
+                        sector.getRemainingAmount());
+
+                processQueueData(
+                        sector,
+                        registration,
+                        eventIssuedEvent.getMessage().getUserId(),
+                        resolveScore(eventIssuedEvent));
+                acknowledge(eventIssuedEvent);
+
+                // sectorAdaptor.save(sector); 데드락 문제 임시 해결
+            } catch (NoEventStockLeftException e) {
+                tracker.info("해당 구간 잔여 여석이 없습니다.", e);
+                acknowledge(eventIssuedEvent);
+            } catch (Exception e) {
+                // ack 하지 않으면 Redis Stream pending entry로 남아 재처리할 수 있다.
+                tracker.error("EventIssuedEventHandler Exception: ", e);
             }
         } finally {
             MDC.clear();
         }
     }
 
-    /**
-     * 대기열에서 pop한 registration을 저장하고 유저 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
-     */
+    /** 대기열에서 pop한 registration을 저장하고 savedAt 기준 순서를 보존한다. */
     public void processQueueData(Sector sector, Registration registration, Long userId, Double score) {
         User user = userAdaptor.findById(userId);
         saveRegistration(sector, user, registration, score);
-//        Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
     }
 
     private void saveRegistration(Sector sector, User user, Registration registration, Double score) {
@@ -127,11 +125,30 @@ public class EventIssuedEventHandler {
 
         registration.setSector(sector);
         registration.setUser(user);
-//        registrationAdaptor.updateSavedAt(registration);
         registration.setSavedAt(score.longValue());
         registrationAdaptor.saveAndFlush(registration);
 
         tracker.info("Registration saved");
+    }
+
+    private Double resolveScore(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getScore() != null) {
+            return eventIssuedEvent.getScore();
+        }
+        String streamRecordId = eventIssuedEvent.getStreamRecordId();
+        if (streamRecordId != null && streamRecordId.contains("-")) {
+            return Double.valueOf(streamRecordId.substring(0, streamRecordId.indexOf('-')));
+        }
+        return (double) System.nanoTime();
+    }
+
+    private void acknowledge(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getStreamRecordId() != null) {
+            waitingQueueService.acknowledge(
+                    REDIS_EVENT_ISSUE_STREAM,
+                    REDIS_EVENT_ISSUE_GROUP,
+                    eventIssuedEvent.getStreamRecordId());
+        }
     }
 
     private boolean isIdleConnectionAvailable() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -26,6 +26,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @RequiredArgsConstructor
@@ -59,14 +61,12 @@ public class EventIssuedEventHandler {
             try {
                 Registration registration =
                         objectMapper.readValue(
-                                eventIssuedEvent.getMessage().getRegistration(), Registration.class);
+                                eventIssuedEvent.getMessage().getRegistration(),
+                                Registration.class);
 
-                if (registration.getId() != null
-                        && Boolean.TRUE.equals(
-                                registrationAdaptor.existsByIdAndIsSavedTrue(
-                                        registration.getId()))) {
+                if (isAlreadySaved(registration)) {
                     tracker.info("Already saved, ignored");
-                    acknowledge(eventIssuedEvent);
+                    acknowledgeAfterCommit(eventIssuedEvent);
                     return;
                 }
                 tracker.info(
@@ -81,15 +81,16 @@ public class EventIssuedEventHandler {
                         registration,
                         eventIssuedEvent.getMessage().getUserId(),
                         resolveScore(eventIssuedEvent));
-                acknowledge(eventIssuedEvent);
+                acknowledgeAfterCommit(eventIssuedEvent);
 
                 // sectorAdaptor.save(sector); 데드락 문제 임시 해결
             } catch (NoEventStockLeftException e) {
                 tracker.info("해당 구간 잔여 여석이 없습니다.", e);
-                acknowledge(eventIssuedEvent);
+                acknowledgeAfterCommit(eventIssuedEvent);
             } catch (Exception e) {
                 // ack 하지 않으면 Redis Stream pending entry로 남아 재처리할 수 있다.
                 tracker.error("EventIssuedEventHandler Exception: ", e);
+                throw new IllegalStateException(e);
             }
         } finally {
             MDC.clear();
@@ -97,12 +98,14 @@ public class EventIssuedEventHandler {
     }
 
     /** 대기열에서 pop한 registration을 저장하고 savedAt 기준 순서를 보존한다. */
-    public void processQueueData(Sector sector, Registration registration, Long userId, Double score) {
+    public void processQueueData(
+            Sector sector, Registration registration, Long userId, Double score) {
         User user = userAdaptor.findById(userId);
         saveRegistration(sector, user, registration, score);
     }
 
-    private void saveRegistration(Sector sector, User user, Registration registration, Double score) {
+    private void saveRegistration(
+            Sector sector, User user, Registration registration, Double score) {
         if (!sector.isRemainingAmount()) {
             tracker.info("[No seats remaining]. Registration: {}", registration);
             throw NoEventStockLeftException.EXCEPTION;
@@ -137,13 +140,49 @@ public class EventIssuedEventHandler {
         return (double) System.nanoTime();
     }
 
+    private boolean isAlreadySaved(Registration registration) {
+        if (registration.getId() != null
+                && Boolean.TRUE.equals(
+                        registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
+            return true;
+        }
+        return registration.getEventId() != null
+                && Boolean.TRUE.equals(
+                        registrationAdaptor.existsByEmailAndIsSavedTrue(
+                                registration.getEmail(), registration.getEventId()));
+    }
+
+    private void acknowledgeAfterCommit(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getStreamRecordId() == null) {
+            return;
+        }
+
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            acknowledge(eventIssuedEvent);
+                        }
+                    });
+            return;
+        }
+
+        acknowledge(eventIssuedEvent);
+    }
+
     private void acknowledge(EventIssuedEvent eventIssuedEvent) {
-        if (eventIssuedEvent.getStreamRecordId() != null) {
-            waitingQueueService.acknowledge(
+        try {
+            waitingQueueService.acknowledgeAndDelete(
                     REDIS_EVENT_ISSUE_STREAM,
                     REDIS_EVENT_ISSUE_GROUP,
                     eventIssuedEvent.getStreamRecordId());
+        } catch (Exception e) {
+            tracker.error(
+                    "Redis Stream ACK failed. recordId: {}",
+                    eventIssuedEvent.getStreamRecordId(),
+                    e);
         }
     }
-
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,7 +1,6 @@
 package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
@@ -175,7 +174,7 @@ public class EventIssuedEventHandler {
     private void acknowledge(EventIssuedEvent eventIssuedEvent) {
         try {
             waitingQueueService.acknowledgeAndDelete(
-                    REDIS_EVENT_ISSUE_STREAM,
+                    resolveStreamKey(eventIssuedEvent),
                     REDIS_EVENT_ISSUE_GROUP,
                     eventIssuedEvent.getStreamRecordId());
         } catch (Exception e) {
@@ -184,5 +183,12 @@ public class EventIssuedEventHandler {
                     eventIssuedEvent.getStreamRecordId(),
                     e);
         }
+    }
+
+    private String resolveStreamKey(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getStreamKey() != null) {
+            return eventIssuedEvent.getStreamKey();
+        }
+        return waitingQueueService.eventStreamKey(eventIssuedEvent.getMessage().getEventId());
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.common.domainEvent.Events;
@@ -37,7 +37,7 @@ public class EventDeleteUseCase {
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
         if (ableRedis) {
-            redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
+            redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
         }
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -1,6 +1,5 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.common.domainEvent.Events;
@@ -10,11 +9,13 @@ import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.event.EventDeletedEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
-import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @UseCase
 @RequiredArgsConstructor
@@ -22,7 +23,7 @@ public class EventDeleteUseCase {
     private final EventAdaptor eventAdaptor;
 
     @Autowired(required = false)
-    private RedisRepository redisRepository;
+    private WaitingQueueService waitingQueueService;
 
     private final SectorAdaptor sectorAdaptor;
     private final RegistrationAdaptor registrationAdaptor;
@@ -36,10 +37,26 @@ public class EventDeleteUseCase {
         Events.raise(EventDeletedEvent.of(event));
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
-        if (ableRedis) {
-            redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
-        }
+        deleteEventStreamAfterCommit(eventId);
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);
+    }
+
+    private void deleteEventStreamAfterCommit(Long eventId) {
+        if (!ableRedis || waitingQueueService == null) {
+            return;
+        }
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            waitingQueueService.deleteEventStream(eventId);
+                        }
+                    });
+            return;
+        }
+        waitingQueueService.deleteEventStream(eventId);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -1,6 +1,5 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketapi.api.event.model.response.GetEventPeriodResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
@@ -52,7 +51,11 @@ public class EventWithDrawUseCase {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
         waitingQueueService.registerQueue(
-                REDIS_EVENT_ISSUE_STREAM, registration, userId, sectorId, eventId);
+                waitingQueueService.eventStreamKey(eventId),
+                registration,
+                userId,
+                sectorId,
+                eventId);
     }
 
     public GetEventPeriodResponse getEventPeriod() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketapi.api.event.model.response.GetEventPeriodResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
@@ -52,7 +52,7 @@ public class EventWithDrawUseCase {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
         waitingQueueService.registerQueue(
-                REDIS_EVENT_ISSUE_STORE, registration, userId, sectorId, eventId);
+                REDIS_EVENT_ISSUE_STREAM, registration, userId, sectorId, eventId);
     }
 
     public GetEventPeriodResponse getEventPeriod() {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -1,0 +1,135 @@
+package com.jnu.ticketapi.api.event.handler;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class EventIssuedEventHandlerTest {
+
+    @Mock private RegistrationAdaptor registrationAdaptor;
+    @Mock private UserAdaptor userAdaptor;
+    @Mock private SectorAdaptor sectorAdaptor;
+    @Mock private WaitingQueueService waitingQueueService;
+    @Mock private Sector sector;
+    @Mock private User user;
+
+    private EventIssuedEventHandler eventIssuedEventHandler;
+
+    @BeforeEach
+    void setUp() {
+        eventIssuedEventHandler =
+                new EventIssuedEventHandler(
+                        registrationAdaptor, userAdaptor, sectorAdaptor, new ObjectMapper());
+        ReflectionTestUtils.setField(
+                eventIssuedEventHandler, "waitingQueueService", waitingQueueService);
+    }
+
+    @AfterEach
+    void clearTransactionSynchronization() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+    }
+
+    @Test
+    @DisplayName("DB 트랜잭션이 커밋된 뒤에만 Stream record를 ACK하고 삭제한다")
+    void handleAcknowledgesStreamRecordAfterCommit() {
+        EventIssuedEvent event = event("1-0", registrationJson());
+        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(sector.isRemainingAmount()).thenReturn(true);
+        when(userAdaptor.findById(1L)).thenReturn(user);
+        beginTransactionSynchronization();
+
+        eventIssuedEventHandler.handle(event);
+
+        verify(waitingQueueService, never())
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+
+        commitSynchronizations();
+
+        verify(waitingQueueService)
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+    }
+
+    @Test
+    @DisplayName("처리에 실패하면 예외를 다시 던지고 Stream record를 ACK하지 않는다")
+    void handleKeepsStreamRecordPendingOnFailure() {
+        EventIssuedEvent event = event("2-0", "not-json");
+        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+
+        assertThatThrownBy(() -> eventIssuedEventHandler.handle(event))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(waitingQueueService, never())
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "2-0");
+    }
+
+    @Test
+    @DisplayName("ID가 없는 신규 신청도 같은 이벤트와 이메일로 이미 저장됐다면 재처리하지 않는다")
+    void handleSkipsRedeliveredRegistrationWithoutId() {
+        EventIssuedEvent event = event("3-0", registrationJson());
+        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(registrationAdaptor.existsByEmailAndIsSavedTrue("student@jnu.ac.kr", 3L))
+                .thenReturn(true);
+
+        eventIssuedEventHandler.handle(event);
+
+        verify(userAdaptor, never()).findById(1L);
+        verify(registrationAdaptor, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(waitingQueueService)
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "3-0");
+    }
+
+    private void beginTransactionSynchronization() {
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    private void commitSynchronizations() {
+        List<TransactionSynchronization> synchronizations =
+                TransactionSynchronizationManager.getSynchronizations();
+        synchronizations.forEach(TransactionSynchronization::afterCommit);
+    }
+
+    private EventIssuedEvent event(String recordId, String registration) {
+        return EventIssuedEvent.from(new ChatMessage(registration, 1L, 2L, 3L), recordId);
+    }
+
+    private String registrationJson() {
+        return "{\"email\":\"student@jnu.ac.kr\","
+                + "\"name\":\"학생\","
+                + "\"studentNum\":\"20240001\","
+                + "\"carNum\":\"12가3456\","
+                + "\"phoneNum\":\"010-0000-0000\","
+                + "\"isLight\":false,"
+                + "\"isSaved\":false,"
+                + "\"isDeleted\":false,"
+                + "\"eventId\":3}";
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -1,7 +1,6 @@
 package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,6 +29,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 @ExtendWith(MockitoExtension.class)
 class EventIssuedEventHandlerTest {
+
+    private static final String EVENT_STREAM_KEY = "쿠폰 발급 스트림:{3}";
 
     @Mock private RegistrationAdaptor registrationAdaptor;
     @Mock private UserAdaptor userAdaptor;
@@ -69,12 +70,12 @@ class EventIssuedEventHandlerTest {
         eventIssuedEventHandler.handle(event);
 
         verify(waitingQueueService, never())
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "1-0");
 
         commitSynchronizations();
 
         verify(waitingQueueService)
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "1-0");
     }
 
     @Test
@@ -87,7 +88,7 @@ class EventIssuedEventHandlerTest {
                 .isInstanceOf(IllegalStateException.class);
 
         verify(waitingQueueService, never())
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "2-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "2-0");
     }
 
     @Test
@@ -103,7 +104,7 @@ class EventIssuedEventHandlerTest {
         verify(userAdaptor, never()).findById(1L);
         verify(registrationAdaptor, never()).save(org.mockito.ArgumentMatchers.any());
         verify(waitingQueueService)
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "3-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "3-0");
     }
 
     private void beginTransactionSynchronization() {
@@ -118,7 +119,8 @@ class EventIssuedEventHandlerTest {
     }
 
     private EventIssuedEvent event(String recordId, String registration) {
-        return EventIssuedEvent.from(new ChatMessage(registration, 1L, 2L, 3L), recordId);
+        return EventIssuedEvent.from(
+                new ChatMessage(registration, 1L, 2L, 3L), recordId, EVENT_STREAM_KEY);
     }
 
     private String registrationJson() {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -1,17 +1,18 @@
 package com.jnu.ticketbatch.config;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_CONSUMER;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
-import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
-import java.util.Set;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
 @Slf4j
 @DisallowConcurrentExecution
@@ -20,20 +21,27 @@ public class ProcessQueueDataJob implements Job {
 
     @Autowired private WaitingQueueService waitingQueueService;
 
+    private static final long READ_COUNT = 100L;
+
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         try {
             // 현재 쓰레드에 ApplicationEventPublisher를 설정
             Events.setPublisher(publisher);
 
-            Set<TypedTuple<Object>> messagesWithScores =
-                    waitingQueueService.findAllWithScore(REDIS_EVENT_ISSUE_STORE);
+            List<StreamQueueMessage> messages =
+                    waitingQueueService.readGroup(
+                            REDIS_EVENT_ISSUE_STREAM,
+                            REDIS_EVENT_ISSUE_GROUP,
+                            REDIS_EVENT_ISSUE_CONSUMER,
+                            READ_COUNT);
 
-            if (!messagesWithScores.isEmpty()) {
-                for (TypedTuple<Object> messageWithScore : messagesWithScores) {
-                    Double score = messageWithScore.getScore();
-                    ChatMessage message = (ChatMessage) messageWithScore.getValue();
-                    Events.raise(EventIssuedEvent.from(message, score));
+            if (!messages.isEmpty()) {
+                for (StreamQueueMessage streamQueueMessage : messages) {
+                    Events.raise(
+                            EventIssuedEvent.from(
+                                    streamQueueMessage.getMessage(),
+                                    streamQueueMessage.getRecordId()));
                 }
             }
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -2,7 +2,6 @@ package com.jnu.ticketbatch.config;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_CONSUMER;
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
@@ -28,10 +27,12 @@ public class ProcessQueueDataJob implements Job {
         try {
             // 현재 쓰레드에 ApplicationEventPublisher를 설정
             Events.setPublisher(publisher);
+            Long eventId = context.getMergedJobDataMap().getLong("eventId");
+            String streamKey = waitingQueueService.eventStreamKey(eventId);
 
             List<StreamQueueMessage> messages =
                     waitingQueueService.readGroup(
-                            REDIS_EVENT_ISSUE_STREAM,
+                            streamKey,
                             REDIS_EVENT_ISSUE_GROUP,
                             REDIS_EVENT_ISSUE_CONSUMER,
                             READ_COUNT);
@@ -41,7 +42,8 @@ public class ProcessQueueDataJob implements Job {
                     Events.raise(
                             EventIssuedEvent.from(
                                     streamQueueMessage.getMessage(),
-                                    streamQueueMessage.getRecordId()));
+                                    streamQueueMessage.getRecordId(),
+                                    streamKey));
                 }
             }
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketbatch.expired;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketdomain.domains.events.EventExpiredEventRaiseGateway;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
@@ -36,7 +36,7 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
-        redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
+        redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 
         JobParameters jobParameters =

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -1,13 +1,11 @@
 package com.jnu.ticketbatch.expired;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketdomain.domains.events.EventExpiredEventRaiseGateway;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
-import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -27,7 +25,6 @@ public class BatchQuartzJob extends QuartzJobBean {
     @Autowired private JobExplorer jobExplorer;
 
     @Autowired EventAdaptor eventAdaptor;
-    @Autowired RedisRepository redisRepository;
     @Autowired RegistrationAdaptor registrationAdaptor;
     @Autowired EventExpiredEventRaiseGateway eventExpiredEventRaiseGateway;
 
@@ -36,7 +33,6 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
-        redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 
         JobParameters jobParameters =
@@ -45,7 +41,7 @@ public class BatchQuartzJob extends QuartzJobBean {
                         .addLong("eventId", eventId)
                         .toJobParameters();
         log.info("EventThrow in BatchQuartzJob");
-//        eventExpiredEventRaiseGateway.handle(eventId);
+        //        eventExpiredEventRaiseGateway.handle(eventId);
         try {
             this.jobLauncher.run(this.job, jobParameters);
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
@@ -38,6 +38,7 @@ public class EventRegisterJob implements Job {
     private static final String GROUP = "group1";
     private static final String ASIA_SEOUL = "Asia/Seoul";
     private static final long OPEN_LEAD_SECONDS = 5L;
+    private static final long QUEUE_DRAIN_GRACE_MINUTES = 5L;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -123,7 +124,11 @@ public class EventRegisterJob implements Job {
                         .build();
 
         Date start = Date.from(startAt.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
-        Date end = Date.from(endAt.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
+        Date end =
+                Date.from(
+                        endAt.plusMinutes(QUEUE_DRAIN_GRACE_MINUTES)
+                                .atZone(ZoneId.of(ASIA_SEOUL))
+                                .toInstant());
 
         Trigger reserveTrigger =
                 newTrigger()

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
@@ -30,6 +30,9 @@ public class TicketStatic {
 
     public static final String REDIS_EVENT_CHANNEL = "쿠폰 발급 채널";
     public static final String REDIS_EVENT_ISSUE_STORE = "쿠폰 발급 저장소";
+    public static final String REDIS_EVENT_ISSUE_STREAM = "쿠폰 발급 스트림";
+    public static final String REDIS_EVENT_ISSUE_GROUP = "쿠폰 발급 그룹";
+    public static final String REDIS_EVENT_ISSUE_CONSUMER = "쿠폰 발급 소비자";
 
     public static final Integer REGISTRATION_SIZE = 14;
     public static final Integer MAX_EMAIL_SEND_RETRY = 10;

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
@@ -64,7 +64,7 @@ public class RedisConfig {
                 new Jackson2JsonRedisSerializer<>(ChatMessage.class);
         redisTemplate.setValueSerializer(serializer);
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(serializer);
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
@@ -10,16 +10,26 @@ import lombok.Getter;
 public class EventIssuedEvent extends InfrastructureEvent {
     private ChatMessage message;
     private final Double score;
+    private final String streamRecordId;
 
     public static EventIssuedEvent from(ChatMessage message, Double score) {
         return EventIssuedEvent.builder().message(message).score(score).build();
     }
 
+    public static EventIssuedEvent from(ChatMessage message, String streamRecordId) {
+        return EventIssuedEvent.builder().message(message).streamRecordId(streamRecordId).build();
+    }
+
     @Override
     public String toString() {
-        return "EventIssuedEvent{" +
-                "message=" + message +
-                ", score=" + score +
-                '}';
+        return "EventIssuedEvent{"
+                + "message="
+                + message
+                + ", score="
+                + score
+                + ", streamRecordId='"
+                + streamRecordId
+                + '\''
+                + '}';
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
@@ -11,6 +11,7 @@ public class EventIssuedEvent extends InfrastructureEvent {
     private ChatMessage message;
     private final Double score;
     private final String streamRecordId;
+    private final String streamKey;
 
     public static EventIssuedEvent from(ChatMessage message, Double score) {
         return EventIssuedEvent.builder().message(message).score(score).build();
@@ -18,6 +19,15 @@ public class EventIssuedEvent extends InfrastructureEvent {
 
     public static EventIssuedEvent from(ChatMessage message, String streamRecordId) {
         return EventIssuedEvent.builder().message(message).streamRecordId(streamRecordId).build();
+    }
+
+    public static EventIssuedEvent from(
+            ChatMessage message, String streamRecordId, String streamKey) {
+        return EventIssuedEvent.builder()
+                .message(message)
+                .streamRecordId(streamRecordId)
+                .streamKey(streamKey)
+                .build();
     }
 
     @Override
@@ -29,6 +39,9 @@ public class EventIssuedEvent extends InfrastructureEvent {
                 + score
                 + ", streamRecordId='"
                 + streamRecordId
+                + '\''
+                + ", streamKey='"
+                + streamKey
                 + '\''
                 + '}';
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
@@ -18,11 +18,16 @@ public class ChatMessage {
 
     @Override
     public String toString() {
-        return "ChatMessage{" +
-                "registration='" + registration + '\'' +
-                ", userId=" + userId +
-                ", sectorId=" + sectorId +
-                ", eventId=" + eventId +
-                '}';
+        return "ChatMessage{"
+                + "registration='"
+                + registration
+                + '\''
+                + ", userId="
+                + userId
+                + ", sectorId="
+                + sectorId
+                + ", eventId="
+                + eventId
+                + '}';
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StreamQueueMessage.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StreamQueueMessage.java
@@ -1,0 +1,12 @@
+package com.jnu.ticketinfrastructure.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StreamQueueMessage {
+    private final String recordId;
+    private final ChatMessage message;
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,12 +3,23 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -18,6 +29,7 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 @ConditionalOnExpression("${ableRedis:true}")
 public class RedisRepository {
+    private static final String STREAM_PAYLOAD_KEY = "payload";
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
 
@@ -107,6 +119,53 @@ public class RedisRepository {
         return redisTemplate.opsForZSet().score(key, value);
     }
 
+    public RecordId xAdd(String key, ChatMessage message) {
+        try {
+            Map<String, String> body =
+                    Map.of(STREAM_PAYLOAD_KEY, objectMapper.writeValueAsString(message));
+            return redisTemplate.opsForStream().add(key, body);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to add message to Redis Stream", e);
+        }
+    }
+
+    public void createConsumerGroupIfAbsent(String key, String group) {
+        try {
+            redisTemplate.execute(
+                    (RedisCallback<String>)
+                            connection ->
+                                    connection.xGroupCreate(
+                                            key.getBytes(StandardCharsets.UTF_8),
+                                            group,
+                                            ReadOffset.from("0-0"),
+                                            true));
+        } catch (DataAccessException e) {
+            if (!isAlreadyCreatedGroup(e)) {
+                throw e;
+            }
+        }
+    }
+
+    public List<StreamQueueMessage> xReadGroup(
+            String key, String group, String consumer, long count) {
+        createConsumerGroupIfAbsent(key, group);
+        List<MapRecord<String, Object, Object>> records =
+                redisTemplate
+                        .opsForStream()
+                        .read(
+                                Consumer.from(group, consumer),
+                                StreamReadOptions.empty().count(count),
+                                StreamOffset.create(key, ReadOffset.lastConsumed()));
+        if (records == null || records.isEmpty()) {
+            return List.of();
+        }
+        return records.stream().map(this::toStreamQueueMessage).toList();
+    }
+
+    public Long xAck(String key, String group, String recordId) {
+        return redisTemplate.opsForStream().acknowledge(key, group, recordId);
+    }
+
     public Long remove(String key, Object value) {
         return redisTemplate.opsForZSet().remove(key, value);
     }
@@ -127,5 +186,21 @@ public class RedisRepository {
             // Set is empty, return null or handle accordingly
             return null;
         }
+    }
+
+    private StreamQueueMessage toStreamQueueMessage(MapRecord<String, Object, Object> record) {
+        Object payload = record.getValue().get(STREAM_PAYLOAD_KEY);
+        try {
+            return new StreamQueueMessage(
+                    record.getId().getValue(),
+                    objectMapper.readValue(String.valueOf(payload), ChatMessage.class));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse Redis Stream message", e);
+        }
+    }
+
+    private boolean isAlreadyCreatedGroup(Exception e) {
+        String message = e.getMessage();
+        return message != null && message.contains("BUSYGROUP");
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -5,17 +5,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
@@ -162,6 +168,44 @@ public class RedisRepository {
         return records.stream().map(this::toStreamQueueMessage).toList();
     }
 
+    public List<StreamQueueMessage> xClaimStale(
+            String key, String group, String consumer, long count, Duration minIdleTime) {
+        createConsumerGroupIfAbsent(key, group);
+        PendingMessages pendingMessages =
+                redisTemplate.opsForStream().pending(key, group, Range.unbounded(), count);
+        if (pendingMessages == null || pendingMessages.isEmpty()) {
+            return List.of();
+        }
+
+        RecordId[] staleRecordIds =
+                StreamSupport.stream(pendingMessages.spliterator(), false)
+                        .filter(pendingMessage -> isStale(pendingMessage, minIdleTime))
+                        .map(PendingMessage::getId)
+                        .toArray(RecordId[]::new);
+        if (staleRecordIds.length == 0) {
+            return List.of();
+        }
+
+        List<ByteRecord> claimedRecords =
+                redisTemplate.execute(
+                        (RedisCallback<List<ByteRecord>>)
+                                connection ->
+                                        connection.xClaim(
+                                                key.getBytes(StandardCharsets.UTF_8),
+                                                group,
+                                                consumer,
+                                                minIdleTime,
+                                                staleRecordIds));
+        if (claimedRecords == null || claimedRecords.isEmpty()) {
+            return List.of();
+        }
+
+        return claimedRecords.stream()
+                .map(redisTemplate.opsForStream()::deserializeRecord)
+                .map(this::toStreamQueueMessage)
+                .toList();
+    }
+
     public Long xAck(String key, String group, String recordId) {
         return redisTemplate.opsForStream().acknowledge(key, group, recordId);
     }
@@ -206,5 +250,9 @@ public class RedisRepository {
     private boolean isAlreadyCreatedGroup(Exception e) {
         String message = e.getMessage();
         return message != null && message.contains("BUSYGROUP");
+    }
+
+    private boolean isStale(PendingMessage pendingMessage, Duration minIdleTime) {
+        return pendingMessage.getElapsedTimeSinceLastDelivery().compareTo(minIdleTime) >= 0;
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -166,6 +166,10 @@ public class RedisRepository {
         return redisTemplate.opsForStream().acknowledge(key, group, recordId);
     }
 
+    public Long xDelete(String key, String recordId) {
+        return redisTemplate.opsForStream().delete(key, recordId);
+    }
+
     public Long remove(String key, Object value) {
         return redisTemplate.opsForZSet().remove(key, value);
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketinfrastructure.service;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -144,5 +145,13 @@ public class WaitingQueueService {
             redisRepository.xDelete(key, recordId);
         }
         return acknowledged;
+    }
+
+    public String eventStreamKey(Long eventId) {
+        return REDIS_EVENT_ISSUE_STREAM + ":{" + eventId + "}";
+    }
+
+    public void deleteEventStream(Long eventId) {
+        redisRepository.delete(eventStreamKey(eventId));
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -9,6 +9,8 @@ import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrat
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Service;
 public class WaitingQueueService {
 
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
+    private static final Duration STREAM_PENDING_MIN_IDLE_TIME = Duration.ofSeconds(30);
 
     private final RedisRepository redisRepository;
     @Autowired private ObjectMapper objectMapper;
@@ -119,7 +122,16 @@ public class WaitingQueueService {
 
     public List<StreamQueueMessage> readGroup(
             String key, String group, String consumer, long count) {
-        return redisRepository.xReadGroup(key, group, consumer, count);
+        List<StreamQueueMessage> recovered =
+                redisRepository.xClaimStale(
+                        key, group, consumer, count, STREAM_PENDING_MIN_IDLE_TIME);
+        if (recovered.size() >= count) {
+            return recovered;
+        }
+
+        List<StreamQueueMessage> messages = new ArrayList<>(recovered);
+        messages.addAll(redisRepository.xReadGroup(key, group, consumer, count - recovered.size()));
+        return messages;
     }
 
     public Long acknowledge(String key, String group, String recordId) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -125,4 +125,12 @@ public class WaitingQueueService {
     public Long acknowledge(String key, String group, String recordId) {
         return redisRepository.xAck(key, group, recordId);
     }
+
+    public Long acknowledgeAndDelete(String key, String group, String recordId) {
+        Long acknowledged = redisRepository.xAck(key, group, recordId);
+        if (acknowledged != null && acknowledged > 0) {
+            redisRepository.xDelete(key, recordId);
+        }
+        return acknowledged;
+    }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -7,8 +7,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -40,9 +42,8 @@ public class WaitingQueueService {
         Double score = (double) System.currentTimeMillis();
         String registrationString = convertRegistrationJSON(registration);
         ChatMessage message = new ChatMessage(registrationString, userId, sectorId, eventId);
-        checkDuplicateData(key, message);
-        redisRepository.zAddIfAbsent(key, message, score);
-        tracker.info("Added to the queue, score:{}", score);
+        redisRepository.xAdd(key, message);
+        tracker.info("Added to the stream, score:{}", score);
     }
 
     public String convertRegistrationJSON(Registration registration) {
@@ -114,5 +115,14 @@ public class WaitingQueueService {
 
     public Set<ZSetOperations.TypedTuple<Object>> findAllWithScore(String key) {
         return redisRepository.zRangeWithScores(key, 0L, -1L);
+    }
+
+    public List<StreamQueueMessage> readGroup(
+            String key, String group, String consumer, long count) {
+        return redisRepository.xReadGroup(key, group, consumer, count);
+    }
+
+    public Long acknowledge(String key, String group, String recordId) {
+        return redisRepository.xAck(key, group, recordId);
     }
 }

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -121,4 +121,15 @@ class RedisRepositoryStreamTest {
 
         assertThat(acknowledged).isEqualTo(1L);
     }
+
+    @Test
+    @DisplayName("xDelete는 처리 완료된 Stream record 삭제를 Redis에 위임한다")
+    void xDeleteDelegatesToStreamOperations() {
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.delete(STREAM_KEY, "1-0")).thenReturn(1L);
+
+        Long deleted = redisRepository.xDelete(STREAM_KEY, "1-0");
+
+        assertThat(deleted).isEqualTo(1L);
+    }
 }

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,8 +21,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
@@ -38,6 +42,7 @@ class RedisRepositoryStreamTest {
 
     @Mock private RedisTemplate<String, Object> redisTemplate;
     @Mock private StreamOperations<String, Object, Object> streamOperations;
+    @Mock private ByteRecord byteRecord;
 
     private RedisRepository redisRepository;
     private ObjectMapper objectMapper;
@@ -109,6 +114,44 @@ class RedisRepositoryStreamTest {
 
         assertThatCode(() -> redisRepository.createConsumerGroupIfAbsent(STREAM_KEY, GROUP))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("xClaimStale은 idle 기준을 넘긴 pending record를 현재 consumer로 가져온다")
+    void xClaimStaleClaimsRecoverablePendingRecord() throws Exception {
+        ChatMessage message = new ChatMessage("{\"id\":10}", 1L, 2L, 3L);
+        MapRecord<String, Object, Object> record =
+                MapRecord.create(
+                                STREAM_KEY,
+                                Map.<Object, Object>of(
+                                        "payload", objectMapper.writeValueAsString(message)))
+                        .withId(RecordId.of("1-0"));
+        PendingMessage pendingMessage =
+                new PendingMessage(
+                        RecordId.of("1-0"),
+                        Consumer.from(GROUP, "stopped-consumer"),
+                        Duration.ofMinutes(1),
+                        2L);
+        PendingMessages pendingMessages = new PendingMessages(GROUP, List.of(pendingMessage));
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenReturn("OK")
+                .thenReturn(List.of(byteRecord));
+        when(streamOperations.pending(
+                        eq(STREAM_KEY),
+                        eq(GROUP),
+                        any(org.springframework.data.domain.Range.class),
+                        eq(10L)))
+                .thenReturn(pendingMessages);
+        when(streamOperations.deserializeRecord(byteRecord)).thenReturn(record);
+
+        List<StreamQueueMessage> result =
+                redisRepository.xClaimStale(
+                        STREAM_KEY, GROUP, CONSUMER, 10L, Duration.ofSeconds(30));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRecordId()).isEqualTo("1-0");
+        assertThat(result.get(0).getMessage().getUserId()).isEqualTo(1L);
     }
 
     @Test

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -1,0 +1,124 @@
+package com.jnu.ticketinfrastructure.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisRepositoryStreamTest {
+
+    private static final String STREAM_KEY = "event-issue-stream";
+    private static final String GROUP = "event-issue-group";
+    private static final String CONSUMER = "event-issue-consumer";
+
+    @Mock private RedisTemplate<String, Object> redisTemplate;
+    @Mock private StreamOperations<String, Object, Object> streamOperations;
+
+    private RedisRepository redisRepository;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        redisRepository = new RedisRepository(redisTemplate);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @DisplayName("xAdd는 ChatMessage를 payload JSON으로 직렬화해서 Stream에 추가한다")
+    void xAddSerializesChatMessageAsPayload() throws Exception {
+        ChatMessage message = new ChatMessage("{\"id\":10}", 1L, 2L, 3L);
+        RecordId recordId = RecordId.of("1-0");
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.add(eq(STREAM_KEY), any(Map.class))).thenReturn(recordId);
+
+        RecordId result = redisRepository.xAdd(STREAM_KEY, message);
+
+        assertThat(result).isEqualTo(recordId);
+        ArgumentCaptor<Map<String, String>> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(streamOperations).add(eq(STREAM_KEY), bodyCaptor.capture());
+
+        String payload = bodyCaptor.getValue().get("payload");
+        ChatMessage parsed = objectMapper.readValue(payload, ChatMessage.class);
+        assertThat(parsed.getRegistration()).isEqualTo("{\"id\":10}");
+        assertThat(parsed.getUserId()).isEqualTo(1L);
+        assertThat(parsed.getSectorId()).isEqualTo(2L);
+        assertThat(parsed.getEventId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("xReadGroup은 Stream record id와 payload를 StreamQueueMessage로 복원한다")
+    void xReadGroupParsesRecordIdAndPayload() throws Exception {
+        ChatMessage message = new ChatMessage("{\"id\":10}", 1L, 2L, 3L);
+        MapRecord<String, Object, Object> record =
+                MapRecord.create(
+                                STREAM_KEY,
+                                Map.<Object, Object>of(
+                                        "payload", objectMapper.writeValueAsString(message)))
+                        .withId(RecordId.of("1690000000000-0"));
+        when(redisTemplate.execute(any(RedisCallback.class))).thenReturn("OK");
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.read(
+                        any(Consumer.class), any(StreamReadOptions.class), any(StreamOffset.class)))
+                .thenReturn(List.of(record));
+
+        List<StreamQueueMessage> result =
+                redisRepository.xReadGroup(STREAM_KEY, GROUP, CONSUMER, 100);
+
+        assertThat(result).hasSize(1);
+        StreamQueueMessage streamQueueMessage = result.get(0);
+        assertThat(streamQueueMessage.getRecordId()).isEqualTo("1690000000000-0");
+        assertThat(streamQueueMessage.getMessage().getRegistration()).isEqualTo("{\"id\":10}");
+        assertThat(streamQueueMessage.getMessage().getUserId()).isEqualTo(1L);
+        assertThat(streamQueueMessage.getMessage().getSectorId()).isEqualTo(2L);
+        assertThat(streamQueueMessage.getMessage().getEventId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("consumer group이 이미 있으면 BUSYGROUP 예외를 성공으로 처리한다")
+    void createConsumerGroupIgnoresBusyGroup() {
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenThrow(
+                        new RedisSystemException(
+                                "BUSYGROUP Consumer Group name already exists",
+                                new RuntimeException()));
+
+        assertThatCode(() -> redisRepository.createConsumerGroupIfAbsent(STREAM_KEY, GROUP))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("xAck는 Stream record ACK를 Redis에 위임한다")
+    void xAckDelegatesToStreamOperations() {
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.acknowledge(STREAM_KEY, GROUP, "1-0")).thenReturn(1L);
+
+        Long acknowledged = redisRepository.xAck(STREAM_KEY, GROUP, "1-0");
+
+        assertThat(acknowledged).isEqualTo(1L);
+    }
+}

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -1,0 +1,108 @@
+package com.jnu.ticketinfrastructure.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WaitingQueueServiceTest {
+
+    private static final String STREAM_KEY = "event-issue-stream";
+
+    @Mock private RedisRepository redisRepository;
+
+    private WaitingQueueService waitingQueueService;
+
+    @BeforeEach
+    void setUp() {
+        waitingQueueService = new WaitingQueueService(redisRepository);
+    }
+
+    @Test
+    @DisplayName("신청 대기열 등록은 Redis Stream에 ChatMessage payload로 저장한다")
+    void registerQueueAddsMessageToRedisStream() throws Exception {
+        Registration registration = registration();
+
+        waitingQueueService.registerQueue(STREAM_KEY, registration, 1L, 2L, 3L);
+
+        ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+        verify(redisRepository).xAdd(eq(STREAM_KEY), messageCaptor.capture());
+        verify(redisRepository, never()).zAddIfAbsent(anyString(), any(), anyDouble());
+
+        ChatMessage message = messageCaptor.getValue();
+        assertThat(message.getUserId()).isEqualTo(1L);
+        assertThat(message.getSectorId()).isEqualTo(2L);
+        assertThat(message.getEventId()).isEqualTo(3L);
+
+        JSONObject payload = new JSONObject(message.getRegistration());
+        assertThat(payload.getLong("id")).isEqualTo(10L);
+        assertThat(payload.getString("email")).isEqualTo("student@jnu.ac.kr");
+        assertThat(payload.getString("studentNum")).isEqualTo("20240001");
+        assertThat(payload.getBoolean("isSaved")).isFalse();
+        assertThat(payload.getLong("eventId")).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("consumer group 조회는 Redis Stream readGroup에 위임한다")
+    void readGroupDelegatesToRedisStreamRepository() {
+        List<StreamQueueMessage> messages =
+                List.of(new StreamQueueMessage("1-0", new ChatMessage("{}", 1L, 2L, 3L)));
+        when(redisRepository.xReadGroup(STREAM_KEY, "group", "consumer", 100L))
+                .thenReturn(messages);
+
+        List<StreamQueueMessage> result =
+                waitingQueueService.readGroup(STREAM_KEY, "group", "consumer", 100L);
+
+        assertThat(result).isSameAs(messages);
+    }
+
+    @Test
+    @DisplayName("처리 완료된 Stream record는 acknowledge로 ACK 처리한다")
+    void acknowledgeDelegatesToRedisStreamRepository() {
+        when(redisRepository.xAck(STREAM_KEY, "group", "1-0")).thenReturn(1L);
+
+        Long acknowledged = waitingQueueService.acknowledge(STREAM_KEY, "group", "1-0");
+
+        assertThat(acknowledged).isEqualTo(1L);
+    }
+
+    private Registration registration() {
+        Registration registration =
+                Registration.builder()
+                        .email("student@jnu.ac.kr")
+                        .name("학생")
+                        .studentNum("20240001")
+                        .affiliation("공과대학")
+                        .department("컴퓨터공학과")
+                        .carNum("12가3456")
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                        .isSaved(false)
+                        .savedAt(null)
+                        .eventId(3L)
+                        .build();
+        registration.setId(10L);
+        return registration;
+    }
+}

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -13,6 +13,7 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.json.JSONObject;
@@ -67,13 +68,35 @@ class WaitingQueueServiceTest {
     void readGroupDelegatesToRedisStreamRepository() {
         List<StreamQueueMessage> messages =
                 List.of(new StreamQueueMessage("1-0", new ChatMessage("{}", 1L, 2L, 3L)));
+        when(redisRepository.xClaimStale(
+                        STREAM_KEY, "group", "consumer", 100L, Duration.ofSeconds(30)))
+                .thenReturn(List.of());
         when(redisRepository.xReadGroup(STREAM_KEY, "group", "consumer", 100L))
                 .thenReturn(messages);
 
         List<StreamQueueMessage> result =
                 waitingQueueService.readGroup(STREAM_KEY, "group", "consumer", 100L);
 
-        assertThat(result).isSameAs(messages);
+        assertThat(result).containsExactlyElementsOf(messages);
+    }
+
+    @Test
+    @DisplayName("stale pending record를 먼저 복구하고 남은 수만큼 새 메시지를 읽는다")
+    void readGroupRecoversStalePendingBeforeNewMessages() {
+        StreamQueueMessage recovered =
+                new StreamQueueMessage("1-0", new ChatMessage("{}", 1L, 2L, 3L));
+        StreamQueueMessage newMessage =
+                new StreamQueueMessage("2-0", new ChatMessage("{}", 2L, 2L, 3L));
+        when(redisRepository.xClaimStale(
+                        STREAM_KEY, "group", "consumer", 2L, Duration.ofSeconds(30)))
+                .thenReturn(List.of(recovered));
+        when(redisRepository.xReadGroup(STREAM_KEY, "group", "consumer", 1L))
+                .thenReturn(List.of(newMessage));
+
+        List<StreamQueueMessage> result =
+                waitingQueueService.readGroup(STREAM_KEY, "group", "consumer", 2L);
+
+        assertThat(result).containsExactly(recovered, newMessage);
     }
 
     @Test

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -130,6 +130,20 @@ class WaitingQueueServiceTest {
         verify(redisRepository, never()).xDelete(STREAM_KEY, "1-0");
     }
 
+    @Test
+    @DisplayName("이벤트별 Stream key는 Redis Cluster hash tag에 eventId를 사용한다")
+    void eventStreamKeyUsesEventHashTag() {
+        assertThat(waitingQueueService.eventStreamKey(3L)).isEqualTo("쿠폰 발급 스트림:{3}");
+    }
+
+    @Test
+    @DisplayName("이벤트 삭제는 해당 이벤트의 Stream만 삭제한다")
+    void deleteEventStreamDeletesOnlyEventStreamKey() {
+        waitingQueueService.deleteEventStream(3L);
+
+        verify(redisRepository).delete("쿠폰 발급 스트림:{3}");
+    }
+
     private Registration registration() {
         Registration registration =
                 Registration.builder()

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -86,6 +86,27 @@ class WaitingQueueServiceTest {
         assertThat(acknowledged).isEqualTo(1L);
     }
 
+    @Test
+    @DisplayName("ACK에 성공한 Stream record는 원본 entry도 삭제한다")
+    void acknowledgeAndDeleteRemovesAcknowledgedRecord() {
+        when(redisRepository.xAck(STREAM_KEY, "group", "1-0")).thenReturn(1L);
+
+        Long acknowledged = waitingQueueService.acknowledgeAndDelete(STREAM_KEY, "group", "1-0");
+
+        assertThat(acknowledged).isEqualTo(1L);
+        verify(redisRepository).xDelete(STREAM_KEY, "1-0");
+    }
+
+    @Test
+    @DisplayName("ACK하지 못한 Stream record는 삭제하지 않는다")
+    void acknowledgeAndDeleteKeepsUnacknowledgedRecord() {
+        when(redisRepository.xAck(STREAM_KEY, "group", "1-0")).thenReturn(0L);
+
+        waitingQueueService.acknowledgeAndDelete(STREAM_KEY, "group", "1-0");
+
+        verify(redisRepository, never()).xDelete(STREAM_KEY, "1-0");
+    }
+
     private Registration registration() {
         Registration registration =
                 Registration.builder()


### PR DESCRIPTION
## 주요 변경사항

> [!IMPORTANT]
> 이 PR은 `origin/dev` 기준으로 브랜치와 BE 번호 규칙을 다시 정리하면서 닫혔습니다. 같은 Issue #520의 현재 구현과 리뷰는 [PR #526](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/526)에서 진행합니다.

- Redis Sorted Set 대기열을 이벤트별 Redis Stream Consumer Group으로 전환합니다.
- 정상 소비를 담당하던 400ms `PROCESS_QUEUE_DATA_JOB`을 제거하고 blocking `XREADGROUP` consumer를 사용합니다.
- `@Async ApplicationEvent` 중간 단계를 제거하고 Stream 전용 bounded executor에서 저장 handler를 직접 호출합니다.
- DB 동시 처리는 Hikari connection 여유 범위로 제한하고 queue 포화 시 backpressure를 적용합니다.
- DB commit 후에만 `XACK`/`XDEL`하며 stale Pending은 `XAUTOCLAIM`으로 회수합니다.
- 이벤트 OPEN 시 구독을 시작하고 CLOSED 후 lag, pending, in-flight가 모두 소진되면 구독을 종료합니다.
- Quartz는 이벤트 OPEN/CLOSED 시각 관리에만 유지합니다.

## 리뷰어에게...

- 이 닫힌 PR의 과거 diff와 설명은 리뷰 기준이 아닙니다.
- 최신 코드, 테스트 결과, 제외 범위는 [PR #526](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/526) 본문을 확인해 주세요.

## 관련 이슈

- [Issue #520](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/issues/520)
- [대체 PR #526](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/526)

## 체크리스트

- [x] 대체 PR 링크 명시
- [x] 현재 Stream 소비 구조 반영
- [x] 관련 이슈 연결
