### PR TITLE
[BE-247] feat: 신청 저장 시 순번 확정 및 메일 Outbox 생성

### DIFF
--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
@@ -1,24 +1,13 @@
 package com.jnu.ticketapi.api.council.handler;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
 
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.events.event.SendEmailEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
-import com.jnu.ticketinfrastructure.service.MailService;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -30,14 +19,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 @Slf4j
 public class EmailSendEventHandler {
-    private final MailService mailService;
     private final RegistrationAdaptor registrationAdaptor;
+    private final EmailOutboxAdaptor emailOutboxAdaptor;
 
-    @Retryable(
-            retryFor = {Exception.class},
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 30000))
-    @SneakyThrows
     @Async
     @TransactionalEventListener(
             classes = SendEmailEvent.class,
@@ -45,108 +29,22 @@ public class EmailSendEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(SendEmailEvent sendEmailEvent) {
         int startIndex = 0;
-        int batchSize = 14;
         Page<Registration> registrations;
-        Queue<Registration> failQueue = new LinkedList<>();
-        Map<Registration, Integer> retryCounts = new HashMap<>(); // Map to track retry counts
 
         do {
             registrations =
                     registrationAdaptor.findByIsDeletedFalseAndIsSavedTrueByPage(
                             sendEmailEvent.getEventId(), startIndex);
 
-            List<Registration> batch = new ArrayList<>(batchSize);
             for (Registration registration : registrations.getContent()) {
-                batch.add(registration);
-
-                if (batch.size() == batchSize) {
-                    processBatch(batch, failQueue, retryCounts);
-                    batch.clear();
-
-                    TimeUnit.SECONDS.sleep(1);
-                }
-            }
-
-            if (!batch.isEmpty()) {
-                processBatch(batch, failQueue, retryCounts);
-                batch.clear();
-                TimeUnit.SECONDS.sleep(1);
+                emailOutboxAdaptor.saveRegistrationResultIfAbsent(registration);
             }
             startIndex++;
 
         } while (registrations.hasNext());
 
-        failOver(failQueue, retryCounts);
-    }
-
-    private void processBatch(
-            List<Registration> batch,
-            Queue<Registration> failQueue,
-            Map<Registration, Integer> retryCounts) {
-        for (Registration registration : batch) {
-            try {
-                boolean result =
-                        mailService.sendRegistrationResultMail(
-                                registration.getEmail(),
-                                registration.getName(),
-                                registration.getUser().getStatus().getValue(),
-                                registration.getUser().getSequence());
-
-                if (!result) {
-                    failQueue.add(registration);
-                    retryCounts.put(
-                            registration,
-                            retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
-                }
-            } catch (Exception e) {
-                log.error(
-                        "Email sending failed for {}: {}", registration.getEmail(), e.getMessage());
-                failQueue.add(registration);
-                retryCounts.put(
-                        registration,
-                        retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
-            }
-        }
-    }
-
-    private void failOver(Queue<Registration> failQueue, Map<Registration, Integer> retryCounts)
-            throws InterruptedException {
-        while (!failQueue.isEmpty()) {
-            int queueSize = failQueue.size();
-            for (int i = 0; i < queueSize; i++) {
-                Registration registration = failQueue.poll();
-
-                int retryCount = retryCounts.getOrDefault(registration, 0);
-                if (retryCount >= MAX_EMAIL_SEND_RETRY) {
-                    log.error("최대 10번 retry 실패시: {}", registration.getEmail());
-                    continue;
-                }
-                try {
-                    boolean result =
-                            mailService.sendRegistrationResultMail(
-                                    registration.getEmail(),
-                                    registration.getName(),
-                                    registration.getUser().getStatus().getValue(),
-                                    registration.getUser().getSequence());
-
-                    if (!result) {
-                        retryCounts.put(registration, retryCount + 1);
-                        failQueue.add(registration);
-                        log.warn(
-                                "Retry failed for email: {} (Attempt {})",
-                                registration.getEmail(),
-                                retryCount + 1);
-                    }
-                } catch (Exception e) {
-                    log.error(
-                            "Retry exception for email {}: {}",
-                            registration.getEmail(),
-                            e.getMessage());
-                    retryCounts.put(registration, retryCount + 1);
-                    failQueue.add(registration);
-                }
-            }
-            TimeUnit.SECONDS.sleep(1);
-        }
+        log.info(
+                "Manual SendEmailEvent outbox backfill completed. eventId: {}",
+                sendEmailEvent.getEventId());
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -3,6 +3,7 @@ package com.jnu.ticketapi.api.event.handler;
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
@@ -10,6 +11,7 @@ import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,7 @@ public class EventIssuedEventHandler {
 
     private final RegistrationAdaptor registrationAdaptor;
     private final UserAdaptor userAdaptor;
+    private final EmailOutboxAdaptor emailOutboxAdaptor;
 
     @Autowired(required = false)
     private WaitingQueueService waitingQueueService;
@@ -55,7 +58,8 @@ public class EventIssuedEventHandler {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
 
-            Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
+            Sector sector =
+                    sectorAdaptor.findByIdForUpdate(eventIssuedEvent.getMessage().getSectorId());
 
             try {
                 Registration registration =
@@ -96,7 +100,11 @@ public class EventIssuedEventHandler {
         }
     }
 
-    /** 대기열에서 pop한 registration을 저장하고 savedAt 기준 순서를 보존한다. */
+    /** 대기열에서 pop한 registration을 저장하는 시점에 순번과 결과를 확정하고 메일 outbox를 생성한다. */
+    public void processQueueData(Sector sector, Registration registration, Long userId) {
+        processQueueData(sector, registration, userId, (double) System.currentTimeMillis());
+    }
+
     public void processQueueData(
             Sector sector, Registration registration, Long userId, Double score) {
         User user = userAdaptor.findById(userId);
@@ -105,27 +113,61 @@ public class EventIssuedEventHandler {
 
     private void saveRegistration(
             Sector sector, User user, Registration registration, Double score) {
-        if (!sector.isRemainingAmount()) {
-            tracker.info("[No seats remaining]. Registration: {}", registration);
-            throw NoEventStockLeftException.EXCEPTION;
+        int position =
+                Math.toIntExact(registrationAdaptor.countSavedBySectorId(sector.getId())) + 1;
+        RegistrationDecision decision = decideResult(sector, position);
+
+        if (!decision.isFail()) {
+            sector.decreaseEventStock();
         }
+
+        reflectUserState(user, decision);
 
         if (!registration.isSaved()) {
             // if문 사용 안됨.
-            registration.finalSave();
+            registration.finalSave(position, decision.resultStatus, decision.sequence);
             registration.setSector(sector);
             registration.setUser(user);
             registration.setSavedAt(score.longValue());
-            registrationAdaptor.save(registration);
-            return;
+            Registration savedRegistration = registrationAdaptor.save(registration);
+            emailOutboxAdaptor.saveRegistrationResultIfAbsent(savedRegistration);
+        } else {
+            registration.finalSave(position, decision.resultStatus, decision.sequence);
+            registration.setSector(sector);
+            registration.setUser(user);
+            registration.setSavedAt(score.longValue());
+            Registration savedRegistration = registrationAdaptor.saveAndFlush(registration);
+            emailOutboxAdaptor.saveRegistrationResultIfAbsent(savedRegistration);
         }
 
-        registration.setSector(sector);
-        registration.setUser(user);
-        registration.setSavedAt(score.longValue());
-        registrationAdaptor.saveAndFlush(registration);
+        tracker.info(
+                "Registration saved. position: {}, status: {}, sequence: {}",
+                position,
+                decision.resultStatus.getValue(),
+                decision.sequence);
+    }
 
-        tracker.info("Registration saved");
+    private RegistrationDecision decideResult(Sector sector, int position) {
+        if (position <= sector.getInitSectorCapacity()) {
+            return new RegistrationDecision(UserStatus.SUCCESS, -2);
+        }
+        if (position <= sector.getIssueAmount()) {
+            return new RegistrationDecision(
+                    UserStatus.PREPARE, position - sector.getInitSectorCapacity());
+        }
+        return new RegistrationDecision(UserStatus.FAIL, -1);
+    }
+
+    private void reflectUserState(User user, RegistrationDecision decision) {
+        if (decision.resultStatus == UserStatus.SUCCESS) {
+            user.success();
+            return;
+        }
+        if (decision.resultStatus == UserStatus.PREPARE) {
+            user.prepare(decision.sequence);
+            return;
+        }
+        user.fail();
     }
 
     private Double resolveScore(EventIssuedEvent eventIssuedEvent) {
@@ -136,7 +178,7 @@ public class EventIssuedEventHandler {
         if (streamRecordId != null && streamRecordId.contains("-")) {
             return Double.valueOf(streamRecordId.substring(0, streamRecordId.indexOf('-')));
         }
-        return (double) System.nanoTime();
+        return (double) System.currentTimeMillis();
     }
 
     private boolean isAlreadySaved(Registration registration) {
@@ -190,5 +232,19 @@ public class EventIssuedEventHandler {
             return eventIssuedEvent.getStreamKey();
         }
         return waitingQueueService.eventStreamKey(eventIssuedEvent.getMessage().getEventId());
+    }
+
+    private static class RegistrationDecision {
+        private final UserStatus resultStatus;
+        private final Integer sequence;
+
+        private RegistrationDecision(UserStatus resultStatus, Integer sequence) {
+            this.resultStatus = resultStatus;
+            this.sequence = sequence;
+        }
+
+        private boolean isFail() {
+            return resultStatus == UserStatus.FAIL;
+        }
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -13,7 +13,6 @@ import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
-import com.zaxxer.hikari.HikariDataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -43,7 +42,6 @@ public class EventIssuedEventHandler {
 
     private final SectorAdaptor sectorAdaptor;
     private final ObjectMapper objectMapper;
-    private final HikariDataSource hikariDataSource;
 
     @Async
     @EventListener(classes = EventIssuedEvent.class)
@@ -55,9 +53,6 @@ public class EventIssuedEventHandler {
     public void handle(EventIssuedEvent eventIssuedEvent) {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
-            if (!isIdleConnectionAvailable()) {
-                return;
-            }
 
             Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
@@ -151,8 +146,4 @@ public class EventIssuedEventHandler {
         }
     }
 
-    private boolean isIdleConnectionAvailable() {
-        int idleConnections = hikariDataSource.getHikariPoolMXBean().getIdleConnections();
-        return idleConnections > 0;
-    }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,7 +1,9 @@
 package com.jnu.ticketapi.api.event.handler;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
@@ -9,7 +11,6 @@ import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
-import com.jnu.ticketdomain.domains.user.event.UserReflectStatusEvent;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import com.zaxxer.hikari.HikariDataSource;
@@ -26,8 +27,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @Component
 @RequiredArgsConstructor
@@ -56,57 +55,56 @@ public class EventIssuedEventHandler {
     public void handle(EventIssuedEvent eventIssuedEvent) {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
-            if (isIdleConnectionAvailable()) {
-                Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
+            if (!isIdleConnectionAvailable()) {
+                return;
+            }
 
-                try {
-                    Double score = eventIssuedEvent.getScore();
+            Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
-                    Registration registration =
-                            objectMapper.readValue(
-                                    eventIssuedEvent.getMessage().getRegistration(),
-                                    Registration.class);
+            try {
+                Registration registration =
+                        objectMapper.readValue(
+                                eventIssuedEvent.getMessage().getRegistration(), Registration.class);
 
-                    if (Boolean.TRUE.equals(
-                            registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
-                        tracker.info("Already saved, ignored");
-                        return;
-                    }
-                    tracker.info(
-                            "현재구간 정보, sectorId: {}, 정원여석: {}, 예비여석: {}, 총 여석: {},",
-                            sector.getId(),
-                            sector.getSectorCapacity(),
-                            sector.getReserve(),
-                            sector.getRemainingAmount());
-
-                    processQueueData(
-                            sector, registration, eventIssuedEvent.getMessage().getUserId(), score);
-                    waitingQueueService.remove(
-                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-//                    sector.decreaseEventStock();
-
-                    // sectorAdaptor.save(sector); 데드락 문제 임시 해결
-                } catch (NoEventStockLeftException e) {
-                    tracker.info("해당 구간 잔여 여석이 없습니다.", e);
-                    waitingQueueService.remove(
-                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-                } catch (Exception e) {
-                    // 에러가 났을 때 redis에 데이터를 재등록 한다.(Not Waiting 상태로)
-                    tracker.error("EventIssuedEventHandler Exception: ", e);
+                if (registration.getId() != null
+                        && Boolean.TRUE.equals(
+                                registrationAdaptor.existsByIdAndIsSavedTrue(
+                                        registration.getId()))) {
+                    tracker.info("Already saved, ignored");
+                    acknowledge(eventIssuedEvent);
+                    return;
                 }
+                tracker.info(
+                        "현재구간 정보, sectorId: {}, 정원여석: {}, 예비여석: {}, 총 여석: {},",
+                        sector.getId(),
+                        sector.getSectorCapacity(),
+                        sector.getReserve(),
+                        sector.getRemainingAmount());
+
+                processQueueData(
+                        sector,
+                        registration,
+                        eventIssuedEvent.getMessage().getUserId(),
+                        resolveScore(eventIssuedEvent));
+                acknowledge(eventIssuedEvent);
+
+                // sectorAdaptor.save(sector); 데드락 문제 임시 해결
+            } catch (NoEventStockLeftException e) {
+                tracker.info("해당 구간 잔여 여석이 없습니다.", e);
+                acknowledge(eventIssuedEvent);
+            } catch (Exception e) {
+                // ack 하지 않으면 Redis Stream pending entry로 남아 재처리할 수 있다.
+                tracker.error("EventIssuedEventHandler Exception: ", e);
             }
         } finally {
             MDC.clear();
         }
     }
 
-    /**
-     * 대기열에서 pop한 registration을 저장하고 유저 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
-     */
+    /** 대기열에서 pop한 registration을 저장하고 savedAt 기준 순서를 보존한다. */
     public void processQueueData(Sector sector, Registration registration, Long userId, Double score) {
         User user = userAdaptor.findById(userId);
         saveRegistration(sector, user, registration, score);
-//        Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
     }
 
     private void saveRegistration(Sector sector, User user, Registration registration, Double score) {
@@ -127,11 +125,30 @@ public class EventIssuedEventHandler {
 
         registration.setSector(sector);
         registration.setUser(user);
-//        registrationAdaptor.updateSavedAt(registration);
         registration.setSavedAt(score.longValue());
         registrationAdaptor.saveAndFlush(registration);
 
         tracker.info("Registration saved");
+    }
+
+    private Double resolveScore(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getScore() != null) {
+            return eventIssuedEvent.getScore();
+        }
+        String streamRecordId = eventIssuedEvent.getStreamRecordId();
+        if (streamRecordId != null && streamRecordId.contains("-")) {
+            return Double.valueOf(streamRecordId.substring(0, streamRecordId.indexOf('-')));
+        }
+        return (double) System.nanoTime();
+    }
+
+    private void acknowledge(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getStreamRecordId() != null) {
+            waitingQueueService.acknowledge(
+                    REDIS_EVENT_ISSUE_STREAM,
+                    REDIS_EVENT_ISSUE_GROUP,
+                    eventIssuedEvent.getStreamRecordId());
+        }
     }
 
     private boolean isIdleConnectionAvailable() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -26,6 +26,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @RequiredArgsConstructor
@@ -59,14 +61,12 @@ public class EventIssuedEventHandler {
             try {
                 Registration registration =
                         objectMapper.readValue(
-                                eventIssuedEvent.getMessage().getRegistration(), Registration.class);
+                                eventIssuedEvent.getMessage().getRegistration(),
+                                Registration.class);
 
-                if (registration.getId() != null
-                        && Boolean.TRUE.equals(
-                                registrationAdaptor.existsByIdAndIsSavedTrue(
-                                        registration.getId()))) {
+                if (isAlreadySaved(registration)) {
                     tracker.info("Already saved, ignored");
-                    acknowledge(eventIssuedEvent);
+                    acknowledgeAfterCommit(eventIssuedEvent);
                     return;
                 }
                 tracker.info(
@@ -81,15 +81,16 @@ public class EventIssuedEventHandler {
                         registration,
                         eventIssuedEvent.getMessage().getUserId(),
                         resolveScore(eventIssuedEvent));
-                acknowledge(eventIssuedEvent);
+                acknowledgeAfterCommit(eventIssuedEvent);
 
                 // sectorAdaptor.save(sector); 데드락 문제 임시 해결
             } catch (NoEventStockLeftException e) {
                 tracker.info("해당 구간 잔여 여석이 없습니다.", e);
-                acknowledge(eventIssuedEvent);
+                acknowledgeAfterCommit(eventIssuedEvent);
             } catch (Exception e) {
                 // ack 하지 않으면 Redis Stream pending entry로 남아 재처리할 수 있다.
                 tracker.error("EventIssuedEventHandler Exception: ", e);
+                throw new IllegalStateException(e);
             }
         } finally {
             MDC.clear();
@@ -97,12 +98,14 @@ public class EventIssuedEventHandler {
     }
 
     /** 대기열에서 pop한 registration을 저장하고 savedAt 기준 순서를 보존한다. */
-    public void processQueueData(Sector sector, Registration registration, Long userId, Double score) {
+    public void processQueueData(
+            Sector sector, Registration registration, Long userId, Double score) {
         User user = userAdaptor.findById(userId);
         saveRegistration(sector, user, registration, score);
     }
 
-    private void saveRegistration(Sector sector, User user, Registration registration, Double score) {
+    private void saveRegistration(
+            Sector sector, User user, Registration registration, Double score) {
         if (!sector.isRemainingAmount()) {
             tracker.info("[No seats remaining]. Registration: {}", registration);
             throw NoEventStockLeftException.EXCEPTION;
@@ -137,13 +140,49 @@ public class EventIssuedEventHandler {
         return (double) System.nanoTime();
     }
 
+    private boolean isAlreadySaved(Registration registration) {
+        if (registration.getId() != null
+                && Boolean.TRUE.equals(
+                        registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
+            return true;
+        }
+        return registration.getEventId() != null
+                && Boolean.TRUE.equals(
+                        registrationAdaptor.existsByEmailAndIsSavedTrue(
+                                registration.getEmail(), registration.getEventId()));
+    }
+
+    private void acknowledgeAfterCommit(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getStreamRecordId() == null) {
+            return;
+        }
+
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            acknowledge(eventIssuedEvent);
+                        }
+                    });
+            return;
+        }
+
+        acknowledge(eventIssuedEvent);
+    }
+
     private void acknowledge(EventIssuedEvent eventIssuedEvent) {
-        if (eventIssuedEvent.getStreamRecordId() != null) {
-            waitingQueueService.acknowledge(
+        try {
+            waitingQueueService.acknowledgeAndDelete(
                     REDIS_EVENT_ISSUE_STREAM,
                     REDIS_EVENT_ISSUE_GROUP,
                     eventIssuedEvent.getStreamRecordId());
+        } catch (Exception e) {
+            tracker.error(
+                    "Redis Stream ACK failed. recordId: {}",
+                    eventIssuedEvent.getStreamRecordId(),
+                    e);
         }
     }
-
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,7 +1,6 @@
 package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
@@ -175,7 +174,7 @@ public class EventIssuedEventHandler {
     private void acknowledge(EventIssuedEvent eventIssuedEvent) {
         try {
             waitingQueueService.acknowledgeAndDelete(
-                    REDIS_EVENT_ISSUE_STREAM,
+                    resolveStreamKey(eventIssuedEvent),
                     REDIS_EVENT_ISSUE_GROUP,
                     eventIssuedEvent.getStreamRecordId());
         } catch (Exception e) {
@@ -184,5 +183,12 @@ public class EventIssuedEventHandler {
                     eventIssuedEvent.getStreamRecordId(),
                     e);
         }
+    }
+
+    private String resolveStreamKey(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getStreamKey() != null) {
+            return eventIssuedEvent.getStreamKey();
+        }
+        return waitingQueueService.eventStreamKey(eventIssuedEvent.getMessage().getEventId());
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.common.domainEvent.Events;
@@ -37,7 +37,7 @@ public class EventDeleteUseCase {
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
         if (ableRedis) {
-            redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
+            redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
         }
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -1,6 +1,5 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.common.domainEvent.Events;
@@ -10,11 +9,13 @@ import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.event.EventDeletedEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
-import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @UseCase
 @RequiredArgsConstructor
@@ -22,7 +23,7 @@ public class EventDeleteUseCase {
     private final EventAdaptor eventAdaptor;
 
     @Autowired(required = false)
-    private RedisRepository redisRepository;
+    private WaitingQueueService waitingQueueService;
 
     private final SectorAdaptor sectorAdaptor;
     private final RegistrationAdaptor registrationAdaptor;
@@ -36,10 +37,26 @@ public class EventDeleteUseCase {
         Events.raise(EventDeletedEvent.of(event));
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
-        if (ableRedis) {
-            redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
-        }
+        deleteEventStreamAfterCommit(eventId);
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);
+    }
+
+    private void deleteEventStreamAfterCommit(Long eventId) {
+        if (!ableRedis || waitingQueueService == null) {
+            return;
+        }
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            waitingQueueService.deleteEventStream(eventId);
+                        }
+                    });
+            return;
+        }
+        waitingQueueService.deleteEventStream(eventId);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -1,6 +1,5 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketapi.api.event.model.response.GetEventPeriodResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
@@ -52,7 +51,11 @@ public class EventWithDrawUseCase {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
         waitingQueueService.registerQueue(
-                REDIS_EVENT_ISSUE_STREAM, registration, userId, sectorId, eventId);
+                waitingQueueService.eventStreamKey(eventId),
+                registration,
+                userId,
+                sectorId,
+                eventId);
     }
 
     public GetEventPeriodResponse getEventPeriod() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketapi.api.event.model.response.GetEventPeriodResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
@@ -52,7 +52,7 @@ public class EventWithDrawUseCase {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
         waitingQueueService.registerQueue(
-                REDIS_EVENT_ISSUE_STORE, registration, userId, sectorId, eventId);
+                REDIS_EVENT_ISSUE_STREAM, registration, userId, sectorId, eventId);
     }
 
     public GetEventPeriodResponse getEventPeriod() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.registration.handler;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
 
 import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
@@ -28,10 +29,11 @@ public class EmailOutboxWorker {
             initialDelayString = "${mail.outbox.initial-delay-ms:1000}")
     public void sendPendingRegistrationResultMail() {
         LocalDateTime staleBefore = LocalDateTime.now().minusMinutes(STALE_PROCESSING_MINUTES);
-        List<EmailOutbox> pendingOutboxes = emailOutboxAdaptor.findPending(BATCH_SIZE, staleBefore);
+        List<EmailOutbox> pendingOutboxes =
+                emailOutboxAdaptor.findPending(BATCH_SIZE, staleBefore, MAX_EMAIL_SEND_RETRY);
 
         for (EmailOutbox outbox : pendingOutboxes) {
-            if (!emailOutboxAdaptor.claim(outbox.getId(), staleBefore)) {
+            if (!emailOutboxAdaptor.claim(outbox.getId(), staleBefore, MAX_EMAIL_SEND_RETRY)) {
                 continue;
             }
             send(outbox);
@@ -51,7 +53,7 @@ public class EmailOutboxWorker {
             return;
         }
 
-        emailOutboxAdaptor.releaseAfterFailure(outbox.getId());
+        emailOutboxAdaptor.markFailed(outbox.getId());
         log.warn("신청 결과 메일 outbox 발송 실패. outboxId: {}", outbox.getId());
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
@@ -1,0 +1,55 @@
+package com.jnu.ticketapi.api.registration.handler;
+
+
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketinfrastructure.service.MailService;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EmailOutboxWorker {
+    private static final int BATCH_SIZE = 20;
+    private static final long STALE_PROCESSING_MINUTES = 10;
+
+    private final EmailOutboxAdaptor emailOutboxAdaptor;
+    private final MailService mailService;
+
+    @Scheduled(
+            fixedDelayString = "${mail.outbox.fixed-delay-ms:1000}",
+            initialDelayString = "${mail.outbox.initial-delay-ms:1000}")
+    public void sendPendingRegistrationResultMail() {
+        LocalDateTime staleBefore = LocalDateTime.now().minusMinutes(STALE_PROCESSING_MINUTES);
+        List<EmailOutbox> pendingOutboxes = emailOutboxAdaptor.findPending(BATCH_SIZE, staleBefore);
+
+        for (EmailOutbox outbox : pendingOutboxes) {
+            if (!emailOutboxAdaptor.claim(outbox.getId(), staleBefore)) {
+                continue;
+            }
+            send(outbox);
+        }
+    }
+
+    private void send(EmailOutbox outbox) {
+        boolean sent =
+                mailService.sendRegistrationResultMail(
+                        outbox.getEmail(),
+                        outbox.getName(),
+                        outbox.getResultStatus().getValue(),
+                        outbox.getSequence());
+
+        if (sent) {
+            emailOutboxAdaptor.markSent(outbox.getId());
+            return;
+        }
+
+        emailOutboxAdaptor.releaseAfterFailure(outbox.getId());
+        log.warn("신청 결과 메일 outbox 발송 실패. outboxId: {}", outbox.getId());
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
@@ -8,10 +8,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(value = "mail.outbox.enabled", havingValue = "true", matchIfMissing = true)
 @RequiredArgsConstructor
 @Slf4j
 public class EmailOutboxWorker {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EventExpiredEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EventExpiredEventHandler.java
@@ -1,24 +1,13 @@
 package com.jnu.ticketapi.api.registration.handler;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
 
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.events.event.EventExpiredEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
-import com.jnu.ticketinfrastructure.service.MailService;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -30,14 +19,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 @Slf4j
 public class EventExpiredEventHandler {
-    private final MailService mailService;
     private final RegistrationAdaptor registrationAdaptor;
+    private final EmailOutboxAdaptor emailOutboxAdaptor;
 
-    @Retryable(
-            retryFor = {Exception.class},
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 30000))
-    @SneakyThrows
     @Async
     @TransactionalEventListener(
             classes = EventExpiredEvent.class,
@@ -45,108 +29,22 @@ public class EventExpiredEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(EventExpiredEvent eventExpiredEvent) {
         int startIndex = 0;
-        int batchSize = 14;
         Page<Registration> registrations;
-        Queue<Registration> failQueue = new LinkedList<>();
-        Map<Registration, Integer> retryCounts = new HashMap<>(); // Map to track retry counts
 
         do {
             registrations =
                     registrationAdaptor.findByIsDeletedFalseAndIsSavedTrueByPage(
                             eventExpiredEvent.getEventId(), startIndex);
 
-            List<Registration> batch = new ArrayList<>(batchSize);
             for (Registration registration : registrations.getContent()) {
-                batch.add(registration);
-
-                if (batch.size() == batchSize) {
-                    processBatch(batch, failQueue, retryCounts);
-                    batch.clear();
-
-                    TimeUnit.SECONDS.sleep(1);
-                }
-            }
-
-            if (!batch.isEmpty()) {
-                processBatch(batch, failQueue, retryCounts);
-                batch.clear();
-                TimeUnit.SECONDS.sleep(1);
+                emailOutboxAdaptor.saveRegistrationResultIfAbsent(registration);
             }
             startIndex++;
 
         } while (registrations.hasNext());
 
-        failOver(failQueue, retryCounts);
-    }
-
-    private void processBatch(
-            List<Registration> batch,
-            Queue<Registration> failQueue,
-            Map<Registration, Integer> retryCounts) {
-        for (Registration registration : batch) {
-            try {
-                boolean result =
-                        mailService.sendRegistrationResultMail(
-                                registration.getEmail(),
-                                registration.getName(),
-                                registration.getUser().getStatus().getValue(),
-                                registration.getUser().getSequence());
-
-                if (!result) {
-                    failQueue.add(registration);
-                    retryCounts.put(
-                            registration,
-                            retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
-                }
-            } catch (Exception e) {
-                log.error(
-                        "Email sending failed for {}: {}", registration.getEmail(), e.getMessage());
-                failQueue.add(registration);
-                retryCounts.put(
-                        registration,
-                        retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
-            }
-        }
-    }
-
-    private void failOver(Queue<Registration> failQueue, Map<Registration, Integer> retryCounts)
-            throws InterruptedException {
-        while (!failQueue.isEmpty()) {
-            int queueSize = failQueue.size();
-            for (int i = 0; i < queueSize; i++) {
-                Registration registration = failQueue.poll();
-
-                int retryCount = retryCounts.getOrDefault(registration, 0);
-                if (retryCount >= MAX_EMAIL_SEND_RETRY) {
-                    log.error("최대 10번 retry 실패시: {}", registration.getEmail());
-                    continue;
-                }
-                try {
-                    boolean result =
-                            mailService.sendRegistrationResultMail(
-                                    registration.getEmail(),
-                                    registration.getName(),
-                                    registration.getUser().getStatus().getValue(),
-                                    registration.getUser().getSequence());
-
-                    if (!result) {
-                        retryCounts.put(registration, retryCount + 1);
-                        failQueue.add(registration);
-                        log.warn(
-                                "Retry failed for email: {} (Attempt {})",
-                                registration.getEmail(),
-                                retryCount + 1);
-                    }
-                } catch (Exception e) {
-                    log.error(
-                            "Retry exception for email {}: {}",
-                            registration.getEmail(),
-                            e.getMessage());
-                    retryCounts.put(registration, retryCount + 1);
-                    failQueue.add(registration);
-                }
-            }
-            TimeUnit.SECONDS.sleep(1);
-        }
+        log.info(
+                "EventExpiredEvent outbox backfill completed. eventId: {}",
+                eventExpiredEvent.getEventId());
     }
 }

--- a/Ticket-Api/src/main/resources/db/teardown.sql
+++ b/Ticket-Api/src/main/resources/db/teardown.sql
@@ -7,6 +7,7 @@ truncate table captcha_tb;
 truncate table captcha_log_tb;
 truncate table council_tb;
 truncate table credential_code_tb;
+truncate table email_outbox;
 truncate table event;
 truncate table notice_tb;
 truncate table registration_tb;
@@ -69,4 +70,3 @@ values (1, '공지사항입니다.', '공지사항', CURRENT_TIMESTAMP);
 
 insert into notice_tb(id, created_at, modified_at, content)
 values (1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '안내사항입니다.');
-

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -1,0 +1,135 @@
+package com.jnu.ticketapi.api.event.handler;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class EventIssuedEventHandlerTest {
+
+    @Mock private RegistrationAdaptor registrationAdaptor;
+    @Mock private UserAdaptor userAdaptor;
+    @Mock private SectorAdaptor sectorAdaptor;
+    @Mock private WaitingQueueService waitingQueueService;
+    @Mock private Sector sector;
+    @Mock private User user;
+
+    private EventIssuedEventHandler eventIssuedEventHandler;
+
+    @BeforeEach
+    void setUp() {
+        eventIssuedEventHandler =
+                new EventIssuedEventHandler(
+                        registrationAdaptor, userAdaptor, sectorAdaptor, new ObjectMapper());
+        ReflectionTestUtils.setField(
+                eventIssuedEventHandler, "waitingQueueService", waitingQueueService);
+    }
+
+    @AfterEach
+    void clearTransactionSynchronization() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+    }
+
+    @Test
+    @DisplayName("DB 트랜잭션이 커밋된 뒤에만 Stream record를 ACK하고 삭제한다")
+    void handleAcknowledgesStreamRecordAfterCommit() {
+        EventIssuedEvent event = event("1-0", registrationJson());
+        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(sector.isRemainingAmount()).thenReturn(true);
+        when(userAdaptor.findById(1L)).thenReturn(user);
+        beginTransactionSynchronization();
+
+        eventIssuedEventHandler.handle(event);
+
+        verify(waitingQueueService, never())
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+
+        commitSynchronizations();
+
+        verify(waitingQueueService)
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+    }
+
+    @Test
+    @DisplayName("처리에 실패하면 예외를 다시 던지고 Stream record를 ACK하지 않는다")
+    void handleKeepsStreamRecordPendingOnFailure() {
+        EventIssuedEvent event = event("2-0", "not-json");
+        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+
+        assertThatThrownBy(() -> eventIssuedEventHandler.handle(event))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(waitingQueueService, never())
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "2-0");
+    }
+
+    @Test
+    @DisplayName("ID가 없는 신규 신청도 같은 이벤트와 이메일로 이미 저장됐다면 재처리하지 않는다")
+    void handleSkipsRedeliveredRegistrationWithoutId() {
+        EventIssuedEvent event = event("3-0", registrationJson());
+        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(registrationAdaptor.existsByEmailAndIsSavedTrue("student@jnu.ac.kr", 3L))
+                .thenReturn(true);
+
+        eventIssuedEventHandler.handle(event);
+
+        verify(userAdaptor, never()).findById(1L);
+        verify(registrationAdaptor, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(waitingQueueService)
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "3-0");
+    }
+
+    private void beginTransactionSynchronization() {
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    private void commitSynchronizations() {
+        List<TransactionSynchronization> synchronizations =
+                TransactionSynchronizationManager.getSynchronizations();
+        synchronizations.forEach(TransactionSynchronization::afterCommit);
+    }
+
+    private EventIssuedEvent event(String recordId, String registration) {
+        return EventIssuedEvent.from(new ChatMessage(registration, 1L, 2L, 3L), recordId);
+    }
+
+    private String registrationJson() {
+        return "{\"email\":\"student@jnu.ac.kr\","
+                + "\"name\":\"학생\","
+                + "\"studentNum\":\"20240001\","
+                + "\"carNum\":\"12가3456\","
+                + "\"phoneNum\":\"010-0000-0000\","
+                + "\"isLight\":false,"
+                + "\"isSaved\":false,"
+                + "\"isDeleted\":false,"
+                + "\"eventId\":3}";
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -1,20 +1,27 @@
 package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserRole;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,10 +41,11 @@ class EventIssuedEventHandlerTest {
 
     @Mock private RegistrationAdaptor registrationAdaptor;
     @Mock private UserAdaptor userAdaptor;
+    @Mock private EmailOutboxAdaptor emailOutboxAdaptor;
     @Mock private SectorAdaptor sectorAdaptor;
     @Mock private WaitingQueueService waitingQueueService;
     @Mock private Sector sector;
-    @Mock private User user;
+    @Mock private User queuedUser;
 
     private EventIssuedEventHandler eventIssuedEventHandler;
 
@@ -45,7 +53,11 @@ class EventIssuedEventHandlerTest {
     void setUp() {
         eventIssuedEventHandler =
                 new EventIssuedEventHandler(
-                        registrationAdaptor, userAdaptor, sectorAdaptor, new ObjectMapper());
+                        registrationAdaptor,
+                        userAdaptor,
+                        emailOutboxAdaptor,
+                        sectorAdaptor,
+                        new ObjectMapper());
         ReflectionTestUtils.setField(
                 eventIssuedEventHandler, "waitingQueueService", waitingQueueService);
     }
@@ -62,9 +74,10 @@ class EventIssuedEventHandlerTest {
     @DisplayName("DB 트랜잭션이 커밋된 뒤에만 Stream record를 ACK하고 삭제한다")
     void handleAcknowledgesStreamRecordAfterCommit() {
         EventIssuedEvent event = event("1-0", registrationJson());
-        when(sectorAdaptor.findById(2L)).thenReturn(sector);
-        when(sector.isRemainingAmount()).thenReturn(true);
-        when(userAdaptor.findById(1L)).thenReturn(user);
+        givenQueuedRegistrationSector();
+        when(userAdaptor.findById(1L)).thenReturn(queuedUser);
+        when(registrationAdaptor.save(any(Registration.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
         beginTransactionSynchronization();
 
         eventIssuedEventHandler.handle(event);
@@ -82,7 +95,7 @@ class EventIssuedEventHandlerTest {
     @DisplayName("처리에 실패하면 예외를 다시 던지고 Stream record를 ACK하지 않는다")
     void handleKeepsStreamRecordPendingOnFailure() {
         EventIssuedEvent event = event("2-0", "not-json");
-        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(sectorAdaptor.findByIdForUpdate(2L)).thenReturn(sector);
 
         assertThatThrownBy(() -> eventIssuedEventHandler.handle(event))
                 .isInstanceOf(IllegalStateException.class);
@@ -95,16 +108,94 @@ class EventIssuedEventHandlerTest {
     @DisplayName("ID가 없는 신규 신청도 같은 이벤트와 이메일로 이미 저장됐다면 재처리하지 않는다")
     void handleSkipsRedeliveredRegistrationWithoutId() {
         EventIssuedEvent event = event("3-0", registrationJson());
-        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(sectorAdaptor.findByIdForUpdate(2L)).thenReturn(sector);
         when(registrationAdaptor.existsByEmailAndIsSavedTrue("student@jnu.ac.kr", 3L))
                 .thenReturn(true);
 
         eventIssuedEventHandler.handle(event);
 
         verify(userAdaptor, never()).findById(1L);
-        verify(registrationAdaptor, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(registrationAdaptor, never()).save(any());
         verify(waitingQueueService)
                 .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "3-0");
+    }
+
+    @Test
+    @DisplayName("정원 이내 position이면 합격으로 확정하고 outbox를 생성한다")
+    void processQueueDataDecidesSuccess() {
+        Registration registration = registration();
+        User user = user();
+        givenSector(2, 4);
+        when(registrationAdaptor.countSavedBySectorId(1L)).thenReturn(0L);
+        when(userAdaptor.findById(100L)).thenReturn(user);
+        when(registrationAdaptor.save(registration)).thenReturn(registration);
+
+        eventIssuedEventHandler.processQueueData(sector, registration, 100L, 1_234D);
+
+        assertThat(registration.getPosition()).isEqualTo(1);
+        assertThat(registration.getResultStatus()).isEqualTo(UserStatus.SUCCESS);
+        assertThat(registration.getSequence()).isEqualTo(-2);
+        assertThat(registration.getSavedAt()).isEqualTo(1_234L);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.SUCCESS);
+        assertThat(user.getSequence()).isEqualTo(-2);
+        verify(sector).decreaseEventStock();
+        verify(emailOutboxAdaptor).saveRegistrationResultIfAbsent(registration);
+    }
+
+    @Test
+    @DisplayName("정원 초과 예비 정원 이내 position이면 예비 번호로 확정한다")
+    void processQueueDataDecidesPrepare() {
+        Registration registration = registration();
+        User user = user();
+        givenSector(2, 4);
+        when(registrationAdaptor.countSavedBySectorId(1L)).thenReturn(2L);
+        when(userAdaptor.findById(100L)).thenReturn(user);
+        when(registrationAdaptor.save(registration)).thenReturn(registration);
+
+        eventIssuedEventHandler.processQueueData(sector, registration, 100L);
+
+        assertThat(registration.getPosition()).isEqualTo(3);
+        assertThat(registration.getResultStatus()).isEqualTo(UserStatus.PREPARE);
+        assertThat(registration.getSequence()).isEqualTo(1);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.PREPARE);
+        assertThat(user.getSequence()).isEqualTo(1);
+        verify(sector).decreaseEventStock();
+        verify(emailOutboxAdaptor).saveRegistrationResultIfAbsent(registration);
+    }
+
+    @Test
+    @DisplayName("예비 정원까지 초과한 position이면 불합격으로 저장하고 재고는 차감하지 않는다")
+    void processQueueDataDecidesFailWithoutDecreasingStock() {
+        Registration registration = registration();
+        User user = user();
+        givenSector(2, 4);
+        when(registrationAdaptor.countSavedBySectorId(1L)).thenReturn(4L);
+        when(userAdaptor.findById(100L)).thenReturn(user);
+        when(registrationAdaptor.save(registration)).thenReturn(registration);
+
+        eventIssuedEventHandler.processQueueData(sector, registration, 100L);
+
+        assertThat(registration.getPosition()).isEqualTo(5);
+        assertThat(registration.getResultStatus()).isEqualTo(UserStatus.FAIL);
+        assertThat(registration.getSequence()).isEqualTo(-1);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.FAIL);
+        assertThat(user.getSequence()).isEqualTo(-1);
+        verify(sector, never()).decreaseEventStock();
+        verify(emailOutboxAdaptor).saveRegistrationResultIfAbsent(registration);
+    }
+
+    private void givenQueuedRegistrationSector() {
+        when(sectorAdaptor.findByIdForUpdate(2L)).thenReturn(sector);
+        when(sector.getId()).thenReturn(2L);
+        when(sector.getInitSectorCapacity()).thenReturn(1);
+        when(sector.getIssueAmount()).thenReturn(2);
+        when(registrationAdaptor.countSavedBySectorId(2L)).thenReturn(0L);
+    }
+
+    private void givenSector(int initSectorCapacity, int issueAmount) {
+        when(sector.getId()).thenReturn(1L);
+        when(sector.getInitSectorCapacity()).thenReturn(initSectorCapacity);
+        org.mockito.Mockito.lenient().when(sector.getIssueAmount()).thenReturn(issueAmount);
     }
 
     private void beginTransactionSynchronization() {
@@ -133,5 +224,32 @@ class EventIssuedEventHandlerTest {
                 + "\"isSaved\":false,"
                 + "\"isDeleted\":false,"
                 + "\"eventId\":3}";
+    }
+
+    private Registration registration() {
+        Registration registration =
+                Registration.builder()
+                        .email("student@jnu.ac.kr")
+                        .name("학생")
+                        .studentNum("20240001")
+                        .affiliation("공과대학")
+                        .department("컴퓨터공학과")
+                        .carNum("12가3456")
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                        .isSaved(false)
+                        .eventId(10L)
+                        .build();
+        registration.setId(10L);
+        return registration;
+    }
+
+    private User user() {
+        return User.builder()
+                .email("student@jnu.ac.kr")
+                .pwd("encoded-password")
+                .userRole(UserRole.USER)
+                .build();
     }
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -1,7 +1,6 @@
 package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,6 +29,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 @ExtendWith(MockitoExtension.class)
 class EventIssuedEventHandlerTest {
+
+    private static final String EVENT_STREAM_KEY = "쿠폰 발급 스트림:{3}";
 
     @Mock private RegistrationAdaptor registrationAdaptor;
     @Mock private UserAdaptor userAdaptor;
@@ -69,12 +70,12 @@ class EventIssuedEventHandlerTest {
         eventIssuedEventHandler.handle(event);
 
         verify(waitingQueueService, never())
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "1-0");
 
         commitSynchronizations();
 
         verify(waitingQueueService)
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "1-0");
     }
 
     @Test
@@ -87,7 +88,7 @@ class EventIssuedEventHandlerTest {
                 .isInstanceOf(IllegalStateException.class);
 
         verify(waitingQueueService, never())
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "2-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "2-0");
     }
 
     @Test
@@ -103,7 +104,7 @@ class EventIssuedEventHandlerTest {
         verify(userAdaptor, never()).findById(1L);
         verify(registrationAdaptor, never()).save(org.mockito.ArgumentMatchers.any());
         verify(waitingQueueService)
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "3-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "3-0");
     }
 
     private void beginTransactionSynchronization() {
@@ -118,7 +119,8 @@ class EventIssuedEventHandlerTest {
     }
 
     private EventIssuedEvent event(String recordId, String registration) {
-        return EventIssuedEvent.from(new ChatMessage(registration, 1L, 2L, 3L), recordId);
+        return EventIssuedEvent.from(
+                new ChatMessage(registration, 1L, 2L, 3L), recordId, EVENT_STREAM_KEY);
     }
 
     private String registrationJson() {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -188,7 +188,6 @@ class EventIssuedEventHandlerTest {
         when(sectorAdaptor.findByIdForUpdate(2L)).thenReturn(sector);
         when(sector.getId()).thenReturn(2L);
         when(sector.getInitSectorCapacity()).thenReturn(1);
-        when(sector.getIssueAmount()).thenReturn(2);
         when(registrationAdaptor.countSavedBySectorId(2L)).thenReturn(0L);
     }
 

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.registration.handler;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -37,21 +38,23 @@ class EmailOutboxWorkerTest {
     @DisplayName("claim에 성공한 outbox 메일 발송이 성공하면 sent_at을 기록한다")
     void sendPendingMarksSentWhenMailSucceeded() {
         givenPendingOutbox();
-        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(true);
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
+                .thenReturn(true);
         when(mailService.sendRegistrationResultMail("student@jnu.ac.kr", "학생", "합격", -2))
                 .thenReturn(true);
 
         emailOutboxWorker.sendPendingRegistrationResultMail();
 
         verify(emailOutboxAdaptor).markSent(1L);
-        verify(emailOutboxAdaptor, never()).releaseAfterFailure(1L);
+        verify(emailOutboxAdaptor, never()).markFailed(1L);
     }
 
     @Test
     @DisplayName("claim에 실패한 outbox는 메일을 보내지 않는다")
     void sendPendingSkipsWhenClaimFailed() {
         givenPendingOutboxWithoutMailPayload();
-        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(false);
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
+                .thenReturn(false);
 
         emailOutboxWorker.sendPendingRegistrationResultMail();
 
@@ -60,16 +63,17 @@ class EmailOutboxWorkerTest {
     }
 
     @Test
-    @DisplayName("메일 발송이 실패하면 outbox claim을 해제하고 재시도 대상으로 남긴다")
-    void sendPendingReleasesClaimWhenMailFailed() {
+    @DisplayName("메일 발송이 실패하면 실패 시각과 재시도 횟수를 기록한다")
+    void sendPendingMarksOutboxFailedWhenMailFailed() {
         givenPendingOutbox();
-        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(true);
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
+                .thenReturn(true);
         when(mailService.sendRegistrationResultMail("student@jnu.ac.kr", "학생", "합격", -2))
                 .thenReturn(false);
 
         emailOutboxWorker.sendPendingRegistrationResultMail();
 
-        verify(emailOutboxAdaptor).releaseAfterFailure(1L);
+        verify(emailOutboxAdaptor).markFailed(1L);
         verify(emailOutboxAdaptor, never()).markSent(1L);
     }
 
@@ -82,7 +86,8 @@ class EmailOutboxWorkerTest {
     }
 
     private void givenPendingOutboxWithoutMailPayload() {
-        when(emailOutboxAdaptor.findPending(eq(20), any(LocalDateTime.class)))
+        when(emailOutboxAdaptor.findPending(
+                        eq(20), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
                 .thenReturn(List.of(outbox));
         when(outbox.getId()).thenReturn(1L);
     }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
@@ -1,0 +1,89 @@
+package com.jnu.ticketapi.api.registration.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import com.jnu.ticketinfrastructure.service.MailService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EmailOutboxWorkerTest {
+
+    @Mock private EmailOutboxAdaptor emailOutboxAdaptor;
+    @Mock private MailService mailService;
+    @Mock private EmailOutbox outbox;
+
+    private EmailOutboxWorker emailOutboxWorker;
+
+    @BeforeEach
+    void setUp() {
+        emailOutboxWorker = new EmailOutboxWorker(emailOutboxAdaptor, mailService);
+    }
+
+    @Test
+    @DisplayName("claim에 성공한 outbox 메일 발송이 성공하면 sent_at을 기록한다")
+    void sendPendingMarksSentWhenMailSucceeded() {
+        givenPendingOutbox();
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(true);
+        when(mailService.sendRegistrationResultMail("student@jnu.ac.kr", "학생", "합격", -2))
+                .thenReturn(true);
+
+        emailOutboxWorker.sendPendingRegistrationResultMail();
+
+        verify(emailOutboxAdaptor).markSent(1L);
+        verify(emailOutboxAdaptor, never()).releaseAfterFailure(1L);
+    }
+
+    @Test
+    @DisplayName("claim에 실패한 outbox는 메일을 보내지 않는다")
+    void sendPendingSkipsWhenClaimFailed() {
+        givenPendingOutboxWithoutMailPayload();
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(false);
+
+        emailOutboxWorker.sendPendingRegistrationResultMail();
+
+        verify(mailService, never()).sendRegistrationResultMail(any(), any(), any(), any());
+        verify(emailOutboxAdaptor, never()).markSent(1L);
+    }
+
+    @Test
+    @DisplayName("메일 발송이 실패하면 outbox claim을 해제하고 재시도 대상으로 남긴다")
+    void sendPendingReleasesClaimWhenMailFailed() {
+        givenPendingOutbox();
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(true);
+        when(mailService.sendRegistrationResultMail("student@jnu.ac.kr", "학생", "합격", -2))
+                .thenReturn(false);
+
+        emailOutboxWorker.sendPendingRegistrationResultMail();
+
+        verify(emailOutboxAdaptor).releaseAfterFailure(1L);
+        verify(emailOutboxAdaptor, never()).markSent(1L);
+    }
+
+    private void givenPendingOutbox() {
+        givenPendingOutboxWithoutMailPayload();
+        when(outbox.getEmail()).thenReturn("student@jnu.ac.kr");
+        when(outbox.getName()).thenReturn("학생");
+        when(outbox.getResultStatus()).thenReturn(UserStatus.SUCCESS);
+        when(outbox.getSequence()).thenReturn(-2);
+    }
+
+    private void givenPendingOutboxWithoutMailPayload() {
+        when(emailOutboxAdaptor.findPending(eq(20), any(LocalDateTime.class)))
+                .thenReturn(List.of(outbox));
+        when(outbox.getId()).thenReturn(1L);
+    }
+}

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -1,17 +1,18 @@
 package com.jnu.ticketbatch.config;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_CONSUMER;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
-import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
-import java.util.Set;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
 @Slf4j
 @DisallowConcurrentExecution
@@ -20,20 +21,27 @@ public class ProcessQueueDataJob implements Job {
 
     @Autowired private WaitingQueueService waitingQueueService;
 
+    private static final long READ_COUNT = 100L;
+
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         try {
             // 현재 쓰레드에 ApplicationEventPublisher를 설정
             Events.setPublisher(publisher);
 
-            Set<TypedTuple<Object>> messagesWithScores =
-                    waitingQueueService.findAllWithScore(REDIS_EVENT_ISSUE_STORE);
+            List<StreamQueueMessage> messages =
+                    waitingQueueService.readGroup(
+                            REDIS_EVENT_ISSUE_STREAM,
+                            REDIS_EVENT_ISSUE_GROUP,
+                            REDIS_EVENT_ISSUE_CONSUMER,
+                            READ_COUNT);
 
-            if (!messagesWithScores.isEmpty()) {
-                for (TypedTuple<Object> messageWithScore : messagesWithScores) {
-                    Double score = messageWithScore.getScore();
-                    ChatMessage message = (ChatMessage) messageWithScore.getValue();
-                    Events.raise(EventIssuedEvent.from(message, score));
+            if (!messages.isEmpty()) {
+                for (StreamQueueMessage streamQueueMessage : messages) {
+                    Events.raise(
+                            EventIssuedEvent.from(
+                                    streamQueueMessage.getMessage(),
+                                    streamQueueMessage.getRecordId()));
                 }
             }
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -2,7 +2,6 @@ package com.jnu.ticketbatch.config;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_CONSUMER;
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
@@ -28,10 +27,12 @@ public class ProcessQueueDataJob implements Job {
         try {
             // 현재 쓰레드에 ApplicationEventPublisher를 설정
             Events.setPublisher(publisher);
+            Long eventId = context.getMergedJobDataMap().getLong("eventId");
+            String streamKey = waitingQueueService.eventStreamKey(eventId);
 
             List<StreamQueueMessage> messages =
                     waitingQueueService.readGroup(
-                            REDIS_EVENT_ISSUE_STREAM,
+                            streamKey,
                             REDIS_EVENT_ISSUE_GROUP,
                             REDIS_EVENT_ISSUE_CONSUMER,
                             READ_COUNT);
@@ -41,7 +42,8 @@ public class ProcessQueueDataJob implements Job {
                     Events.raise(
                             EventIssuedEvent.from(
                                     streamQueueMessage.getMessage(),
-                                    streamQueueMessage.getRecordId()));
+                                    streamQueueMessage.getRecordId(),
+                                    streamKey));
                 }
             }
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketbatch.expired;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketdomain.domains.events.EventExpiredEventRaiseGateway;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
@@ -36,7 +36,7 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
-        redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
+        redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 
         JobParameters jobParameters =

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -1,13 +1,11 @@
 package com.jnu.ticketbatch.expired;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketdomain.domains.events.EventExpiredEventRaiseGateway;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
-import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -27,7 +25,6 @@ public class BatchQuartzJob extends QuartzJobBean {
     @Autowired private JobExplorer jobExplorer;
 
     @Autowired EventAdaptor eventAdaptor;
-    @Autowired RedisRepository redisRepository;
     @Autowired RegistrationAdaptor registrationAdaptor;
     @Autowired EventExpiredEventRaiseGateway eventExpiredEventRaiseGateway;
 
@@ -36,7 +33,6 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
-        redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 
         JobParameters jobParameters =
@@ -45,7 +41,7 @@ public class BatchQuartzJob extends QuartzJobBean {
                         .addLong("eventId", eventId)
                         .toJobParameters();
         log.info("EventThrow in BatchQuartzJob");
-//        eventExpiredEventRaiseGateway.handle(eventId);
+        //        eventExpiredEventRaiseGateway.handle(eventId);
         try {
             this.jobLauncher.run(this.job, jobParameters);
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
@@ -38,6 +38,7 @@ public class EventRegisterJob implements Job {
     private static final String GROUP = "group1";
     private static final String ASIA_SEOUL = "Asia/Seoul";
     private static final long OPEN_LEAD_SECONDS = 5L;
+    private static final long QUEUE_DRAIN_GRACE_MINUTES = 5L;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -123,7 +124,11 @@ public class EventRegisterJob implements Job {
                         .build();
 
         Date start = Date.from(startAt.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
-        Date end = Date.from(endAt.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
+        Date end =
+                Date.from(
+                        endAt.plusMinutes(QUEUE_DRAIN_GRACE_MINUTES)
+                                .atZone(ZoneId.of(ASIA_SEOUL))
+                                .toInstant());
 
         Trigger reserveTrigger =
                 newTrigger()

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
@@ -30,6 +30,9 @@ public class TicketStatic {
 
     public static final String REDIS_EVENT_CHANNEL = "쿠폰 발급 채널";
     public static final String REDIS_EVENT_ISSUE_STORE = "쿠폰 발급 저장소";
+    public static final String REDIS_EVENT_ISSUE_STREAM = "쿠폰 발급 스트림";
+    public static final String REDIS_EVENT_ISSUE_GROUP = "쿠폰 발급 그룹";
+    public static final String REDIS_EVENT_ISSUE_CONSUMER = "쿠폰 발급 소비자";
 
     public static final Integer REGISTRATION_SIZE = 14;
     public static final Integer MAX_EMAIL_SEND_RETRY = 10;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/adaptor/EmailOutboxAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/adaptor/EmailOutboxAdaptor.java
@@ -23,13 +23,15 @@ public class EmailOutboxAdaptor {
         emailOutboxRepository.save(EmailOutbox.from(registration));
     }
 
-    public List<EmailOutbox> findPending(int size, LocalDateTime staleBefore) {
-        return emailOutboxRepository.findPending(staleBefore, PageRequest.of(0, size));
+    public List<EmailOutbox> findPending(int size, LocalDateTime staleBefore, int maxRetryCount) {
+        return emailOutboxRepository.findPending(
+                staleBefore, maxRetryCount, PageRequest.of(0, size));
     }
 
     @Transactional
-    public boolean claim(Long id, LocalDateTime staleBefore) {
-        return emailOutboxRepository.claim(id, LocalDateTime.now(), staleBefore) == 1;
+    public boolean claim(Long id, LocalDateTime staleBefore, int maxRetryCount) {
+        return emailOutboxRepository.claim(id, LocalDateTime.now(), staleBefore, maxRetryCount)
+                == 1;
     }
 
     @Transactional
@@ -38,7 +40,7 @@ public class EmailOutboxAdaptor {
     }
 
     @Transactional
-    public void releaseAfterFailure(Long id) {
-        emailOutboxRepository.releaseAfterFailure(id);
+    public void markFailed(Long id) {
+        emailOutboxRepository.markFailed(id, LocalDateTime.now());
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/adaptor/EmailOutboxAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/adaptor/EmailOutboxAdaptor.java
@@ -1,0 +1,44 @@
+package com.jnu.ticketdomain.domains.email.adaptor;
+
+
+import com.jnu.ticketcommon.annotation.Adaptor;
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.email.repository.EmailOutboxRepository;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Adaptor
+@RequiredArgsConstructor
+public class EmailOutboxAdaptor {
+    private final EmailOutboxRepository emailOutboxRepository;
+
+    public void saveRegistrationResultIfAbsent(Registration registration) {
+        if (emailOutboxRepository.existsByRegistrationId(registration.getId())) {
+            return;
+        }
+        emailOutboxRepository.save(EmailOutbox.from(registration));
+    }
+
+    public List<EmailOutbox> findPending(int size, LocalDateTime staleBefore) {
+        return emailOutboxRepository.findPending(staleBefore, PageRequest.of(0, size));
+    }
+
+    @Transactional
+    public boolean claim(Long id, LocalDateTime staleBefore) {
+        return emailOutboxRepository.claim(id, LocalDateTime.now(), staleBefore) == 1;
+    }
+
+    @Transactional
+    public void markSent(Long id) {
+        emailOutboxRepository.markSent(id, LocalDateTime.now());
+    }
+
+    @Transactional
+    public void releaseAfterFailure(Long id) {
+        emailOutboxRepository.releaseAfterFailure(id);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/domain/EmailOutbox.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/domain/EmailOutbox.java
@@ -3,8 +3,10 @@ package com.jnu.ticketdomain.domains.email.domain;
 
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import com.jnu.ticketdomain.domains.user.domain.UserStatusConverter;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
@@ -47,6 +49,7 @@ public class EmailOutbox {
     private String name;
 
     @Column(name = "result_status", nullable = false)
+    @Convert(converter = UserStatusConverter.class)
     private UserStatus resultStatus;
 
     @Column(name = "sequence", nullable = false)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/domain/EmailOutbox.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/domain/EmailOutbox.java
@@ -1,0 +1,100 @@
+package com.jnu.ticketdomain.domains.email.domain;
+
+
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "email_outbox",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_email_outbox_registration_id",
+                    columnNames = "registration_id")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class EmailOutbox {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+    @Column(name = "registration_id", nullable = false)
+    private Long registrationId;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "result_status", nullable = false)
+    private UserStatus resultStatus;
+
+    @Column(name = "sequence", nullable = false)
+    private Integer sequence;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "processing_at")
+    private LocalDateTime processingAt;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Column(name = "retry_count", nullable = false)
+    private Integer retryCount = 0;
+
+    private EmailOutbox(
+            Long eventId,
+            Long registrationId,
+            String email,
+            String name,
+            UserStatus resultStatus,
+            Integer sequence) {
+        this.eventId = eventId;
+        this.registrationId = registrationId;
+        this.email = email;
+        this.name = name;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
+    }
+
+    public static EmailOutbox from(Registration registration) {
+        UserStatus resultStatus =
+                registration.getResultStatus() != null
+                        ? registration.getResultStatus()
+                        : registration.getUser().getStatus();
+        Integer sequence =
+                registration.getSequence() != null
+                        ? registration.getSequence()
+                        : registration.getUser().getSequence();
+        return new EmailOutbox(
+                registration.getEventId(),
+                registration.getId(),
+                registration.getEmail(),
+                registration.getName(),
+                resultStatus,
+                sequence);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/repository/EmailOutboxRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/repository/EmailOutboxRepository.java
@@ -1,0 +1,44 @@
+package com.jnu.ticketdomain.domains.email.repository;
+
+
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EmailOutboxRepository extends JpaRepository<EmailOutbox, Long> {
+    boolean existsByRegistrationId(Long registrationId);
+
+    @Query(
+            "select e from EmailOutbox e "
+                    + "where e.sentAt is null "
+                    + "and (e.processingAt is null or e.processingAt < :staleBefore) "
+                    + "order by e.id asc")
+    List<EmailOutbox> findPending(
+            @Param("staleBefore") LocalDateTime staleBefore, Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "update EmailOutbox e set e.processingAt = :now "
+                    + "where e.id = :id "
+                    + "and e.sentAt is null "
+                    + "and (e.processingAt is null or e.processingAt < :staleBefore)")
+    int claim(
+            @Param("id") Long id,
+            @Param("now") LocalDateTime now,
+            @Param("staleBefore") LocalDateTime staleBefore);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update EmailOutbox e set e.sentAt = :sentAt, e.processingAt = null where e.id = :id")
+    int markSent(@Param("id") Long id, @Param("sentAt") LocalDateTime sentAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "update EmailOutbox e set e.processingAt = null, e.retryCount = e.retryCount + 1 "
+                    + "where e.id = :id")
+    int releaseAfterFailure(@Param("id") Long id);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/repository/EmailOutboxRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/repository/EmailOutboxRepository.java
@@ -16,21 +16,26 @@ public interface EmailOutboxRepository extends JpaRepository<EmailOutbox, Long> 
     @Query(
             "select e from EmailOutbox e "
                     + "where e.sentAt is null "
+                    + "and e.retryCount < :maxRetryCount "
                     + "and (e.processingAt is null or e.processingAt < :staleBefore) "
                     + "order by e.id asc")
     List<EmailOutbox> findPending(
-            @Param("staleBefore") LocalDateTime staleBefore, Pageable pageable);
+            @Param("staleBefore") LocalDateTime staleBefore,
+            @Param("maxRetryCount") int maxRetryCount,
+            Pageable pageable);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
             "update EmailOutbox e set e.processingAt = :now "
                     + "where e.id = :id "
                     + "and e.sentAt is null "
+                    + "and e.retryCount < :maxRetryCount "
                     + "and (e.processingAt is null or e.processingAt < :staleBefore)")
     int claim(
             @Param("id") Long id,
             @Param("now") LocalDateTime now,
-            @Param("staleBefore") LocalDateTime staleBefore);
+            @Param("staleBefore") LocalDateTime staleBefore,
+            @Param("maxRetryCount") int maxRetryCount);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update EmailOutbox e set e.sentAt = :sentAt, e.processingAt = null where e.id = :id")
@@ -38,7 +43,8 @@ public interface EmailOutboxRepository extends JpaRepository<EmailOutbox, Long> 
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
-            "update EmailOutbox e set e.processingAt = null, e.retryCount = e.retryCount + 1 "
-                    + "where e.id = :id")
-    int releaseAfterFailure(@Param("id") Long id);
+            "update EmailOutbox e "
+                    + "set e.processingAt = :failedAt, e.retryCount = e.retryCount + 1 "
+                    + "where e.id = :id and e.sentAt is null")
+    int markFailed(@Param("id") Long id, @Param("failedAt") LocalDateTime failedAt);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -27,6 +27,13 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
     }
 
     @Override
+    public Sector findByIdForUpdate(Long sectorId) {
+        return sectorRepository
+                .findByIdForUpdate(sectorId)
+                .orElseThrow(() -> NotFoundSectorException.EXCEPTION);
+    }
+
+    @Override
     public List<Sector> findAll() {
         return sectorRepository.findAll();
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface SectorLoadPort {
     Sector findById(Long sectorId);
 
+    Sector findByIdForUpdate(Long sectorId);
+
     List<Sector> findAll();
 
     List<Sector> findByEventId(Long eventId);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -4,7 +4,9 @@ package com.jnu.ticketdomain.domains.events.repository;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,6 +18,10 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
 
     @Query("select s from Sector s where s.event.id = :eventId")
     List<Sector> findByEventId(@Param("eventId") Long eventId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Sector s where s.id = :sectorId")
+    Optional<Sector> findByIdForUpdate(@Param("sectorId") Long sectorId);
 
     @Query(
             "select s from Sector s join fetch s.event where s.event.eventStatus = 'OPEN' or s.event.eventStatus = 'READY'")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -121,6 +121,11 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     }
 
     @Override
+    public Long countSavedBySectorId(Long sectorId) {
+        return registrationRepository.countSavedBySectorId(sectorId);
+    }
+
+    @Override
     public List<Registration> findSortedRegistrationsByEventId(Long eventId) {
         return registrationRepository.findSortedRegistrationsByEventId(eventId);
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import java.time.LocalDateTime;
 import javax.persistence.*;
 import lombok.*;
@@ -76,6 +77,15 @@ public class Registration {
     @Column(name = "saved_at")
     private Long savedAt;
 
+    @Column(name = "position")
+    private Integer position;
+
+    @Column(name = "result_status")
+    private UserStatus resultStatus;
+
+    @Column(name = "sequence")
+    private Integer sequence;
+
     @JsonBackReference(value = "user-registration")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -102,6 +112,9 @@ public class Registration {
             LocalDateTime createdAt,
             boolean isSaved,
             Long savedAt,
+            Integer position,
+            UserStatus resultStatus,
+            Integer sequence,
             User user,
             Sector sector,
             Long eventId) {
@@ -116,6 +129,9 @@ public class Registration {
         this.createdAt = createdAt;
         this.isSaved = isSaved;
         this.savedAt = savedAt;
+        this.position = position;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
         this.user = user;
         this.sector = sector;
         this.eventId = eventId;
@@ -135,6 +151,9 @@ public class Registration {
             @JsonProperty("isSaved") boolean isSaved,
             @JsonProperty("isDeleted") boolean isDeleted,
             @JsonProperty("savedAt") Long savedAt,
+            @JsonProperty("position") Integer position,
+            @JsonProperty("resultStatus") UserStatus resultStatus,
+            @JsonProperty("sequence") Integer sequence,
             @JsonProperty("user") User user,
             @JsonProperty("sector") Sector sector,
             @JsonProperty("id") Long id,
@@ -151,6 +170,9 @@ public class Registration {
         this.isSaved = isSaved;
         this.isDeleted = isDeleted;
         this.savedAt = savedAt;
+        this.position = position;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
         this.user = user;
         this.sector = sector;
         this.id = id;
@@ -162,6 +184,13 @@ public class Registration {
     public void finalSave() {
         this.isSaved = true;
 //        this.savedAt = System.nanoTime();
+    }
+
+    public void finalSave(Integer position, UserStatus resultStatus, Integer sequence) {
+        this.position = position;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
+        finalSave();
     }
 
     public void updateIsDeleted(boolean isDeleted) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import com.jnu.ticketdomain.domains.user.domain.UserStatusConverter;
 import java.time.LocalDateTime;
 import javax.persistence.*;
 import lombok.*;
@@ -81,6 +82,7 @@ public class Registration {
     private Integer position;
 
     @Column(name = "result_status")
+    @Convert(converter = UserStatusConverter.class)
     private UserStatus resultStatus;
 
     @Column(name = "sequence")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
@@ -30,5 +30,7 @@ public interface RegistrationLoadPort {
 
     Boolean existsByIdAndIsSavedTrue(Long id);
 
+    Long countSavedBySectorId(Long sectorId);
+
     List<Registration> findSortedRegistrationsByEventId(Long eventId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -91,4 +91,7 @@ public interface RegistrationRepository
     Integer findPositionBySavedAt(@Param("id") Long id, @Param("sectorId") Long sectorId);
 
     Boolean existsByIdAndIsSavedTrue(Long id);
+
+    @Query("select count(r) from Registration r where r.isSaved = true and r.sector.id = :sectorId")
+    Long countSavedBySectorId(@Param("sectorId") Long sectorId);
 }

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -87,7 +87,7 @@ spring:
     activate:
       on-profile: test
   datasource:
-    url: jdbc:h2:~/test;DB_CLOSE_DELAY=-1;MODE=MySQL;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
   jpa:
@@ -101,6 +101,8 @@ spring:
   quartz:
     jdbc:
       initialize-schema: always
+      platform: h2
+
 ---
 
 spring:

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -103,6 +103,10 @@ spring:
       initialize-schema: always
       platform: h2
 
+mail:
+  outbox:
+    enabled: false
+
 ---
 
 spring:
@@ -227,3 +231,7 @@ thread:
   core-pool-size: 10
   max-pool-size: 20
   queue-capacity: 100
+
+mail:
+  outbox:
+    enabled: false

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/AnnounceImage/config/TestDataSourceConfig.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/AnnounceImage/config/TestDataSourceConfig.java
@@ -15,10 +15,9 @@ public class TestDataSourceConfig {
     @Bean
     public DataSource dataSource() {
         DriverManagerDataSource dataSource = new DriverManagerDataSource();
-        dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver");
-        dataSource.setUrl("jdbc:mysql://localhost:3306/ticket");
-        dataSource.setUsername("root");
-        dataSource.setPassword("1234");
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:announce-image-test;MODE=MySQL;DB_CLOSE_DELAY=-1");
+        dataSource.setUsername("sa");
         return dataSource;
     }
 

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxAdaptorTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxAdaptorTest.java
@@ -1,0 +1,71 @@
+package com.jnu.ticketdomain.domains.email;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.email.repository.EmailOutboxRepository;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EmailOutboxAdaptorTest {
+
+    @Mock private EmailOutboxRepository emailOutboxRepository;
+
+    private EmailOutboxAdaptor emailOutboxAdaptor;
+
+    @BeforeEach
+    void setUp() {
+        emailOutboxAdaptor = new EmailOutboxAdaptor(emailOutboxRepository);
+    }
+
+    @Test
+    @DisplayName("이미 outbox가 있는 registration은 중복 저장하지 않는다")
+    void saveRegistrationResultIfAbsentSkipsDuplicateRegistration() {
+        Registration registration = registration();
+        when(emailOutboxRepository.existsByRegistrationId(10L)).thenReturn(true);
+
+        emailOutboxAdaptor.saveRegistrationResultIfAbsent(registration);
+
+        verify(emailOutboxRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("outbox가 없는 registration은 결과 메일 outbox를 저장한다")
+    void saveRegistrationResultIfAbsentSavesNewOutbox() {
+        Registration registration = registration();
+        when(emailOutboxRepository.existsByRegistrationId(10L)).thenReturn(false);
+
+        emailOutboxAdaptor.saveRegistrationResultIfAbsent(registration);
+
+        verify(emailOutboxRepository).save(org.mockito.ArgumentMatchers.any(EmailOutbox.class));
+    }
+
+    private Registration registration() {
+        Registration registration =
+                Registration.builder()
+                        .email("student@jnu.ac.kr")
+                        .name("학생")
+                        .studentNum("20240001")
+                        .carNum("12가3456")
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                        .isSaved(false)
+                        .eventId(10L)
+                        .build();
+        registration.setId(10L);
+        registration.finalSave(1, UserStatus.SUCCESS, -2);
+        return registration;
+    }
+}

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxRepositoryTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxRepositoryTest.java
@@ -1,0 +1,70 @@
+package com.jnu.ticketdomain.domains.email;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.email.repository.EmailOutboxRepository;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+class EmailOutboxRepositoryTest {
+
+    @Autowired private EmailOutboxRepository emailOutboxRepository;
+    @Autowired private EntityManager entityManager;
+
+    @Test
+    @DisplayName("재시도 대기 중이거나 최대 재시도에 도달한 outbox는 pending 조회와 claim에서 제외한다")
+    void findPendingExcludesCoolingDownAndExhaustedOutboxes() {
+        LocalDateTime now = LocalDateTime.of(2026, 7, 28, 12, 0);
+        LocalDateTime staleBefore = now.minusMinutes(10);
+        EmailOutbox ready = emailOutboxRepository.saveAndFlush(outbox(1L));
+        EmailOutbox coolingDown = emailOutboxRepository.saveAndFlush(outbox(2L));
+        EmailOutbox exhausted = emailOutboxRepository.saveAndFlush(outbox(3L));
+
+        emailOutboxRepository.markFailed(coolingDown.getId(), now.minusMinutes(1));
+        for (int retry = 0; retry < MAX_EMAIL_SEND_RETRY; retry++) {
+            emailOutboxRepository.markFailed(exhausted.getId(), now.minusMinutes(20));
+        }
+        entityManager.clear();
+
+        List<EmailOutbox> pending =
+                emailOutboxRepository.findPending(
+                        staleBefore, MAX_EMAIL_SEND_RETRY, PageRequest.of(0, 20));
+
+        assertThat(pending)
+                .extracting(EmailOutbox::getRegistrationId)
+                .containsExactly(ready.getRegistrationId());
+        assertThat(
+                        emailOutboxRepository.claim(
+                                exhausted.getId(), now, staleBefore, MAX_EMAIL_SEND_RETRY))
+                .isZero();
+    }
+
+    private EmailOutbox outbox(Long registrationId) {
+        Registration registration =
+                Registration.builder()
+                        .email("student" + registrationId + "@jnu.ac.kr")
+                        .name("학생" + registrationId)
+                        .studentNum("2024" + registrationId)
+                        .carNum("12가" + registrationId)
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 7, 28, 10, 0))
+                        .isSaved(true)
+                        .eventId(10L)
+                        .build();
+        registration.setId(registrationId);
+        registration.finalSave(1, UserStatus.SUCCESS, -2);
+        return EmailOutbox.from(registration);
+    }
+}

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxTest.java
@@ -1,0 +1,67 @@
+package com.jnu.ticketdomain.domains.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserRole;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EmailOutboxTest {
+
+    @Test
+    @DisplayName("Registration에 확정된 결과가 있으면 해당 결과로 outbox를 생성한다")
+    void fromUsesRegistrationDecision() {
+        Registration registration = registration();
+        registration.finalSave(3, UserStatus.PREPARE, 1);
+
+        EmailOutbox outbox = EmailOutbox.from(registration);
+
+        assertThat(outbox.getEventId()).isEqualTo(10L);
+        assertThat(outbox.getRegistrationId()).isEqualTo(10L);
+        assertThat(outbox.getEmail()).isEqualTo("student@jnu.ac.kr");
+        assertThat(outbox.getName()).isEqualTo("학생");
+        assertThat(outbox.getResultStatus()).isEqualTo(UserStatus.PREPARE);
+        assertThat(outbox.getSequence()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Registration 결과가 비어 있으면 기존 User 결과로 outbox를 생성한다")
+    void fromFallsBackToUserDecision() {
+        User user =
+                User.builder()
+                        .email("student@jnu.ac.kr")
+                        .pwd("encoded-password")
+                        .userRole(UserRole.USER)
+                        .build();
+        user.success();
+        Registration registration = registration();
+        registration.setUser(user);
+
+        EmailOutbox outbox = EmailOutbox.from(registration);
+
+        assertThat(outbox.getResultStatus()).isEqualTo(UserStatus.SUCCESS);
+        assertThat(outbox.getSequence()).isEqualTo(-2);
+    }
+
+    private Registration registration() {
+        Registration registration =
+                Registration.builder()
+                        .email("student@jnu.ac.kr")
+                        .name("학생")
+                        .studentNum("20240001")
+                        .carNum("12가3456")
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                        .isSaved(false)
+                        .eventId(10L)
+                        .build();
+        registration.setId(10L);
+        return registration;
+    }
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
@@ -64,7 +64,7 @@ public class RedisConfig {
                 new Jackson2JsonRedisSerializer<>(ChatMessage.class);
         redisTemplate.setValueSerializer(serializer);
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(serializer);
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
@@ -10,16 +10,26 @@ import lombok.Getter;
 public class EventIssuedEvent extends InfrastructureEvent {
     private ChatMessage message;
     private final Double score;
+    private final String streamRecordId;
 
     public static EventIssuedEvent from(ChatMessage message, Double score) {
         return EventIssuedEvent.builder().message(message).score(score).build();
     }
 
+    public static EventIssuedEvent from(ChatMessage message, String streamRecordId) {
+        return EventIssuedEvent.builder().message(message).streamRecordId(streamRecordId).build();
+    }
+
     @Override
     public String toString() {
-        return "EventIssuedEvent{" +
-                "message=" + message +
-                ", score=" + score +
-                '}';
+        return "EventIssuedEvent{"
+                + "message="
+                + message
+                + ", score="
+                + score
+                + ", streamRecordId='"
+                + streamRecordId
+                + '\''
+                + '}';
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
@@ -11,6 +11,7 @@ public class EventIssuedEvent extends InfrastructureEvent {
     private ChatMessage message;
     private final Double score;
     private final String streamRecordId;
+    private final String streamKey;
 
     public static EventIssuedEvent from(ChatMessage message, Double score) {
         return EventIssuedEvent.builder().message(message).score(score).build();
@@ -18,6 +19,15 @@ public class EventIssuedEvent extends InfrastructureEvent {
 
     public static EventIssuedEvent from(ChatMessage message, String streamRecordId) {
         return EventIssuedEvent.builder().message(message).streamRecordId(streamRecordId).build();
+    }
+
+    public static EventIssuedEvent from(
+            ChatMessage message, String streamRecordId, String streamKey) {
+        return EventIssuedEvent.builder()
+                .message(message)
+                .streamRecordId(streamRecordId)
+                .streamKey(streamKey)
+                .build();
     }
 
     @Override
@@ -29,6 +39,9 @@ public class EventIssuedEvent extends InfrastructureEvent {
                 + score
                 + ", streamRecordId='"
                 + streamRecordId
+                + '\''
+                + ", streamKey='"
+                + streamKey
                 + '\''
                 + '}';
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
@@ -18,11 +18,16 @@ public class ChatMessage {
 
     @Override
     public String toString() {
-        return "ChatMessage{" +
-                "registration='" + registration + '\'' +
-                ", userId=" + userId +
-                ", sectorId=" + sectorId +
-                ", eventId=" + eventId +
-                '}';
+        return "ChatMessage{"
+                + "registration='"
+                + registration
+                + '\''
+                + ", userId="
+                + userId
+                + ", sectorId="
+                + sectorId
+                + ", eventId="
+                + eventId
+                + '}';
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StreamQueueMessage.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StreamQueueMessage.java
@@ -1,0 +1,12 @@
+package com.jnu.ticketinfrastructure.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StreamQueueMessage {
+    private final String recordId;
+    private final ChatMessage message;
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,12 +3,23 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -18,6 +29,7 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 @ConditionalOnExpression("${ableRedis:true}")
 public class RedisRepository {
+    private static final String STREAM_PAYLOAD_KEY = "payload";
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
 
@@ -107,6 +119,53 @@ public class RedisRepository {
         return redisTemplate.opsForZSet().score(key, value);
     }
 
+    public RecordId xAdd(String key, ChatMessage message) {
+        try {
+            Map<String, String> body =
+                    Map.of(STREAM_PAYLOAD_KEY, objectMapper.writeValueAsString(message));
+            return redisTemplate.opsForStream().add(key, body);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to add message to Redis Stream", e);
+        }
+    }
+
+    public void createConsumerGroupIfAbsent(String key, String group) {
+        try {
+            redisTemplate.execute(
+                    (RedisCallback<String>)
+                            connection ->
+                                    connection.xGroupCreate(
+                                            key.getBytes(StandardCharsets.UTF_8),
+                                            group,
+                                            ReadOffset.from("0-0"),
+                                            true));
+        } catch (DataAccessException e) {
+            if (!isAlreadyCreatedGroup(e)) {
+                throw e;
+            }
+        }
+    }
+
+    public List<StreamQueueMessage> xReadGroup(
+            String key, String group, String consumer, long count) {
+        createConsumerGroupIfAbsent(key, group);
+        List<MapRecord<String, Object, Object>> records =
+                redisTemplate
+                        .opsForStream()
+                        .read(
+                                Consumer.from(group, consumer),
+                                StreamReadOptions.empty().count(count),
+                                StreamOffset.create(key, ReadOffset.lastConsumed()));
+        if (records == null || records.isEmpty()) {
+            return List.of();
+        }
+        return records.stream().map(this::toStreamQueueMessage).toList();
+    }
+
+    public Long xAck(String key, String group, String recordId) {
+        return redisTemplate.opsForStream().acknowledge(key, group, recordId);
+    }
+
     public Long remove(String key, Object value) {
         return redisTemplate.opsForZSet().remove(key, value);
     }
@@ -127,5 +186,21 @@ public class RedisRepository {
             // Set is empty, return null or handle accordingly
             return null;
         }
+    }
+
+    private StreamQueueMessage toStreamQueueMessage(MapRecord<String, Object, Object> record) {
+        Object payload = record.getValue().get(STREAM_PAYLOAD_KEY);
+        try {
+            return new StreamQueueMessage(
+                    record.getId().getValue(),
+                    objectMapper.readValue(String.valueOf(payload), ChatMessage.class));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse Redis Stream message", e);
+        }
+    }
+
+    private boolean isAlreadyCreatedGroup(Exception e) {
+        String message = e.getMessage();
+        return message != null && message.contains("BUSYGROUP");
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -5,17 +5,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
@@ -162,6 +168,44 @@ public class RedisRepository {
         return records.stream().map(this::toStreamQueueMessage).toList();
     }
 
+    public List<StreamQueueMessage> xClaimStale(
+            String key, String group, String consumer, long count, Duration minIdleTime) {
+        createConsumerGroupIfAbsent(key, group);
+        PendingMessages pendingMessages =
+                redisTemplate.opsForStream().pending(key, group, Range.unbounded(), count);
+        if (pendingMessages == null || pendingMessages.isEmpty()) {
+            return List.of();
+        }
+
+        RecordId[] staleRecordIds =
+                StreamSupport.stream(pendingMessages.spliterator(), false)
+                        .filter(pendingMessage -> isStale(pendingMessage, minIdleTime))
+                        .map(PendingMessage::getId)
+                        .toArray(RecordId[]::new);
+        if (staleRecordIds.length == 0) {
+            return List.of();
+        }
+
+        List<ByteRecord> claimedRecords =
+                redisTemplate.execute(
+                        (RedisCallback<List<ByteRecord>>)
+                                connection ->
+                                        connection.xClaim(
+                                                key.getBytes(StandardCharsets.UTF_8),
+                                                group,
+                                                consumer,
+                                                minIdleTime,
+                                                staleRecordIds));
+        if (claimedRecords == null || claimedRecords.isEmpty()) {
+            return List.of();
+        }
+
+        return claimedRecords.stream()
+                .map(redisTemplate.opsForStream()::deserializeRecord)
+                .map(this::toStreamQueueMessage)
+                .toList();
+    }
+
     public Long xAck(String key, String group, String recordId) {
         return redisTemplate.opsForStream().acknowledge(key, group, recordId);
     }
@@ -206,5 +250,9 @@ public class RedisRepository {
     private boolean isAlreadyCreatedGroup(Exception e) {
         String message = e.getMessage();
         return message != null && message.contains("BUSYGROUP");
+    }
+
+    private boolean isStale(PendingMessage pendingMessage, Duration minIdleTime) {
+        return pendingMessage.getElapsedTimeSinceLastDelivery().compareTo(minIdleTime) >= 0;
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -166,6 +166,10 @@ public class RedisRepository {
         return redisTemplate.opsForStream().acknowledge(key, group, recordId);
     }
 
+    public Long xDelete(String key, String recordId) {
+        return redisTemplate.opsForStream().delete(key, recordId);
+    }
+
     public Long remove(String key, Object value) {
         return redisTemplate.opsForZSet().remove(key, value);
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketinfrastructure.service;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -144,5 +145,13 @@ public class WaitingQueueService {
             redisRepository.xDelete(key, recordId);
         }
         return acknowledged;
+    }
+
+    public String eventStreamKey(Long eventId) {
+        return REDIS_EVENT_ISSUE_STREAM + ":{" + eventId + "}";
+    }
+
+    public void deleteEventStream(Long eventId) {
+        redisRepository.delete(eventStreamKey(eventId));
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -9,6 +9,8 @@ import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrat
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Service;
 public class WaitingQueueService {
 
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
+    private static final Duration STREAM_PENDING_MIN_IDLE_TIME = Duration.ofSeconds(30);
 
     private final RedisRepository redisRepository;
     @Autowired private ObjectMapper objectMapper;
@@ -119,7 +122,16 @@ public class WaitingQueueService {
 
     public List<StreamQueueMessage> readGroup(
             String key, String group, String consumer, long count) {
-        return redisRepository.xReadGroup(key, group, consumer, count);
+        List<StreamQueueMessage> recovered =
+                redisRepository.xClaimStale(
+                        key, group, consumer, count, STREAM_PENDING_MIN_IDLE_TIME);
+        if (recovered.size() >= count) {
+            return recovered;
+        }
+
+        List<StreamQueueMessage> messages = new ArrayList<>(recovered);
+        messages.addAll(redisRepository.xReadGroup(key, group, consumer, count - recovered.size()));
+        return messages;
     }
 
     public Long acknowledge(String key, String group, String recordId) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -125,4 +125,12 @@ public class WaitingQueueService {
     public Long acknowledge(String key, String group, String recordId) {
         return redisRepository.xAck(key, group, recordId);
     }
+
+    public Long acknowledgeAndDelete(String key, String group, String recordId) {
+        Long acknowledged = redisRepository.xAck(key, group, recordId);
+        if (acknowledged != null && acknowledged > 0) {
+            redisRepository.xDelete(key, recordId);
+        }
+        return acknowledged;
+    }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -7,8 +7,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -40,9 +42,8 @@ public class WaitingQueueService {
         Double score = (double) System.currentTimeMillis();
         String registrationString = convertRegistrationJSON(registration);
         ChatMessage message = new ChatMessage(registrationString, userId, sectorId, eventId);
-        checkDuplicateData(key, message);
-        redisRepository.zAddIfAbsent(key, message, score);
-        tracker.info("Added to the queue, score:{}", score);
+        redisRepository.xAdd(key, message);
+        tracker.info("Added to the stream, score:{}", score);
     }
 
     public String convertRegistrationJSON(Registration registration) {
@@ -114,5 +115,14 @@ public class WaitingQueueService {
 
     public Set<ZSetOperations.TypedTuple<Object>> findAllWithScore(String key) {
         return redisRepository.zRangeWithScores(key, 0L, -1L);
+    }
+
+    public List<StreamQueueMessage> readGroup(
+            String key, String group, String consumer, long count) {
+        return redisRepository.xReadGroup(key, group, consumer, count);
+    }
+
+    public Long acknowledge(String key, String group, String recordId) {
+        return redisRepository.xAck(key, group, recordId);
     }
 }

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -121,4 +121,15 @@ class RedisRepositoryStreamTest {
 
         assertThat(acknowledged).isEqualTo(1L);
     }
+
+    @Test
+    @DisplayName("xDelete는 처리 완료된 Stream record 삭제를 Redis에 위임한다")
+    void xDeleteDelegatesToStreamOperations() {
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.delete(STREAM_KEY, "1-0")).thenReturn(1L);
+
+        Long deleted = redisRepository.xDelete(STREAM_KEY, "1-0");
+
+        assertThat(deleted).isEqualTo(1L);
+    }
 }

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,8 +21,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
@@ -38,6 +42,7 @@ class RedisRepositoryStreamTest {
 
     @Mock private RedisTemplate<String, Object> redisTemplate;
     @Mock private StreamOperations<String, Object, Object> streamOperations;
+    @Mock private ByteRecord byteRecord;
 
     private RedisRepository redisRepository;
     private ObjectMapper objectMapper;
@@ -109,6 +114,44 @@ class RedisRepositoryStreamTest {
 
         assertThatCode(() -> redisRepository.createConsumerGroupIfAbsent(STREAM_KEY, GROUP))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("xClaimStale은 idle 기준을 넘긴 pending record를 현재 consumer로 가져온다")
+    void xClaimStaleClaimsRecoverablePendingRecord() throws Exception {
+        ChatMessage message = new ChatMessage("{\"id\":10}", 1L, 2L, 3L);
+        MapRecord<String, Object, Object> record =
+                MapRecord.create(
+                                STREAM_KEY,
+                                Map.<Object, Object>of(
+                                        "payload", objectMapper.writeValueAsString(message)))
+                        .withId(RecordId.of("1-0"));
+        PendingMessage pendingMessage =
+                new PendingMessage(
+                        RecordId.of("1-0"),
+                        Consumer.from(GROUP, "stopped-consumer"),
+                        Duration.ofMinutes(1),
+                        2L);
+        PendingMessages pendingMessages = new PendingMessages(GROUP, List.of(pendingMessage));
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenReturn("OK")
+                .thenReturn(List.of(byteRecord));
+        when(streamOperations.pending(
+                        eq(STREAM_KEY),
+                        eq(GROUP),
+                        any(org.springframework.data.domain.Range.class),
+                        eq(10L)))
+                .thenReturn(pendingMessages);
+        when(streamOperations.deserializeRecord(byteRecord)).thenReturn(record);
+
+        List<StreamQueueMessage> result =
+                redisRepository.xClaimStale(
+                        STREAM_KEY, GROUP, CONSUMER, 10L, Duration.ofSeconds(30));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRecordId()).isEqualTo("1-0");
+        assertThat(result.get(0).getMessage().getUserId()).isEqualTo(1L);
     }
 
     @Test

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -1,0 +1,124 @@
+package com.jnu.ticketinfrastructure.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisRepositoryStreamTest {
+
+    private static final String STREAM_KEY = "event-issue-stream";
+    private static final String GROUP = "event-issue-group";
+    private static final String CONSUMER = "event-issue-consumer";
+
+    @Mock private RedisTemplate<String, Object> redisTemplate;
+    @Mock private StreamOperations<String, Object, Object> streamOperations;
+
+    private RedisRepository redisRepository;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        redisRepository = new RedisRepository(redisTemplate);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @DisplayName("xAdd는 ChatMessage를 payload JSON으로 직렬화해서 Stream에 추가한다")
+    void xAddSerializesChatMessageAsPayload() throws Exception {
+        ChatMessage message = new ChatMessage("{\"id\":10}", 1L, 2L, 3L);
+        RecordId recordId = RecordId.of("1-0");
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.add(eq(STREAM_KEY), any(Map.class))).thenReturn(recordId);
+
+        RecordId result = redisRepository.xAdd(STREAM_KEY, message);
+
+        assertThat(result).isEqualTo(recordId);
+        ArgumentCaptor<Map<String, String>> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(streamOperations).add(eq(STREAM_KEY), bodyCaptor.capture());
+
+        String payload = bodyCaptor.getValue().get("payload");
+        ChatMessage parsed = objectMapper.readValue(payload, ChatMessage.class);
+        assertThat(parsed.getRegistration()).isEqualTo("{\"id\":10}");
+        assertThat(parsed.getUserId()).isEqualTo(1L);
+        assertThat(parsed.getSectorId()).isEqualTo(2L);
+        assertThat(parsed.getEventId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("xReadGroup은 Stream record id와 payload를 StreamQueueMessage로 복원한다")
+    void xReadGroupParsesRecordIdAndPayload() throws Exception {
+        ChatMessage message = new ChatMessage("{\"id\":10}", 1L, 2L, 3L);
+        MapRecord<String, Object, Object> record =
+                MapRecord.create(
+                                STREAM_KEY,
+                                Map.<Object, Object>of(
+                                        "payload", objectMapper.writeValueAsString(message)))
+                        .withId(RecordId.of("1690000000000-0"));
+        when(redisTemplate.execute(any(RedisCallback.class))).thenReturn("OK");
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.read(
+                        any(Consumer.class), any(StreamReadOptions.class), any(StreamOffset.class)))
+                .thenReturn(List.of(record));
+
+        List<StreamQueueMessage> result =
+                redisRepository.xReadGroup(STREAM_KEY, GROUP, CONSUMER, 100);
+
+        assertThat(result).hasSize(1);
+        StreamQueueMessage streamQueueMessage = result.get(0);
+        assertThat(streamQueueMessage.getRecordId()).isEqualTo("1690000000000-0");
+        assertThat(streamQueueMessage.getMessage().getRegistration()).isEqualTo("{\"id\":10}");
+        assertThat(streamQueueMessage.getMessage().getUserId()).isEqualTo(1L);
+        assertThat(streamQueueMessage.getMessage().getSectorId()).isEqualTo(2L);
+        assertThat(streamQueueMessage.getMessage().getEventId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("consumer group이 이미 있으면 BUSYGROUP 예외를 성공으로 처리한다")
+    void createConsumerGroupIgnoresBusyGroup() {
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenThrow(
+                        new RedisSystemException(
+                                "BUSYGROUP Consumer Group name already exists",
+                                new RuntimeException()));
+
+        assertThatCode(() -> redisRepository.createConsumerGroupIfAbsent(STREAM_KEY, GROUP))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("xAck는 Stream record ACK를 Redis에 위임한다")
+    void xAckDelegatesToStreamOperations() {
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.acknowledge(STREAM_KEY, GROUP, "1-0")).thenReturn(1L);
+
+        Long acknowledged = redisRepository.xAck(STREAM_KEY, GROUP, "1-0");
+
+        assertThat(acknowledged).isEqualTo(1L);
+    }
+}

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -1,0 +1,108 @@
+package com.jnu.ticketinfrastructure.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WaitingQueueServiceTest {
+
+    private static final String STREAM_KEY = "event-issue-stream";
+
+    @Mock private RedisRepository redisRepository;
+
+    private WaitingQueueService waitingQueueService;
+
+    @BeforeEach
+    void setUp() {
+        waitingQueueService = new WaitingQueueService(redisRepository);
+    }
+
+    @Test
+    @DisplayName("신청 대기열 등록은 Redis Stream에 ChatMessage payload로 저장한다")
+    void registerQueueAddsMessageToRedisStream() throws Exception {
+        Registration registration = registration();
+
+        waitingQueueService.registerQueue(STREAM_KEY, registration, 1L, 2L, 3L);
+
+        ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+        verify(redisRepository).xAdd(eq(STREAM_KEY), messageCaptor.capture());
+        verify(redisRepository, never()).zAddIfAbsent(anyString(), any(), anyDouble());
+
+        ChatMessage message = messageCaptor.getValue();
+        assertThat(message.getUserId()).isEqualTo(1L);
+        assertThat(message.getSectorId()).isEqualTo(2L);
+        assertThat(message.getEventId()).isEqualTo(3L);
+
+        JSONObject payload = new JSONObject(message.getRegistration());
+        assertThat(payload.getLong("id")).isEqualTo(10L);
+        assertThat(payload.getString("email")).isEqualTo("student@jnu.ac.kr");
+        assertThat(payload.getString("studentNum")).isEqualTo("20240001");
+        assertThat(payload.getBoolean("isSaved")).isFalse();
+        assertThat(payload.getLong("eventId")).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("consumer group 조회는 Redis Stream readGroup에 위임한다")
+    void readGroupDelegatesToRedisStreamRepository() {
+        List<StreamQueueMessage> messages =
+                List.of(new StreamQueueMessage("1-0", new ChatMessage("{}", 1L, 2L, 3L)));
+        when(redisRepository.xReadGroup(STREAM_KEY, "group", "consumer", 100L))
+                .thenReturn(messages);
+
+        List<StreamQueueMessage> result =
+                waitingQueueService.readGroup(STREAM_KEY, "group", "consumer", 100L);
+
+        assertThat(result).isSameAs(messages);
+    }
+
+    @Test
+    @DisplayName("처리 완료된 Stream record는 acknowledge로 ACK 처리한다")
+    void acknowledgeDelegatesToRedisStreamRepository() {
+        when(redisRepository.xAck(STREAM_KEY, "group", "1-0")).thenReturn(1L);
+
+        Long acknowledged = waitingQueueService.acknowledge(STREAM_KEY, "group", "1-0");
+
+        assertThat(acknowledged).isEqualTo(1L);
+    }
+
+    private Registration registration() {
+        Registration registration =
+                Registration.builder()
+                        .email("student@jnu.ac.kr")
+                        .name("학생")
+                        .studentNum("20240001")
+                        .affiliation("공과대학")
+                        .department("컴퓨터공학과")
+                        .carNum("12가3456")
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                        .isSaved(false)
+                        .savedAt(null)
+                        .eventId(3L)
+                        .build();
+        registration.setId(10L);
+        return registration;
+    }
+}

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -13,6 +13,7 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.json.JSONObject;
@@ -67,13 +68,35 @@ class WaitingQueueServiceTest {
     void readGroupDelegatesToRedisStreamRepository() {
         List<StreamQueueMessage> messages =
                 List.of(new StreamQueueMessage("1-0", new ChatMessage("{}", 1L, 2L, 3L)));
+        when(redisRepository.xClaimStale(
+                        STREAM_KEY, "group", "consumer", 100L, Duration.ofSeconds(30)))
+                .thenReturn(List.of());
         when(redisRepository.xReadGroup(STREAM_KEY, "group", "consumer", 100L))
                 .thenReturn(messages);
 
         List<StreamQueueMessage> result =
                 waitingQueueService.readGroup(STREAM_KEY, "group", "consumer", 100L);
 
-        assertThat(result).isSameAs(messages);
+        assertThat(result).containsExactlyElementsOf(messages);
+    }
+
+    @Test
+    @DisplayName("stale pending record를 먼저 복구하고 남은 수만큼 새 메시지를 읽는다")
+    void readGroupRecoversStalePendingBeforeNewMessages() {
+        StreamQueueMessage recovered =
+                new StreamQueueMessage("1-0", new ChatMessage("{}", 1L, 2L, 3L));
+        StreamQueueMessage newMessage =
+                new StreamQueueMessage("2-0", new ChatMessage("{}", 2L, 2L, 3L));
+        when(redisRepository.xClaimStale(
+                        STREAM_KEY, "group", "consumer", 2L, Duration.ofSeconds(30)))
+                .thenReturn(List.of(recovered));
+        when(redisRepository.xReadGroup(STREAM_KEY, "group", "consumer", 1L))
+                .thenReturn(List.of(newMessage));
+
+        List<StreamQueueMessage> result =
+                waitingQueueService.readGroup(STREAM_KEY, "group", "consumer", 2L);
+
+        assertThat(result).containsExactly(recovered, newMessage);
     }
 
     @Test

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -130,6 +130,20 @@ class WaitingQueueServiceTest {
         verify(redisRepository, never()).xDelete(STREAM_KEY, "1-0");
     }
 
+    @Test
+    @DisplayName("이벤트별 Stream key는 Redis Cluster hash tag에 eventId를 사용한다")
+    void eventStreamKeyUsesEventHashTag() {
+        assertThat(waitingQueueService.eventStreamKey(3L)).isEqualTo("쿠폰 발급 스트림:{3}");
+    }
+
+    @Test
+    @DisplayName("이벤트 삭제는 해당 이벤트의 Stream만 삭제한다")
+    void deleteEventStreamDeletesOnlyEventStreamKey() {
+        waitingQueueService.deleteEventStream(3L);
+
+        verify(redisRepository).delete("쿠폰 발급 스트림:{3}");
+    }
+
     private Registration registration() {
         Registration registration =
                 Registration.builder()

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -86,6 +86,27 @@ class WaitingQueueServiceTest {
         assertThat(acknowledged).isEqualTo(1L);
     }
 
+    @Test
+    @DisplayName("ACK에 성공한 Stream record는 원본 entry도 삭제한다")
+    void acknowledgeAndDeleteRemovesAcknowledgedRecord() {
+        when(redisRepository.xAck(STREAM_KEY, "group", "1-0")).thenReturn(1L);
+
+        Long acknowledged = waitingQueueService.acknowledgeAndDelete(STREAM_KEY, "group", "1-0");
+
+        assertThat(acknowledged).isEqualTo(1L);
+        verify(redisRepository).xDelete(STREAM_KEY, "1-0");
+    }
+
+    @Test
+    @DisplayName("ACK하지 못한 Stream record는 삭제하지 않는다")
+    void acknowledgeAndDeleteKeepsUnacknowledgedRecord() {
+        when(redisRepository.xAck(STREAM_KEY, "group", "1-0")).thenReturn(0L);
+
+        waitingQueueService.acknowledgeAndDelete(STREAM_KEY, "group", "1-0");
+
+        verify(redisRepository, never()).xDelete(STREAM_KEY, "1-0");
+    }
+
     private Registration registration() {
         Registration registration =
                 Registration.builder()

--- a/initdb/init.sql
+++ b/initdb/init.sql
@@ -464,6 +464,9 @@ create table registration_tb
     name        varchar(255)     not null,
     phone_num   varchar(255)     not null,
     saved_at    bigint           null,
+    position    int              null,
+    result_status varchar(255)   null,
+    sequence    int              null,
     student_num varchar(255)     not null,
     sector_id   bigint           not null,
     user_id     bigint           null,
@@ -477,3 +480,22 @@ create table registration_tb
         unique (event_id, email, student_num)
 );
 
+create table email_outbox
+(
+    id              bigint auto_increment
+        primary key,
+    event_id        bigint       not null,
+    registration_id bigint       not null,
+    email           varchar(255) not null,
+    name            varchar(255) not null,
+    result_status   varchar(255) not null,
+    sequence        int          not null,
+    created_at      datetime(6)  not null,
+    processing_at   datetime(6)  null,
+    sent_at         datetime(6)  null,
+    retry_count     int          not null,
+    constraint uk_email_outbox_registration_id
+        unique (registration_id),
+    constraint FK_email_outbox_registration
+        foreign key (registration_id) references registration_tb (id)
+);


### PR DESCRIPTION
## 주요 변경사항

> [!IMPORTANT]
> 이 PR은 `origin/dev` 기준으로 브랜치와 BE 번호 규칙을 다시 정리하면서 닫혔습니다. 같은 Issue #521의 현재 구현과 리뷰는 [PR #527](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/527)에서 진행합니다.

- 신청을 DB에 저장하는 transaction에서 순번과 합격·예비·불합격 결과를 확정합니다.
- Registration 및 User 결과를 저장하고 같은 transaction에서 registration당 Email Outbox 1건을 생성합니다.
- 외부 메일은 transaction 안에서 직접 보내지 않고 별도 worker가 commit된 Outbox를 발송합니다.
- 발송 worker는 조건부 claim, 실패 cooldown, 최대 재시도를 적용합니다.
- Redis 승인 순서와 원자 재고 판정은 후속 [PR #528](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/528)의 범위입니다.

## 리뷰어에게...

- 이 닫힌 PR의 과거 diff와 설명은 리뷰 기준이 아닙니다.
- 최신 코드, 테스트 결과, DB row lock 기준의 중간 순번 정책은 [PR #527](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/527) 본문을 확인해 주세요.

## 관련 이슈

- [Issue #521](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/issues/521)
- [대체 PR #527](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/527)

## 체크리스트

- [x] 대체 PR 링크 명시
- [x] 현재 순번·Outbox 범위 반영
- [x] 관련 이슈 연결
