### PR TITLE
[BE-248] feat: Redis 원자 잔여여석 예약 게이트 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ dump.rdb
 application-local.yml
 logs/**
 *.log
+
+# Load test output
+test-script/registration-load-summary.json

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/council/handler/EmailSendEventHandler.java
@@ -1,24 +1,13 @@
 package com.jnu.ticketapi.api.council.handler;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
 
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.events.event.SendEmailEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
-import com.jnu.ticketinfrastructure.service.MailService;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -30,14 +19,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 @Slf4j
 public class EmailSendEventHandler {
-    private final MailService mailService;
     private final RegistrationAdaptor registrationAdaptor;
+    private final EmailOutboxAdaptor emailOutboxAdaptor;
 
-    @Retryable(
-            retryFor = {Exception.class},
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 30000))
-    @SneakyThrows
     @Async
     @TransactionalEventListener(
             classes = SendEmailEvent.class,
@@ -45,108 +29,22 @@ public class EmailSendEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(SendEmailEvent sendEmailEvent) {
         int startIndex = 0;
-        int batchSize = 14;
         Page<Registration> registrations;
-        Queue<Registration> failQueue = new LinkedList<>();
-        Map<Registration, Integer> retryCounts = new HashMap<>(); // Map to track retry counts
 
         do {
             registrations =
                     registrationAdaptor.findByIsDeletedFalseAndIsSavedTrueByPage(
                             sendEmailEvent.getEventId(), startIndex);
 
-            List<Registration> batch = new ArrayList<>(batchSize);
             for (Registration registration : registrations.getContent()) {
-                batch.add(registration);
-
-                if (batch.size() == batchSize) {
-                    processBatch(batch, failQueue, retryCounts);
-                    batch.clear();
-
-                    TimeUnit.SECONDS.sleep(1);
-                }
-            }
-
-            if (!batch.isEmpty()) {
-                processBatch(batch, failQueue, retryCounts);
-                batch.clear();
-                TimeUnit.SECONDS.sleep(1);
+                emailOutboxAdaptor.saveRegistrationResultIfAbsent(registration);
             }
             startIndex++;
 
         } while (registrations.hasNext());
 
-        failOver(failQueue, retryCounts);
-    }
-
-    private void processBatch(
-            List<Registration> batch,
-            Queue<Registration> failQueue,
-            Map<Registration, Integer> retryCounts) {
-        for (Registration registration : batch) {
-            try {
-                boolean result =
-                        mailService.sendRegistrationResultMail(
-                                registration.getEmail(),
-                                registration.getName(),
-                                registration.getUser().getStatus().getValue(),
-                                registration.getUser().getSequence());
-
-                if (!result) {
-                    failQueue.add(registration);
-                    retryCounts.put(
-                            registration,
-                            retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
-                }
-            } catch (Exception e) {
-                log.error(
-                        "Email sending failed for {}: {}", registration.getEmail(), e.getMessage());
-                failQueue.add(registration);
-                retryCounts.put(
-                        registration,
-                        retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
-            }
-        }
-    }
-
-    private void failOver(Queue<Registration> failQueue, Map<Registration, Integer> retryCounts)
-            throws InterruptedException {
-        while (!failQueue.isEmpty()) {
-            int queueSize = failQueue.size();
-            for (int i = 0; i < queueSize; i++) {
-                Registration registration = failQueue.poll();
-
-                int retryCount = retryCounts.getOrDefault(registration, 0);
-                if (retryCount >= MAX_EMAIL_SEND_RETRY) {
-                    log.error("최대 10번 retry 실패시: {}", registration.getEmail());
-                    continue;
-                }
-                try {
-                    boolean result =
-                            mailService.sendRegistrationResultMail(
-                                    registration.getEmail(),
-                                    registration.getName(),
-                                    registration.getUser().getStatus().getValue(),
-                                    registration.getUser().getSequence());
-
-                    if (!result) {
-                        retryCounts.put(registration, retryCount + 1);
-                        failQueue.add(registration);
-                        log.warn(
-                                "Retry failed for email: {} (Attempt {})",
-                                registration.getEmail(),
-                                retryCount + 1);
-                    }
-                } catch (Exception e) {
-                    log.error(
-                            "Retry exception for email {}: {}",
-                            registration.getEmail(),
-                            e.getMessage());
-                    retryCounts.put(registration, retryCount + 1);
-                    failQueue.add(registration);
-                }
-            }
-            TimeUnit.SECONDS.sleep(1);
-        }
+        log.info(
+                "Manual SendEmailEvent outbox backfill completed. eventId: {}",
+                sendEmailEvent.getEventId());
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -3,6 +3,7 @@ package com.jnu.ticketapi.api.event.handler;
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
@@ -10,6 +11,7 @@ import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,7 @@ public class EventIssuedEventHandler {
 
     private final RegistrationAdaptor registrationAdaptor;
     private final UserAdaptor userAdaptor;
+    private final EmailOutboxAdaptor emailOutboxAdaptor;
 
     @Autowired(required = false)
     private WaitingQueueService waitingQueueService;
@@ -55,7 +58,8 @@ public class EventIssuedEventHandler {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
 
-            Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
+            Sector sector =
+                    sectorAdaptor.findByIdForUpdate(eventIssuedEvent.getMessage().getSectorId());
 
             try {
                 Registration registration =
@@ -96,7 +100,11 @@ public class EventIssuedEventHandler {
         }
     }
 
-    /** 대기열에서 pop한 registration을 저장하고 savedAt 기준 순서를 보존한다. */
+    /** 대기열에서 pop한 registration을 저장하는 시점에 순번과 결과를 확정하고 메일 outbox를 생성한다. */
+    public void processQueueData(Sector sector, Registration registration, Long userId) {
+        processQueueData(sector, registration, userId, (double) System.currentTimeMillis());
+    }
+
     public void processQueueData(
             Sector sector, Registration registration, Long userId, Double score) {
         User user = userAdaptor.findById(userId);
@@ -105,27 +113,61 @@ public class EventIssuedEventHandler {
 
     private void saveRegistration(
             Sector sector, User user, Registration registration, Double score) {
-        if (!sector.isRemainingAmount()) {
-            tracker.info("[No seats remaining]. Registration: {}", registration);
-            throw NoEventStockLeftException.EXCEPTION;
+        int position =
+                Math.toIntExact(registrationAdaptor.countSavedBySectorId(sector.getId())) + 1;
+        RegistrationDecision decision = decideResult(sector, position);
+
+        if (!decision.isFail()) {
+            sector.decreaseEventStock();
         }
+
+        reflectUserState(user, decision);
 
         if (!registration.isSaved()) {
             // if문 사용 안됨.
-            registration.finalSave();
+            registration.finalSave(position, decision.resultStatus, decision.sequence);
             registration.setSector(sector);
             registration.setUser(user);
             registration.setSavedAt(score.longValue());
-            registrationAdaptor.save(registration);
-            return;
+            Registration savedRegistration = registrationAdaptor.save(registration);
+            emailOutboxAdaptor.saveRegistrationResultIfAbsent(savedRegistration);
+        } else {
+            registration.finalSave(position, decision.resultStatus, decision.sequence);
+            registration.setSector(sector);
+            registration.setUser(user);
+            registration.setSavedAt(score.longValue());
+            Registration savedRegistration = registrationAdaptor.saveAndFlush(registration);
+            emailOutboxAdaptor.saveRegistrationResultIfAbsent(savedRegistration);
         }
 
-        registration.setSector(sector);
-        registration.setUser(user);
-        registration.setSavedAt(score.longValue());
-        registrationAdaptor.saveAndFlush(registration);
+        tracker.info(
+                "Registration saved. position: {}, status: {}, sequence: {}",
+                position,
+                decision.resultStatus.getValue(),
+                decision.sequence);
+    }
 
-        tracker.info("Registration saved");
+    private RegistrationDecision decideResult(Sector sector, int position) {
+        if (position <= sector.getInitSectorCapacity()) {
+            return new RegistrationDecision(UserStatus.SUCCESS, -2);
+        }
+        if (position <= sector.getIssueAmount()) {
+            return new RegistrationDecision(
+                    UserStatus.PREPARE, position - sector.getInitSectorCapacity());
+        }
+        return new RegistrationDecision(UserStatus.FAIL, -1);
+    }
+
+    private void reflectUserState(User user, RegistrationDecision decision) {
+        if (decision.resultStatus == UserStatus.SUCCESS) {
+            user.success();
+            return;
+        }
+        if (decision.resultStatus == UserStatus.PREPARE) {
+            user.prepare(decision.sequence);
+            return;
+        }
+        user.fail();
     }
 
     private Double resolveScore(EventIssuedEvent eventIssuedEvent) {
@@ -136,7 +178,7 @@ public class EventIssuedEventHandler {
         if (streamRecordId != null && streamRecordId.contains("-")) {
             return Double.valueOf(streamRecordId.substring(0, streamRecordId.indexOf('-')));
         }
-        return (double) System.nanoTime();
+        return (double) System.currentTimeMillis();
     }
 
     private boolean isAlreadySaved(Registration registration) {
@@ -190,5 +232,19 @@ public class EventIssuedEventHandler {
             return eventIssuedEvent.getStreamKey();
         }
         return waitingQueueService.eventStreamKey(eventIssuedEvent.getMessage().getEventId());
+    }
+
+    private static class RegistrationDecision {
+        private final UserStatus resultStatus;
+        private final Integer sequence;
+
+        private RegistrationDecision(UserStatus resultStatus, Integer sequence) {
+            this.resultStatus = resultStatus;
+            this.sequence = sequence;
+        }
+
+        private boolean isFail() {
+            return resultStatus == UserStatus.FAIL;
+        }
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -13,6 +13,7 @@ import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -57,9 +58,9 @@ public class EventIssuedEventHandler {
     public void handle(EventIssuedEvent eventIssuedEvent) {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
+            ChatMessage message = eventIssuedEvent.getMessage();
 
-            Sector sector =
-                    sectorAdaptor.findByIdForUpdate(eventIssuedEvent.getMessage().getSectorId());
+            Sector sector = findSector(message);
 
             try {
                 Registration registration =
@@ -79,11 +80,7 @@ public class EventIssuedEventHandler {
                         sector.getReserve(),
                         sector.getRemainingAmount());
 
-                processQueueData(
-                        sector,
-                        registration,
-                        eventIssuedEvent.getMessage().getUserId(),
-                        resolveScore(eventIssuedEvent));
+                processQueueData(sector, registration, message, resolveScore(eventIssuedEvent));
                 acknowledgeAfterCommit(eventIssuedEvent);
 
                 // sectorAdaptor.save(sector); 데드락 문제 임시 해결
@@ -107,17 +104,40 @@ public class EventIssuedEventHandler {
 
     public void processQueueData(
             Sector sector, Registration registration, Long userId, Double score) {
-        User user = userAdaptor.findById(userId);
-        saveRegistration(sector, user, registration, score);
+        processQueueData(
+                sector,
+                registration,
+                new ChatMessage(null, userId, sector.getId(), registration.getEventId()),
+                score);
+    }
+
+    public void processQueueData(Sector sector, Registration registration, ChatMessage message) {
+        processQueueData(sector, registration, message, (double) System.currentTimeMillis());
+    }
+
+    public void processQueueData(
+            Sector sector, Registration registration, ChatMessage message, Double score) {
+        User user = userAdaptor.findById(message.getUserId());
+        saveRegistration(sector, user, registration, message, score);
+    }
+
+    private Sector findSector(ChatMessage message) {
+        if (message.hasDecision()) {
+            return sectorAdaptor.findById(message.getSectorId());
+        }
+        return sectorAdaptor.findByIdForUpdate(message.getSectorId());
     }
 
     private void saveRegistration(
-            Sector sector, User user, Registration registration, Double score) {
-        int position =
-                Math.toIntExact(registrationAdaptor.countSavedBySectorId(sector.getId())) + 1;
-        RegistrationDecision decision = decideResult(sector, position);
+            Sector sector,
+            User user,
+            Registration registration,
+            ChatMessage message,
+            Double score) {
+        RegistrationDecision decision = resolveDecision(sector, message);
+        int position = decision.position;
 
-        if (!decision.isFail()) {
+        if (!message.hasDecision() && !decision.isFail()) {
             sector.decreaseEventStock();
         }
 
@@ -147,15 +167,25 @@ public class EventIssuedEventHandler {
                 decision.sequence);
     }
 
+    private RegistrationDecision resolveDecision(Sector sector, ChatMessage message) {
+        if (message.hasDecision()) {
+            return new RegistrationDecision(
+                    message.getPosition(), message.getResultStatus(), message.getSequence());
+        }
+        int position =
+                Math.toIntExact(registrationAdaptor.countSavedBySectorId(sector.getId())) + 1;
+        return decideResult(sector, position);
+    }
+
     private RegistrationDecision decideResult(Sector sector, int position) {
         if (position <= sector.getInitSectorCapacity()) {
-            return new RegistrationDecision(UserStatus.SUCCESS, -2);
+            return new RegistrationDecision(position, UserStatus.SUCCESS, -2);
         }
         if (position <= sector.getIssueAmount()) {
             return new RegistrationDecision(
-                    UserStatus.PREPARE, position - sector.getInitSectorCapacity());
+                    position, UserStatus.PREPARE, position - sector.getInitSectorCapacity());
         }
-        return new RegistrationDecision(UserStatus.FAIL, -1);
+        return new RegistrationDecision(position, UserStatus.FAIL, -1);
     }
 
     private void reflectUserState(User user, RegistrationDecision decision) {
@@ -235,10 +265,12 @@ public class EventIssuedEventHandler {
     }
 
     private static class RegistrationDecision {
+        private final Integer position;
         private final UserStatus resultStatus;
         private final Integer sequence;
 
-        private RegistrationDecision(UserStatus resultStatus, Integer sequence) {
+        private RegistrationDecision(Integer position, UserStatus resultStatus, Integer sequence) {
+            this.position = position;
             this.resultStatus = resultStatus;
             this.sequence = sequence;
         }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -13,7 +13,6 @@ import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
-import com.zaxxer.hikari.HikariDataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -43,7 +42,6 @@ public class EventIssuedEventHandler {
 
     private final SectorAdaptor sectorAdaptor;
     private final ObjectMapper objectMapper;
-    private final HikariDataSource hikariDataSource;
 
     @Async
     @EventListener(classes = EventIssuedEvent.class)
@@ -55,9 +53,6 @@ public class EventIssuedEventHandler {
     public void handle(EventIssuedEvent eventIssuedEvent) {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
-            if (!isIdleConnectionAvailable()) {
-                return;
-            }
 
             Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
@@ -151,8 +146,4 @@ public class EventIssuedEventHandler {
         }
     }
 
-    private boolean isIdleConnectionAvailable() {
-        int idleConnections = hikariDataSource.getHikariPoolMXBean().getIdleConnections();
-        return idleConnections > 0;
-    }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,7 +1,9 @@
 package com.jnu.ticketapi.api.event.handler;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jnu.ticketdomain.common.domainEvent.Events;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
@@ -9,7 +11,6 @@ import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
-import com.jnu.ticketdomain.domains.user.event.UserReflectStatusEvent;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import com.zaxxer.hikari.HikariDataSource;
@@ -26,8 +27,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
 
 @Component
 @RequiredArgsConstructor
@@ -56,57 +55,56 @@ public class EventIssuedEventHandler {
     public void handle(EventIssuedEvent eventIssuedEvent) {
         try {
             MDC.put("userId", String.valueOf(eventIssuedEvent.getMessage().getUserId()));
-            if (isIdleConnectionAvailable()) {
-                Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
+            if (!isIdleConnectionAvailable()) {
+                return;
+            }
 
-                try {
-                    Double score = eventIssuedEvent.getScore();
+            Sector sector = sectorAdaptor.findById(eventIssuedEvent.getMessage().getSectorId());
 
-                    Registration registration =
-                            objectMapper.readValue(
-                                    eventIssuedEvent.getMessage().getRegistration(),
-                                    Registration.class);
+            try {
+                Registration registration =
+                        objectMapper.readValue(
+                                eventIssuedEvent.getMessage().getRegistration(), Registration.class);
 
-                    if (Boolean.TRUE.equals(
-                            registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
-                        tracker.info("Already saved, ignored");
-                        return;
-                    }
-                    tracker.info(
-                            "현재구간 정보, sectorId: {}, 정원여석: {}, 예비여석: {}, 총 여석: {},",
-                            sector.getId(),
-                            sector.getSectorCapacity(),
-                            sector.getReserve(),
-                            sector.getRemainingAmount());
-
-                    processQueueData(
-                            sector, registration, eventIssuedEvent.getMessage().getUserId(), score);
-                    waitingQueueService.remove(
-                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-//                    sector.decreaseEventStock();
-
-                    // sectorAdaptor.save(sector); 데드락 문제 임시 해결
-                } catch (NoEventStockLeftException e) {
-                    tracker.info("해당 구간 잔여 여석이 없습니다.", e);
-                    waitingQueueService.remove(
-                            REDIS_EVENT_ISSUE_STORE, eventIssuedEvent.getMessage());
-                } catch (Exception e) {
-                    // 에러가 났을 때 redis에 데이터를 재등록 한다.(Not Waiting 상태로)
-                    tracker.error("EventIssuedEventHandler Exception: ", e);
+                if (registration.getId() != null
+                        && Boolean.TRUE.equals(
+                                registrationAdaptor.existsByIdAndIsSavedTrue(
+                                        registration.getId()))) {
+                    tracker.info("Already saved, ignored");
+                    acknowledge(eventIssuedEvent);
+                    return;
                 }
+                tracker.info(
+                        "현재구간 정보, sectorId: {}, 정원여석: {}, 예비여석: {}, 총 여석: {},",
+                        sector.getId(),
+                        sector.getSectorCapacity(),
+                        sector.getReserve(),
+                        sector.getRemainingAmount());
+
+                processQueueData(
+                        sector,
+                        registration,
+                        eventIssuedEvent.getMessage().getUserId(),
+                        resolveScore(eventIssuedEvent));
+                acknowledge(eventIssuedEvent);
+
+                // sectorAdaptor.save(sector); 데드락 문제 임시 해결
+            } catch (NoEventStockLeftException e) {
+                tracker.info("해당 구간 잔여 여석이 없습니다.", e);
+                acknowledge(eventIssuedEvent);
+            } catch (Exception e) {
+                // ack 하지 않으면 Redis Stream pending entry로 남아 재처리할 수 있다.
+                tracker.error("EventIssuedEventHandler Exception: ", e);
             }
         } finally {
             MDC.clear();
         }
     }
 
-    /**
-     * 대기열에서 pop한 registration을 저장하고 유저 신청 결과 상태 정보를 메일 전송하는 이벤트를 발행한다.
-     */
+    /** 대기열에서 pop한 registration을 저장하고 savedAt 기준 순서를 보존한다. */
     public void processQueueData(Sector sector, Registration registration, Long userId, Double score) {
         User user = userAdaptor.findById(userId);
         saveRegistration(sector, user, registration, score);
-//        Events.raise(UserReflectStatusEvent.of(userId, registration, sector));
     }
 
     private void saveRegistration(Sector sector, User user, Registration registration, Double score) {
@@ -127,11 +125,30 @@ public class EventIssuedEventHandler {
 
         registration.setSector(sector);
         registration.setUser(user);
-//        registrationAdaptor.updateSavedAt(registration);
         registration.setSavedAt(score.longValue());
         registrationAdaptor.saveAndFlush(registration);
 
         tracker.info("Registration saved");
+    }
+
+    private Double resolveScore(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getScore() != null) {
+            return eventIssuedEvent.getScore();
+        }
+        String streamRecordId = eventIssuedEvent.getStreamRecordId();
+        if (streamRecordId != null && streamRecordId.contains("-")) {
+            return Double.valueOf(streamRecordId.substring(0, streamRecordId.indexOf('-')));
+        }
+        return (double) System.nanoTime();
+    }
+
+    private void acknowledge(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getStreamRecordId() != null) {
+            waitingQueueService.acknowledge(
+                    REDIS_EVENT_ISSUE_STREAM,
+                    REDIS_EVENT_ISSUE_GROUP,
+                    eventIssuedEvent.getStreamRecordId());
+        }
     }
 
     private boolean isIdleConnectionAvailable() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -26,6 +26,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @RequiredArgsConstructor
@@ -59,14 +61,12 @@ public class EventIssuedEventHandler {
             try {
                 Registration registration =
                         objectMapper.readValue(
-                                eventIssuedEvent.getMessage().getRegistration(), Registration.class);
+                                eventIssuedEvent.getMessage().getRegistration(),
+                                Registration.class);
 
-                if (registration.getId() != null
-                        && Boolean.TRUE.equals(
-                                registrationAdaptor.existsByIdAndIsSavedTrue(
-                                        registration.getId()))) {
+                if (isAlreadySaved(registration)) {
                     tracker.info("Already saved, ignored");
-                    acknowledge(eventIssuedEvent);
+                    acknowledgeAfterCommit(eventIssuedEvent);
                     return;
                 }
                 tracker.info(
@@ -81,15 +81,16 @@ public class EventIssuedEventHandler {
                         registration,
                         eventIssuedEvent.getMessage().getUserId(),
                         resolveScore(eventIssuedEvent));
-                acknowledge(eventIssuedEvent);
+                acknowledgeAfterCommit(eventIssuedEvent);
 
                 // sectorAdaptor.save(sector); 데드락 문제 임시 해결
             } catch (NoEventStockLeftException e) {
                 tracker.info("해당 구간 잔여 여석이 없습니다.", e);
-                acknowledge(eventIssuedEvent);
+                acknowledgeAfterCommit(eventIssuedEvent);
             } catch (Exception e) {
                 // ack 하지 않으면 Redis Stream pending entry로 남아 재처리할 수 있다.
                 tracker.error("EventIssuedEventHandler Exception: ", e);
+                throw new IllegalStateException(e);
             }
         } finally {
             MDC.clear();
@@ -97,12 +98,14 @@ public class EventIssuedEventHandler {
     }
 
     /** 대기열에서 pop한 registration을 저장하고 savedAt 기준 순서를 보존한다. */
-    public void processQueueData(Sector sector, Registration registration, Long userId, Double score) {
+    public void processQueueData(
+            Sector sector, Registration registration, Long userId, Double score) {
         User user = userAdaptor.findById(userId);
         saveRegistration(sector, user, registration, score);
     }
 
-    private void saveRegistration(Sector sector, User user, Registration registration, Double score) {
+    private void saveRegistration(
+            Sector sector, User user, Registration registration, Double score) {
         if (!sector.isRemainingAmount()) {
             tracker.info("[No seats remaining]. Registration: {}", registration);
             throw NoEventStockLeftException.EXCEPTION;
@@ -137,13 +140,49 @@ public class EventIssuedEventHandler {
         return (double) System.nanoTime();
     }
 
+    private boolean isAlreadySaved(Registration registration) {
+        if (registration.getId() != null
+                && Boolean.TRUE.equals(
+                        registrationAdaptor.existsByIdAndIsSavedTrue(registration.getId()))) {
+            return true;
+        }
+        return registration.getEventId() != null
+                && Boolean.TRUE.equals(
+                        registrationAdaptor.existsByEmailAndIsSavedTrue(
+                                registration.getEmail(), registration.getEventId()));
+    }
+
+    private void acknowledgeAfterCommit(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getStreamRecordId() == null) {
+            return;
+        }
+
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            acknowledge(eventIssuedEvent);
+                        }
+                    });
+            return;
+        }
+
+        acknowledge(eventIssuedEvent);
+    }
+
     private void acknowledge(EventIssuedEvent eventIssuedEvent) {
-        if (eventIssuedEvent.getStreamRecordId() != null) {
-            waitingQueueService.acknowledge(
+        try {
+            waitingQueueService.acknowledgeAndDelete(
                     REDIS_EVENT_ISSUE_STREAM,
                     REDIS_EVENT_ISSUE_GROUP,
                     eventIssuedEvent.getStreamRecordId());
+        } catch (Exception e) {
+            tracker.error(
+                    "Redis Stream ACK failed. recordId: {}",
+                    eventIssuedEvent.getStreamRecordId(),
+                    e);
         }
     }
-
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandler.java
@@ -1,7 +1,6 @@
 package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
@@ -175,7 +174,7 @@ public class EventIssuedEventHandler {
     private void acknowledge(EventIssuedEvent eventIssuedEvent) {
         try {
             waitingQueueService.acknowledgeAndDelete(
-                    REDIS_EVENT_ISSUE_STREAM,
+                    resolveStreamKey(eventIssuedEvent),
                     REDIS_EVENT_ISSUE_GROUP,
                     eventIssuedEvent.getStreamRecordId());
         } catch (Exception e) {
@@ -184,5 +183,12 @@ public class EventIssuedEventHandler {
                     eventIssuedEvent.getStreamRecordId(),
                     e);
         }
+    }
+
+    private String resolveStreamKey(EventIssuedEvent eventIssuedEvent) {
+        if (eventIssuedEvent.getStreamKey() != null) {
+            return eventIssuedEvent.getStreamKey();
+        }
+        return waitingQueueService.eventStreamKey(eventIssuedEvent.getMessage().getEventId());
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/RedisStockSyncWorker.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/handler/RedisStockSyncWorker.java
@@ -1,0 +1,56 @@
+package com.jnu.ticketapi.api.event.handler;
+
+
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnExpression("${ableRedis:true}")
+@ConditionalOnProperty(
+        value = "redis.stock-sync.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class RedisStockSyncWorker {
+
+    private final SectorAdaptor sectorAdaptor;
+
+    @Autowired(required = false)
+    private WaitingQueueService waitingQueueService;
+
+    @Scheduled(
+            fixedDelayString = "${redis.stock-sync.fixed-delay-ms:10000}",
+            initialDelayString = "${redis.stock-sync.initial-delay-ms:10000}")
+    @Transactional
+    public void syncRemainingStock() {
+        if (waitingQueueService == null) {
+            return;
+        }
+        sectorAdaptor.findAllByEventStatusAndPublishAndIsDeleted().forEach(this::syncSector);
+    }
+
+    void syncSector(Sector sector) {
+        waitingQueueService
+                .findRemainingStock(sector.getEvent().getId(), sector.getId())
+                .ifPresent(
+                        remainingAmount -> {
+                            sector.syncRemainingAmount(remainingAmount);
+                            sectorAdaptor.save(sector);
+                            log.info(
+                                    "Synced Redis stock to DB. eventId: {}, sectorId: {}, remaining: {}",
+                                    sector.getEvent().getId(),
+                                    sector.getId(),
+                                    remainingAmount);
+                        });
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -37,12 +37,12 @@ public class EventDeleteUseCase {
         Events.raise(EventDeletedEvent.of(event));
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
-        deleteEventStreamAfterCommit(eventId);
+        deleteEventRedisStateAfterCommit(eventId);
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);
     }
 
-    private void deleteEventStreamAfterCommit(Long eventId) {
+    private void deleteEventRedisStateAfterCommit(Long eventId) {
         if (!ableRedis || waitingQueueService == null) {
             return;
         }
@@ -52,11 +52,16 @@ public class EventDeleteUseCase {
                     new TransactionSynchronization() {
                         @Override
                         public void afterCommit() {
-                            waitingQueueService.deleteEventStream(eventId);
+                            deleteEventRedisState(eventId);
                         }
                     });
             return;
         }
+        deleteEventRedisState(eventId);
+    }
+
+    private void deleteEventRedisState(Long eventId) {
         waitingQueueService.deleteEventStream(eventId);
+        waitingQueueService.deleteEventStockKeys(eventId);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.common.domainEvent.Events;
@@ -37,7 +37,7 @@ public class EventDeleteUseCase {
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
         if (ableRedis) {
-            redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
+            redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
         }
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventDeleteUseCase.java
@@ -1,6 +1,5 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketcommon.annotation.UseCase;
 import com.jnu.ticketdomain.common.domainEvent.Events;
@@ -10,11 +9,13 @@ import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.event.EventDeletedEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
-import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @UseCase
 @RequiredArgsConstructor
@@ -22,7 +23,7 @@ public class EventDeleteUseCase {
     private final EventAdaptor eventAdaptor;
 
     @Autowired(required = false)
-    private RedisRepository redisRepository;
+    private WaitingQueueService waitingQueueService;
 
     private final SectorAdaptor sectorAdaptor;
     private final RegistrationAdaptor registrationAdaptor;
@@ -36,10 +37,26 @@ public class EventDeleteUseCase {
         Events.raise(EventDeletedEvent.of(event));
         event.deleteEvent();
         event.updateStatus(EventStatus.CLOSED, null);
-        if (ableRedis) {
-            redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
-        }
+        deleteEventStreamAfterCommit(eventId);
         sectorAdaptor.deleteByEvent(eventId);
         registrationAdaptor.deleteByEvent(eventId);
+    }
+
+    private void deleteEventStreamAfterCommit(Long eventId) {
+        if (!ableRedis || waitingQueueService == null) {
+            return;
+        }
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            waitingQueueService.deleteEventStream(eventId);
+                        }
+                    });
+            return;
+        }
+        waitingQueueService.deleteEventStream(eventId);
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -64,6 +64,9 @@ public class EventWithDrawUseCase {
         if (result.isNoStock()) {
             throw NoEventStockLeftException.EXCEPTION;
         }
+        if (result.isClosed()) {
+            throw NotOpenEventStatusException.EXCEPTION;
+        }
         return result;
     }
 

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -1,6 +1,5 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketapi.api.event.model.response.GetEventPeriodResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
@@ -52,7 +51,11 @@ public class EventWithDrawUseCase {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
         waitingQueueService.registerQueue(
-                REDIS_EVENT_ISSUE_STREAM, registration, userId, sectorId, eventId);
+                waitingQueueService.eventStreamKey(eventId),
+                registration,
+                userId,
+                sectorId,
+                eventId);
     }
 
     public GetEventPeriodResponse getEventPeriod() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -15,6 +15,7 @@ import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrat
 import com.jnu.ticketinfrastructure.model.StockReservationResult;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -41,18 +42,15 @@ public class EventWithDrawUseCase {
     @SneakyThrows
     public StockReservationResult issueEvent(
             Registration registration, Long userId, Sector sector, Long eventId) {
-        // 재고 감소 로직 구현
-        Result<Event, Object> readyEvent = eventAdaptor.findReadyOrOpenEvent();
-        readyEvent.fold(
-                (event) -> {
-                    if (event.getEventStatus().equals(EventStatus.READY))
-                        throw NotOpenEventStatusException.EXCEPTION;
-                    event.validateIssuePeriod();
-                    return null;
-                },
-                (error) -> {
-                    throw NotReadyEventStatusException.EXCEPTION;
-                });
+        Event event = eventAdaptor.findById(eventId);
+        if (event.getEventStatus() != EventStatus.OPEN) {
+            throw NotOpenEventStatusException.EXCEPTION;
+        }
+        if (sector.getEvent() == null || !Objects.equals(sector.getEvent().getId(), eventId)) {
+            throw NotFoundSectorException.EXCEPTION;
+        }
+        event.validateIssuePeriod();
+
         StockReservationResult result =
                 waitingQueueService.reserveAndRegisterQueue(
                         waitingQueueService.eventStreamKey(eventId),

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -11,6 +11,8 @@ import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.*;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
+import com.jnu.ticketinfrastructure.model.StockReservationResult;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +39,8 @@ public class EventWithDrawUseCase {
     //            leaseTime = 10000,
     //            timeUnit = TimeUnit.MILLISECONDS)
     @SneakyThrows
-    public void issueEvent(Registration registration, Long userId, Long sectorId, Long eventId) {
+    public StockReservationResult issueEvent(
+            Registration registration, Long userId, Sector sector, Long eventId) {
         // 재고 감소 로직 구현
         Result<Event, Object> readyEvent = eventAdaptor.findReadyOrOpenEvent();
         readyEvent.fold(
@@ -50,12 +53,20 @@ public class EventWithDrawUseCase {
                 (error) -> {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
-        waitingQueueService.registerQueue(
-                waitingQueueService.eventStreamKey(eventId),
-                registration,
-                userId,
-                sectorId,
-                eventId);
+        StockReservationResult result =
+                waitingQueueService.reserveAndRegisterQueue(
+                        waitingQueueService.eventStreamKey(eventId),
+                        registration,
+                        userId,
+                        sector,
+                        eventId);
+        if (result.isDuplicate()) {
+            throw AlreadyExistRegistrationException.EXCEPTION;
+        }
+        if (result.isNoStock()) {
+            throw NoEventStockLeftException.EXCEPTION;
+        }
+        return result;
     }
 
     public GetEventPeriodResponse getEventPeriod() {
@@ -77,6 +88,9 @@ public class EventWithDrawUseCase {
                     eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
                     List<Sector> sector = event.getSector();
                     sector.forEach(Sector::resetAmount);
+                    if (waitingQueueService != null) {
+                        waitingQueueService.deleteEventStockKeys(event.getId());
+                    }
                     return null;
                 },
                 (error) -> {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCase.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketapi.api.event.service;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketapi.api.event.model.response.GetEventPeriodResponse;
 import com.jnu.ticketcommon.annotation.UseCase;
@@ -52,7 +52,7 @@ public class EventWithDrawUseCase {
                     throw NotReadyEventStatusException.EXCEPTION;
                 });
         waitingQueueService.registerQueue(
-                REDIS_EVENT_ISSUE_STORE, registration, userId, sectorId, eventId);
+                REDIS_EVENT_ISSUE_STREAM, registration, userId, sectorId, eventId);
     }
 
     public GetEventPeriodResponse getEventPeriod() {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.registration.handler;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
 
 import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
@@ -28,10 +29,11 @@ public class EmailOutboxWorker {
             initialDelayString = "${mail.outbox.initial-delay-ms:1000}")
     public void sendPendingRegistrationResultMail() {
         LocalDateTime staleBefore = LocalDateTime.now().minusMinutes(STALE_PROCESSING_MINUTES);
-        List<EmailOutbox> pendingOutboxes = emailOutboxAdaptor.findPending(BATCH_SIZE, staleBefore);
+        List<EmailOutbox> pendingOutboxes =
+                emailOutboxAdaptor.findPending(BATCH_SIZE, staleBefore, MAX_EMAIL_SEND_RETRY);
 
         for (EmailOutbox outbox : pendingOutboxes) {
-            if (!emailOutboxAdaptor.claim(outbox.getId(), staleBefore)) {
+            if (!emailOutboxAdaptor.claim(outbox.getId(), staleBefore, MAX_EMAIL_SEND_RETRY)) {
                 continue;
             }
             send(outbox);
@@ -51,7 +53,7 @@ public class EmailOutboxWorker {
             return;
         }
 
-        emailOutboxAdaptor.releaseAfterFailure(outbox.getId());
+        emailOutboxAdaptor.markFailed(outbox.getId());
         log.warn("신청 결과 메일 outbox 발송 실패. outboxId: {}", outbox.getId());
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
@@ -1,0 +1,55 @@
+package com.jnu.ticketapi.api.registration.handler;
+
+
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketinfrastructure.service.MailService;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EmailOutboxWorker {
+    private static final int BATCH_SIZE = 20;
+    private static final long STALE_PROCESSING_MINUTES = 10;
+
+    private final EmailOutboxAdaptor emailOutboxAdaptor;
+    private final MailService mailService;
+
+    @Scheduled(
+            fixedDelayString = "${mail.outbox.fixed-delay-ms:1000}",
+            initialDelayString = "${mail.outbox.initial-delay-ms:1000}")
+    public void sendPendingRegistrationResultMail() {
+        LocalDateTime staleBefore = LocalDateTime.now().minusMinutes(STALE_PROCESSING_MINUTES);
+        List<EmailOutbox> pendingOutboxes = emailOutboxAdaptor.findPending(BATCH_SIZE, staleBefore);
+
+        for (EmailOutbox outbox : pendingOutboxes) {
+            if (!emailOutboxAdaptor.claim(outbox.getId(), staleBefore)) {
+                continue;
+            }
+            send(outbox);
+        }
+    }
+
+    private void send(EmailOutbox outbox) {
+        boolean sent =
+                mailService.sendRegistrationResultMail(
+                        outbox.getEmail(),
+                        outbox.getName(),
+                        outbox.getResultStatus().getValue(),
+                        outbox.getSequence());
+
+        if (sent) {
+            emailOutboxAdaptor.markSent(outbox.getId());
+            return;
+        }
+
+        emailOutboxAdaptor.releaseAfterFailure(outbox.getId());
+        log.warn("신청 결과 메일 outbox 발송 실패. outboxId: {}", outbox.getId());
+    }
+}

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
@@ -8,10 +8,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(value = "mail.outbox.enabled", havingValue = "true", matchIfMissing = true)
 @RequiredArgsConstructor
 @Slf4j
 public class EmailOutboxWorker {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorker.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 public class EmailOutboxWorker {
-    private static final int BATCH_SIZE = 20;
+    private static final int BATCH_SIZE = 14;
     private static final long STALE_PROCESSING_MINUTES = 10;
 
     private final EmailOutboxAdaptor emailOutboxAdaptor;

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EventExpiredEventHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/handler/EventExpiredEventHandler.java
@@ -1,24 +1,13 @@
 package com.jnu.ticketapi.api.registration.handler;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
 
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.events.event.EventExpiredEvent;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
-import com.jnu.ticketinfrastructure.service.MailService;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -30,14 +19,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 @Slf4j
 public class EventExpiredEventHandler {
-    private final MailService mailService;
     private final RegistrationAdaptor registrationAdaptor;
+    private final EmailOutboxAdaptor emailOutboxAdaptor;
 
-    @Retryable(
-            retryFor = {Exception.class},
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 30000))
-    @SneakyThrows
     @Async
     @TransactionalEventListener(
             classes = EventExpiredEvent.class,
@@ -45,108 +29,22 @@ public class EventExpiredEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(EventExpiredEvent eventExpiredEvent) {
         int startIndex = 0;
-        int batchSize = 14;
         Page<Registration> registrations;
-        Queue<Registration> failQueue = new LinkedList<>();
-        Map<Registration, Integer> retryCounts = new HashMap<>(); // Map to track retry counts
 
         do {
             registrations =
                     registrationAdaptor.findByIsDeletedFalseAndIsSavedTrueByPage(
                             eventExpiredEvent.getEventId(), startIndex);
 
-            List<Registration> batch = new ArrayList<>(batchSize);
             for (Registration registration : registrations.getContent()) {
-                batch.add(registration);
-
-                if (batch.size() == batchSize) {
-                    processBatch(batch, failQueue, retryCounts);
-                    batch.clear();
-
-                    TimeUnit.SECONDS.sleep(1);
-                }
-            }
-
-            if (!batch.isEmpty()) {
-                processBatch(batch, failQueue, retryCounts);
-                batch.clear();
-                TimeUnit.SECONDS.sleep(1);
+                emailOutboxAdaptor.saveRegistrationResultIfAbsent(registration);
             }
             startIndex++;
 
         } while (registrations.hasNext());
 
-        failOver(failQueue, retryCounts);
-    }
-
-    private void processBatch(
-            List<Registration> batch,
-            Queue<Registration> failQueue,
-            Map<Registration, Integer> retryCounts) {
-        for (Registration registration : batch) {
-            try {
-                boolean result =
-                        mailService.sendRegistrationResultMail(
-                                registration.getEmail(),
-                                registration.getName(),
-                                registration.getUser().getStatus().getValue(),
-                                registration.getUser().getSequence());
-
-                if (!result) {
-                    failQueue.add(registration);
-                    retryCounts.put(
-                            registration,
-                            retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
-                }
-            } catch (Exception e) {
-                log.error(
-                        "Email sending failed for {}: {}", registration.getEmail(), e.getMessage());
-                failQueue.add(registration);
-                retryCounts.put(
-                        registration,
-                        retryCounts.getOrDefault(registration, 0) + 1); // Increment retry count
-            }
-        }
-    }
-
-    private void failOver(Queue<Registration> failQueue, Map<Registration, Integer> retryCounts)
-            throws InterruptedException {
-        while (!failQueue.isEmpty()) {
-            int queueSize = failQueue.size();
-            for (int i = 0; i < queueSize; i++) {
-                Registration registration = failQueue.poll();
-
-                int retryCount = retryCounts.getOrDefault(registration, 0);
-                if (retryCount >= MAX_EMAIL_SEND_RETRY) {
-                    log.error("최대 10번 retry 실패시: {}", registration.getEmail());
-                    continue;
-                }
-                try {
-                    boolean result =
-                            mailService.sendRegistrationResultMail(
-                                    registration.getEmail(),
-                                    registration.getName(),
-                                    registration.getUser().getStatus().getValue(),
-                                    registration.getUser().getSequence());
-
-                    if (!result) {
-                        retryCounts.put(registration, retryCount + 1);
-                        failQueue.add(registration);
-                        log.warn(
-                                "Retry failed for email: {} (Attempt {})",
-                                registration.getEmail(),
-                                retryCount + 1);
-                    }
-                } catch (Exception e) {
-                    log.error(
-                            "Retry exception for email {}: {}",
-                            registration.getEmail(),
-                            e.getMessage());
-                    retryCounts.put(registration, retryCount + 1);
-                    failQueue.add(registration);
-                }
-            }
-            TimeUnit.SECONDS.sleep(1);
-        }
+        log.info(
+                "EventExpiredEvent outbox backfill completed. eventId: {}",
+                eventExpiredEvent.getEventId());
     }
 }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/api/registration/service/RegistrationUseCase.java
@@ -154,7 +154,6 @@ public class RegistrationUseCase {
             User user,
             String email,
             Long eventId) {
-        sector.checkEventLeft();
         registration.setId(tempRegistration.getId()); // update 치기 위해 Id 값을 채워줌
         registration.setCreatedAt(
                 tempRegistration.getCreatedAt()); // create_at이 null이 들어가지 않게 하기 위해 값을 채워줌
@@ -164,7 +163,8 @@ public class RegistrationUseCase {
 
     private void reFinalRegisterProcess(
             Registration registration, User user, String email, Long sectorId, Long eventId) {
-        eventWithDrawUseCase.issueEvent(registration, user.getId(), sectorId, eventId);
+        eventWithDrawUseCase.issueEvent(
+                registration, user.getId(), registration.getSector(), eventId);
         if (ableRedis) {
             redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);
         }
@@ -176,7 +176,6 @@ public class RegistrationUseCase {
             Long currentUserId,
             String email,
             Long eventId) {
-        sector.checkEventLeft();
         return saveRegistrationProcess(registration, sector, currentUserId, email, eventId);
     }
 
@@ -187,7 +186,7 @@ public class RegistrationUseCase {
             String email,
             Long eventId) {
         //        Registration saveReg = saveAndFlush(registration);
-        eventWithDrawUseCase.issueEvent(registration, currentUserId, sector.getId(), eventId);
+        eventWithDrawUseCase.issueEvent(registration, currentUserId, sector, eventId);
         if (ableRedis) {
             redisService.deleteValues("RT(" + TicketStatic.SERVER + "):" + email);
         }

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/WebLoggingInterceptor.java
@@ -1,28 +1,25 @@
 package com.jnu.ticketapi.config;
 
 
-import com.jnu.ticketapi.security.JwtResolver;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.util.ContentCachingRequestWrapper;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class WebLoggingInterceptor implements HandlerInterceptor {
     private static final String START_TIME_ATTR_NAME = "startTime";
-    private static final String REGISTRATION_PATH = "/api/v1/registration/";
 
     private final WebProperties webProperties;
-    private final JwtResolver jwtResolver;
 
     @Override
     public boolean preHandle(
@@ -33,16 +30,17 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
 
     @Override
     public void afterCompletion(
-            HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
-            throws IOException {
-        if (isSkipLogging(request)) {
-            return;
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler,
+            Exception ex) {
+        try {
+            if (!isSkipLogging(request)) {
+                createRequestLog(request, response);
+            }
+        } finally {
+            MDC.clear();
         }
-
-        createRequestLog(request, response);
-        createAdditionalLog(request);
-
-        MDC.clear();
     }
 
     private boolean isSkipLogging(HttpServletRequest request) {
@@ -54,42 +52,29 @@ public class WebLoggingInterceptor implements HandlerInterceptor {
     }
 
     private void createRequestLog(HttpServletRequest request, HttpServletResponse response) {
-        String currentUserId = getCurrentUserId(request);
+        String currentUserId = getCurrentUserId();
         long executionTime = getExecutionTime(request);
         String requestUrl = request.getRequestURI();
         String method = request.getMethod();
         String responseType = response.getContentType();
+        int responseStatus = response.getStatus();
 
         log.info(
-                "Method: {}, URL: {}, User: {}, ResponseType: {}, ResponseTime: {}ms",
+                "Method: {}, URL: {}, User: {}, Status: {}, ResponseType: {}, ResponseTime: {}ms",
                 method,
                 requestUrl,
                 currentUserId,
+                responseStatus,
                 responseType,
                 executionTime);
     }
 
-    private String getCurrentUserId(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (bearerToken == null) {
+    private String getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
             return "anonymous";
         }
-
-        String accessToken = jwtResolver.extractToken(bearerToken);
-        return jwtResolver.getAuthentication(accessToken).getName();
-    }
-
-    private void createAdditionalLog(HttpServletRequest request) throws IOException {
-        String requestUri = request.getRequestURI();
-        if (requestUri.trim().startsWith(REGISTRATION_PATH)) {
-            log.info("[registration request] {}", getRequestBody(request));
-        }
-    }
-
-    private String getRequestBody(HttpServletRequest request) {
-        ContentCachingRequestWrapper wrapRequest = (ContentCachingRequestWrapper) request;
-        byte[] contents = wrapRequest.getContentAsByteArray();
-        return new String(contents, StandardCharsets.UTF_8);
+        return authentication.getName();
     }
 
     private long getExecutionTime(HttpServletRequest request) {

--- a/Ticket-Api/src/main/java/com/jnu/ticketapi/config/response/GlobalExceptionHandler.java
+++ b/Ticket-Api/src/main/java/com/jnu/ticketapi/config/response/GlobalExceptionHandler.java
@@ -112,11 +112,31 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             TicketCodeException e, HttpServletRequest request) {
         BaseErrorCode code = e.getErrorCode();
         ErrorReason errorReason = code.getErrorReason();
-        log.info("TicketCodeException", e);
+        logTicketCodeException(errorReason, request, e);
         ErrorResponse errorResponse =
                 new ErrorResponse(errorReason, request.getRequestURL().toString());
         return ResponseEntity.status(HttpStatus.valueOf(errorReason.getStatus()))
                 .body(errorResponse);
+    }
+
+    private void logTicketCodeException(
+            ErrorReason errorReason, HttpServletRequest request, TicketCodeException exception) {
+        HttpStatus status = HttpStatus.valueOf(errorReason.getStatus());
+        if (status.is5xxServerError()) {
+            log.error(
+                    "TicketCodeException: code={}, method={}, uri={}",
+                    errorReason.getCode(),
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    exception);
+            return;
+        }
+
+        log.debug(
+                "TicketCodeException: code={}, method={}, uri={}",
+                errorReason.getCode(),
+                request.getMethod(),
+                request.getRequestURI());
     }
 
     /** Request Param Validation 예외 처리 */

--- a/Ticket-Api/src/main/resources/db/teardown.sql
+++ b/Ticket-Api/src/main/resources/db/teardown.sql
@@ -7,6 +7,7 @@ truncate table captcha_tb;
 truncate table captcha_log_tb;
 truncate table council_tb;
 truncate table credential_code_tb;
+truncate table email_outbox;
 truncate table event;
 truncate table notice_tb;
 truncate table registration_tb;
@@ -69,4 +70,3 @@ values (1, '공지사항입니다.', '공지사항', CURRENT_TIMESTAMP);
 
 insert into notice_tb(id, created_at, modified_at, content)
 values (1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '안내사항입니다.');
-

--- a/Ticket-Api/src/main/resources/logback.xml
+++ b/Ticket-Api/src/main/resources/logback.xml
@@ -97,13 +97,34 @@
         </filter>
     </appender>
 
-    <root level="${LOGGING_LEVEL_ROOT}">
+    <appender name="ASYNC_CONSOLE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <includeCallerData>false</includeCallerData>
         <appender-ref ref="CONSOLE" />
+    </appender>
+
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <includeCallerData>false</includeCallerData>
         <appender-ref ref="FILE" />
+    </appender>
+
+    <appender name="ASYNC_SPECIAL_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>8192</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <includeCallerData>false</includeCallerData>
+        <appender-ref ref="SPECIAL_FILE" />
+    </appender>
+
+    <root level="${LOGGING_LEVEL_ROOT}">
+        <appender-ref ref="ASYNC_CONSOLE" />
+        <appender-ref ref="ASYNC_FILE" />
     </root>
 
     <logger name="processTracker" level="INFO" additivity="false">
-        <appender-ref ref="SPECIAL_FILE"/>
+        <appender-ref ref="ASYNC_SPECIAL_FILE"/>
     </logger>
 
 </configuration>

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -5,7 +5,6 @@ import com.jnu.ticketapi.api.event.model.request.UpdateEventPublishRequest;
 import com.jnu.ticketapi.api.registration.model.request.FinalSaveRequest;
 import com.jnu.ticketapi.api.registration.model.request.TemporarySaveRequest;
 import com.jnu.ticketapi.api.sector.model.request.SectorRegisterRequest;
-import com.jnu.ticketapi.api.user.ResultAssignment;
 import com.jnu.ticketapi.registration.FinalSaveRequestTestDataBuilder;
 import com.jnu.ticketapi.registration.TemporarySaveRequestTestDataBuilder;
 import com.jnu.ticketapi.security.JwtGenerator;
@@ -14,6 +13,7 @@ import com.jnu.ticketbatch.config.QuartzJobLauncher;
 import com.jnu.ticketdomain.common.vo.DateTimePeriod;
 import com.jnu.ticketdomain.domains.captcha.domain.Captcha;
 import com.jnu.ticketdomain.domains.captcha.repository.CaptchaRepository;
+import com.jnu.ticketdomain.domains.email.repository.EmailOutboxRepository;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.repository.EventRepository;
@@ -33,11 +33,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -60,14 +62,14 @@ import static org.quartz.TriggerBuilder.newTrigger;
 
 @Slf4j
 @ActiveProfiles("integration-test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class FlowTest implements UsingContainers {
 
-    // production 환경변수 값
-    private static final int ASYNC_CORE_POOL_SIZE = 1000;
-    private static final int ASYNC_MAX_POOL_SIZE = 1000;
-    private static final int ASYNC_QUEUE_CAPACITY = 50000;
-    private static final int HIKARI_MAXIMUM_POOL_SIZE = 2000;
+    private static final int ASYNC_CORE_POOL_SIZE = 32;
+    private static final int ASYNC_MAX_POOL_SIZE = 64;
+    private static final int ASYNC_QUEUE_CAPACITY = 5000;
+    private static final int HIKARI_MAXIMUM_POOL_SIZE = 64;
 
     private static final Long EVENT_VALUE = 1L;
     private static final String BEARER_PREFIX = "Bearer ";
@@ -82,6 +84,7 @@ public class FlowTest implements UsingContainers {
     @DynamicPropertySource
     static void hikariProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.datasource.hikari.maximum-pool-size", () -> HIKARI_MAXIMUM_POOL_SIZE);
+        registry.add("spring.redis.command-timeout-ms", () -> 5000);
     }
 
     @Autowired
@@ -109,7 +112,7 @@ public class FlowTest implements UsingContainers {
     RedisRepository redisRepository;
 
     @Autowired
-    ResultAssignment resultAssignment;
+    EmailOutboxRepository emailOutboxRepository;
 
     private record Setting(int capacity, int reserve, int requestCount) {
     }
@@ -162,7 +165,7 @@ public class FlowTest implements UsingContainers {
 
         // when
         ExecutorService executorServiceForSector = Executors.newFixedThreadPool(settings.size());
-        ExecutorService executorServiceInSector = Executors.newCachedThreadPool();
+        ExecutorService executorServiceInSector = Executors.newFixedThreadPool(32);
         AtomicInteger successFinalSaveCount = new AtomicInteger();
         AtomicInteger rejectedFinalSaveCount = new AtomicInteger();
         AtomicInteger studentNumSequence = new AtomicInteger(100_000);
@@ -185,14 +188,12 @@ public class FlowTest implements UsingContainers {
         executorServiceForSector.shutdown();
         executorServiceForSector.awaitTermination(60, SECONDS);
         executorServiceInSector.shutdown();
-        executorServiceInSector.awaitTermination(60, SECONDS);
+        assertThat(executorServiceInSector.awaitTermination(120, SECONDS)).isTrue();
         throwIfRequestError(requestErrors);
         assertFinalSaveRequestCounts(
                 successFinalSaveCount.get(), rejectedFinalSaveCount.get(), issuedCountSum, userCountSum - issuedCountSum);
 
         awaitAllRegistrationsSaved(issuedCountSum);
-
-        resultAssignment.assign(EVENT_VALUE);
 
         // then
         List<User> usersWithResult = userRepository.findAll(Sort.by("id"));
@@ -210,12 +211,14 @@ public class FlowTest implements UsingContainers {
             softly.assertThat(successFinalSaveCount.get()).isEqualTo(issuedCountSum);
             softly.assertThat(rejectedFinalSaveCount.get()).isEqualTo(userCountSum - issuedCountSum);
             softly.assertThat(savedRegistrations).hasSize(issuedCountSum);
+            softly.assertThat(emailOutboxRepository.count()).isEqualTo(issuedCountSum.longValue());
             softly.assertThat(resultByGroup.getOrDefault(SUCCESS, Collections.emptyList())).hasSize(capacityCountSum);
             softly.assertThat(resultByGroup.getOrDefault(PREPARE, Collections.emptyList())).hasSize(reserveCountSum);
             softly.assertThat(resultByGroup.getOrDefault(FAIL, Collections.emptyList())).hasSize(userCountSum - (capacityCountSum + reserveCountSum));
         });
 
         assertPerSector(usersWithResult, settings);
+        assertRegistrationDecisions(savedRegistrations, settings);
     }
 
     private void printRegistrationsWithUserStatus(List<Registration> registrations, List<User> usersWithResult) {
@@ -304,6 +307,7 @@ public class FlowTest implements UsingContainers {
                 try {
                     WebTestClient newClient = client.mutate()
                             .defaultHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken)
+                            .responseTimeout(Duration.ofSeconds(30))
                             .build();
 
                     String captchaCode = newClient.get().uri("/v1/captcha")
@@ -378,6 +382,46 @@ public class FlowTest implements UsingContainers {
                 softly.assertThat(preparedNumbers).containsExactlyInAnyOrderElementsOf(expectedPreparedNumbers);
             });
             i++;
+        }
+    }
+
+    private void assertRegistrationDecisions(
+            List<Registration> registrations, List<Setting> settings) {
+        for (int index = 0; index < settings.size(); index++) {
+            long sectorId = index + 1L;
+            Setting setting = settings.get(index);
+            int issueAmount = setting.capacity() + setting.reserve();
+            List<Registration> sectorRegistrations = registrations.stream()
+                    .filter(registration -> registration.getSector().getId().equals(sectorId))
+                    .toList();
+            Map<UserStatus, List<Registration>> registrationsByResult = sectorRegistrations.stream()
+                    .collect(Collectors.groupingBy(Registration::getResultStatus));
+
+            assertSoftly(softly -> {
+                softly.assertThat(sectorRegistrations).hasSize(issueAmount);
+                softly.assertThat(sectorRegistrations)
+                        .extracting(Registration::getPosition)
+                        .containsExactlyInAnyOrderElementsOf(
+                                IntStream.rangeClosed(1, issueAmount).boxed().toList());
+                softly.assertThat(registrationsByResult.getOrDefault(SUCCESS, List.of()))
+                        .hasSize(setting.capacity())
+                        .extracting(Registration::getPosition)
+                        .allMatch(position -> position <= setting.capacity());
+                softly.assertThat(registrationsByResult.getOrDefault(PREPARE, List.of()))
+                        .hasSize(setting.reserve())
+                        .extracting(Registration::getSequence)
+                        .containsExactlyInAnyOrderElementsOf(
+                                IntStream.rangeClosed(1, setting.reserve()).boxed().toList());
+                softly.assertThat(sectorRegistrations)
+                        .extracting(Registration::getSavedAt)
+                        .doesNotContainNull();
+                softly.assertThat(
+                                redisRepository.getIntegerValue(
+                                        "parking-ticket:event:{1}:sector:"
+                                                + sectorId
+                                                + ":stock"))
+                        .contains(0);
+            });
         }
     }
 

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/FlowTest.java
@@ -25,6 +25,7 @@ import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketdomain.domains.user.repository.UserRepository;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.quartz.*;
@@ -41,14 +42,17 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.jnu.ticketdomain.domains.user.domain.UserStatus.*;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.awaitility.Awaitility.await;
 import static org.quartz.JobBuilder.newJob;
@@ -112,6 +116,13 @@ public class FlowTest implements UsingContainers {
 
     private Long USER_IDENTIFIER = 1L;
 
+    @AfterEach
+    void tearDown() throws SchedulerException {
+        if (!scheduler.isShutdown()) {
+            scheduler.shutdown(true);
+        }
+    }
+
 
     /**
      * Setting record 통해서 구간별 여석, 예비, 요청 수 설정 가능
@@ -134,6 +145,7 @@ public class FlowTest implements UsingContainers {
         Integer capacityCountSum = settings.stream().map(Setting::capacity).reduce(0, Integer::sum);
         Integer reserveCountSum = settings.stream().map(Setting::reserve).reduce(0, Integer::sum);
         Integer userCountSum = settings.stream().map(Setting::requestCount).reduce(0, Integer::sum);
+        Integer issuedCountSum = capacityCountSum + reserveCountSum;
 
         List<List<String>> userAccessTokens = setUpAccessTokensPerSector(settings);
 
@@ -151,18 +163,34 @@ public class FlowTest implements UsingContainers {
         // when
         ExecutorService executorServiceForSector = Executors.newFixedThreadPool(settings.size());
         ExecutorService executorServiceInSector = Executors.newCachedThreadPool();
+        AtomicInteger successFinalSaveCount = new AtomicInteger();
+        AtomicInteger rejectedFinalSaveCount = new AtomicInteger();
+        AtomicInteger studentNumSequence = new AtomicInteger(100_000);
+        Queue<Throwable> requestErrors = new ConcurrentLinkedQueue<>();
 
         for (int i = 0; i < settings.size(); i++) {
             int sectorId = i + 1;
             List<String> accessTokensPerSector = userAccessTokens.get(i);
-            executorServiceForSector.submit(() -> finalSaveRequestToSector(sectorId, accessTokensPerSector, executorServiceInSector));
+            executorServiceForSector.submit(
+                    () ->
+                            finalSaveRequestToSector(
+                                    sectorId,
+                                    accessTokensPerSector,
+                                    executorServiceInSector,
+                                    successFinalSaveCount,
+                                    rejectedFinalSaveCount,
+                                    studentNumSequence,
+                                    requestErrors));
         }
         executorServiceForSector.shutdown();
         executorServiceForSector.awaitTermination(60, SECONDS);
         executorServiceInSector.shutdown();
         executorServiceInSector.awaitTermination(60, SECONDS);
+        throwIfRequestError(requestErrors);
+        assertFinalSaveRequestCounts(
+                successFinalSaveCount.get(), rejectedFinalSaveCount.get(), issuedCountSum, userCountSum - issuedCountSum);
 
-        awaitAllRegistrationsSaved(userCountSum);
+        awaitAllRegistrationsSaved(issuedCountSum);
 
         resultAssignment.assign(EVENT_VALUE);
 
@@ -170,6 +198,8 @@ public class FlowTest implements UsingContainers {
         List<User> usersWithResult = userRepository.findAll(Sort.by("id"));
         List<Registration> resultRegistration = registrationRepository.findSortedRegistrationsByEventId(EVENT_VALUE);
         List<Registration> registrations = registrationRepository.findAll();
+        List<Registration> savedRegistrations =
+                registrations.stream().filter(Registration::isSaved).toList();
 
         Map<UserStatus, List<User>> resultByGroup = usersWithResult.stream()
                 .collect(Collectors.groupingBy(User::getStatus, Collectors.toList()));
@@ -177,7 +207,9 @@ public class FlowTest implements UsingContainers {
         printRegistrationsWithUserStatus(resultRegistration, usersWithResult);
 
         assertSoftly(softly -> {
-            softly.assertThat(registrations).hasSize(userCountSum);
+            softly.assertThat(successFinalSaveCount.get()).isEqualTo(issuedCountSum);
+            softly.assertThat(rejectedFinalSaveCount.get()).isEqualTo(userCountSum - issuedCountSum);
+            softly.assertThat(savedRegistrations).hasSize(issuedCountSum);
             softly.assertThat(resultByGroup.getOrDefault(SUCCESS, Collections.emptyList())).hasSize(capacityCountSum);
             softly.assertThat(resultByGroup.getOrDefault(PREPARE, Collections.emptyList())).hasSize(reserveCountSum);
             softly.assertThat(resultByGroup.getOrDefault(FAIL, Collections.emptyList())).hasSize(userCountSum - (capacityCountSum + reserveCountSum));
@@ -259,30 +291,71 @@ public class FlowTest implements UsingContainers {
                 .toList();
     }
 
-    private void finalSaveRequestToSector(long sectorId, List<String> accessTokens, ExecutorService executorService) {
+    private void finalSaveRequestToSector(
+            long sectorId,
+            List<String> accessTokens,
+            ExecutorService executorService,
+            AtomicInteger successFinalSaveCount,
+            AtomicInteger rejectedFinalSaveCount,
+            AtomicInteger studentNumSequence,
+            Queue<Throwable> requestErrors) {
         for (String accessToken : accessTokens) {
             executorService.execute(() -> {
-                WebTestClient newClient = client.mutate()
-                        .defaultHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken)
-                        .build();
+                try {
+                    WebTestClient newClient = client.mutate()
+                            .defaultHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken)
+                            .build();
 
-                String captchaCode = newClient.get().uri("/v1/captcha")
-                        .exchange().expectStatus().isOk()
-                        .expectBody(CaptchaResponse.class)
-                        .returnResult().getResponseBody().captchaCode();
+                    String captchaCode = newClient.get().uri("/v1/captcha")
+                            .exchange().expectStatus().isOk()
+                            .expectBody(CaptchaResponse.class)
+                            .returnResult().getResponseBody().captchaCode();
 
-                FinalSaveRequest request2 = FinalSaveRequestTestDataBuilder
-                        .builder()
-                        .withSelectSectorId(sectorId)
-                        .withCaptchaCode(captchaCode)
-                        .withCaptchaAnswer("1")
-                        .build();
+                    FinalSaveRequest request2 = FinalSaveRequestTestDataBuilder
+                            .builder()
+                            .withSelectSectorId(sectorId)
+                            .withStudentNum(String.valueOf(studentNumSequence.incrementAndGet()))
+                            .withCaptchaCode(captchaCode)
+                            .withCaptchaAnswer("1")
+                            .build();
 
-                newClient.post().uri("/v1/registration/{event-id}", EVENT_VALUE)
-                        .bodyValue(request2)
-                        .exchange().expectStatus().isOk();
+                    int statusCode = newClient.post().uri("/v1/registration/{event-id}", EVENT_VALUE)
+                            .bodyValue(request2)
+                            .exchange()
+                            .expectBody()
+                            .returnResult()
+                            .getStatus()
+                            .value();
+
+                    if (statusCode >= 200 && statusCode < 300) {
+                        successFinalSaveCount.incrementAndGet();
+                        return;
+                    }
+                    if (statusCode >= 400 && statusCode < 500) {
+                        rejectedFinalSaveCount.incrementAndGet();
+                        return;
+                    }
+                    requestErrors.add(new AssertionError("Unexpected finalSave status: " + statusCode));
+                } catch (Throwable e) {
+                    requestErrors.add(e);
+                }
             });
         }
+    }
+
+    private void throwIfRequestError(Queue<Throwable> requestErrors) {
+        Throwable requestError = requestErrors.peek();
+        if (requestError != null) {
+            throw new AssertionError("finalSave 요청 중 예상하지 못한 오류가 발생했습니다.", requestError);
+        }
+    }
+
+    private void assertFinalSaveRequestCounts(
+            int successCount, int rejectedCount, int expectedSuccessCount, int expectedRejectedCount) {
+        assertSoftly(softly -> {
+            softly.assertThat(successCount).isEqualTo(expectedSuccessCount);
+            softly.assertThat(rejectedCount).isEqualTo(expectedRejectedCount);
+        });
     }
 
     private void assertPerSector(List<User> usersWithResult, List<Setting> settings) {
@@ -440,9 +513,13 @@ public class FlowTest implements UsingContainers {
     private void awaitAllRegistrationsSaved(int expectedSavedCount) {
         await().atMost(60, SECONDS)
                 .pollInterval(200, MILLISECONDS)
-                .until(() -> registrationRepository.findAll().stream()
-                        .filter(Registration::isSaved)
-                        .count() == expectedSavedCount);
+                .untilAsserted(() -> {
+                    long savedCount =
+                            registrationRepository.findAll().stream()
+                                    .filter(Registration::isSaved)
+                                    .count();
+                    assertThat(savedCount).isEqualTo(expectedSavedCount);
+                });
         System.out.println("============데이터 처리 완료===============");
     }
 
@@ -460,5 +537,3 @@ public class FlowTest implements UsingContainers {
     }
 
 }
-
-

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/RestDocsConfig.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/RestDocsConfig.java
@@ -1,6 +1,9 @@
 package com.jnu.ticketapi;
 
 
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
+
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +27,7 @@ public class RestDocsConfig {
     public void setup(
             WebApplicationContext webApplicationContext,
             RestDocumentationContextProvider restDocumentation) {
+        clearRedisState(webApplicationContext);
         this.document =
                 MockMvcRestDocumentation.document(
                         "{class-name}/{method-name}",
@@ -39,5 +43,15 @@ public class RestDocsConfig {
                         // .apply(SecurityMockMvcConfigurers.springSecurity())
                         .alwaysDo(document)
                         .build();
+    }
+
+    private void clearRedisState(WebApplicationContext webApplicationContext) {
+        webApplicationContext
+                .getBeanProvider(RedisRepository.class)
+                .ifAvailable(
+                        redisRepository -> {
+                            redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
+                            redisRepository.deleteKeysByPrefix("parking-ticket:event:");
+                        });
     }
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/RestDocsConfig.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/RestDocsConfig.java
@@ -1,6 +1,5 @@
 package com.jnu.ticketapi;
 
-
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
@@ -51,6 +50,7 @@ public class RestDocsConfig {
                 .ifAvailable(
                         redisRepository -> {
                             redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
+                            redisRepository.deleteKeysByPrefix(REDIS_EVENT_ISSUE_STREAM + ":");
                             redisRepository.deleteKeysByPrefix("parking-ticket:event:");
                         });
     }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -184,6 +184,28 @@ class EventIssuedEventHandlerTest {
         verify(emailOutboxAdaptor).saveRegistrationResultIfAbsent(registration);
     }
 
+    @Test
+    @DisplayName("Redis에서 확정된 position과 결과가 있으면 DB count 없이 그대로 저장한다")
+    void processQueueDataUsesRedisDecisionWithoutCountingOrDecreasingStock() {
+        Registration registration = registration();
+        User user = user();
+        ChatMessage message = new ChatMessage("{}", 100L, 1L, 10L, 3, UserStatus.PREPARE, 1);
+        when(userAdaptor.findById(100L)).thenReturn(user);
+        when(registrationAdaptor.save(registration)).thenReturn(registration);
+
+        eventIssuedEventHandler.processQueueData(sector, registration, message);
+
+        assertThat(registration.getPosition()).isEqualTo(3);
+        assertThat(registration.getResultStatus()).isEqualTo(UserStatus.PREPARE);
+        assertThat(registration.getSequence()).isEqualTo(1);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.PREPARE);
+        assertThat(user.getSequence()).isEqualTo(1);
+        verify(registrationAdaptor, never())
+                .countSavedBySectorId(org.mockito.ArgumentMatchers.any());
+        verify(sector, never()).decreaseEventStock();
+        verify(emailOutboxAdaptor).saveRegistrationResultIfAbsent(registration);
+    }
+
     private void givenQueuedRegistrationSector() {
         when(sectorAdaptor.findByIdForUpdate(2L)).thenReturn(sector);
         when(sector.getId()).thenReturn(2L);

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -1,0 +1,135 @@
+package com.jnu.ticketapi.api.event.handler;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class EventIssuedEventHandlerTest {
+
+    @Mock private RegistrationAdaptor registrationAdaptor;
+    @Mock private UserAdaptor userAdaptor;
+    @Mock private SectorAdaptor sectorAdaptor;
+    @Mock private WaitingQueueService waitingQueueService;
+    @Mock private Sector sector;
+    @Mock private User user;
+
+    private EventIssuedEventHandler eventIssuedEventHandler;
+
+    @BeforeEach
+    void setUp() {
+        eventIssuedEventHandler =
+                new EventIssuedEventHandler(
+                        registrationAdaptor, userAdaptor, sectorAdaptor, new ObjectMapper());
+        ReflectionTestUtils.setField(
+                eventIssuedEventHandler, "waitingQueueService", waitingQueueService);
+    }
+
+    @AfterEach
+    void clearTransactionSynchronization() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+    }
+
+    @Test
+    @DisplayName("DB 트랜잭션이 커밋된 뒤에만 Stream record를 ACK하고 삭제한다")
+    void handleAcknowledgesStreamRecordAfterCommit() {
+        EventIssuedEvent event = event("1-0", registrationJson());
+        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(sector.isRemainingAmount()).thenReturn(true);
+        when(userAdaptor.findById(1L)).thenReturn(user);
+        beginTransactionSynchronization();
+
+        eventIssuedEventHandler.handle(event);
+
+        verify(waitingQueueService, never())
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+
+        commitSynchronizations();
+
+        verify(waitingQueueService)
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+    }
+
+    @Test
+    @DisplayName("처리에 실패하면 예외를 다시 던지고 Stream record를 ACK하지 않는다")
+    void handleKeepsStreamRecordPendingOnFailure() {
+        EventIssuedEvent event = event("2-0", "not-json");
+        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+
+        assertThatThrownBy(() -> eventIssuedEventHandler.handle(event))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(waitingQueueService, never())
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "2-0");
+    }
+
+    @Test
+    @DisplayName("ID가 없는 신규 신청도 같은 이벤트와 이메일로 이미 저장됐다면 재처리하지 않는다")
+    void handleSkipsRedeliveredRegistrationWithoutId() {
+        EventIssuedEvent event = event("3-0", registrationJson());
+        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(registrationAdaptor.existsByEmailAndIsSavedTrue("student@jnu.ac.kr", 3L))
+                .thenReturn(true);
+
+        eventIssuedEventHandler.handle(event);
+
+        verify(userAdaptor, never()).findById(1L);
+        verify(registrationAdaptor, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(waitingQueueService)
+                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "3-0");
+    }
+
+    private void beginTransactionSynchronization() {
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    private void commitSynchronizations() {
+        List<TransactionSynchronization> synchronizations =
+                TransactionSynchronizationManager.getSynchronizations();
+        synchronizations.forEach(TransactionSynchronization::afterCommit);
+    }
+
+    private EventIssuedEvent event(String recordId, String registration) {
+        return EventIssuedEvent.from(new ChatMessage(registration, 1L, 2L, 3L), recordId);
+    }
+
+    private String registrationJson() {
+        return "{\"email\":\"student@jnu.ac.kr\","
+                + "\"name\":\"학생\","
+                + "\"studentNum\":\"20240001\","
+                + "\"carNum\":\"12가3456\","
+                + "\"phoneNum\":\"010-0000-0000\","
+                + "\"isLight\":false,"
+                + "\"isSaved\":false,"
+                + "\"isDeleted\":false,"
+                + "\"eventId\":3}";
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -1,20 +1,27 @@
 package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
 import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.adaptor.UserAdaptor;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserRole;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,10 +41,11 @@ class EventIssuedEventHandlerTest {
 
     @Mock private RegistrationAdaptor registrationAdaptor;
     @Mock private UserAdaptor userAdaptor;
+    @Mock private EmailOutboxAdaptor emailOutboxAdaptor;
     @Mock private SectorAdaptor sectorAdaptor;
     @Mock private WaitingQueueService waitingQueueService;
     @Mock private Sector sector;
-    @Mock private User user;
+    @Mock private User queuedUser;
 
     private EventIssuedEventHandler eventIssuedEventHandler;
 
@@ -45,7 +53,11 @@ class EventIssuedEventHandlerTest {
     void setUp() {
         eventIssuedEventHandler =
                 new EventIssuedEventHandler(
-                        registrationAdaptor, userAdaptor, sectorAdaptor, new ObjectMapper());
+                        registrationAdaptor,
+                        userAdaptor,
+                        emailOutboxAdaptor,
+                        sectorAdaptor,
+                        new ObjectMapper());
         ReflectionTestUtils.setField(
                 eventIssuedEventHandler, "waitingQueueService", waitingQueueService);
     }
@@ -62,9 +74,10 @@ class EventIssuedEventHandlerTest {
     @DisplayName("DB 트랜잭션이 커밋된 뒤에만 Stream record를 ACK하고 삭제한다")
     void handleAcknowledgesStreamRecordAfterCommit() {
         EventIssuedEvent event = event("1-0", registrationJson());
-        when(sectorAdaptor.findById(2L)).thenReturn(sector);
-        when(sector.isRemainingAmount()).thenReturn(true);
-        when(userAdaptor.findById(1L)).thenReturn(user);
+        givenQueuedRegistrationSector();
+        when(userAdaptor.findById(1L)).thenReturn(queuedUser);
+        when(registrationAdaptor.save(any(Registration.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
         beginTransactionSynchronization();
 
         eventIssuedEventHandler.handle(event);
@@ -82,7 +95,7 @@ class EventIssuedEventHandlerTest {
     @DisplayName("처리에 실패하면 예외를 다시 던지고 Stream record를 ACK하지 않는다")
     void handleKeepsStreamRecordPendingOnFailure() {
         EventIssuedEvent event = event("2-0", "not-json");
-        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(sectorAdaptor.findByIdForUpdate(2L)).thenReturn(sector);
 
         assertThatThrownBy(() -> eventIssuedEventHandler.handle(event))
                 .isInstanceOf(IllegalStateException.class);
@@ -95,16 +108,94 @@ class EventIssuedEventHandlerTest {
     @DisplayName("ID가 없는 신규 신청도 같은 이벤트와 이메일로 이미 저장됐다면 재처리하지 않는다")
     void handleSkipsRedeliveredRegistrationWithoutId() {
         EventIssuedEvent event = event("3-0", registrationJson());
-        when(sectorAdaptor.findById(2L)).thenReturn(sector);
+        when(sectorAdaptor.findByIdForUpdate(2L)).thenReturn(sector);
         when(registrationAdaptor.existsByEmailAndIsSavedTrue("student@jnu.ac.kr", 3L))
                 .thenReturn(true);
 
         eventIssuedEventHandler.handle(event);
 
         verify(userAdaptor, never()).findById(1L);
-        verify(registrationAdaptor, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(registrationAdaptor, never()).save(any());
         verify(waitingQueueService)
                 .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "3-0");
+    }
+
+    @Test
+    @DisplayName("정원 이내 position이면 합격으로 확정하고 outbox를 생성한다")
+    void processQueueDataDecidesSuccess() {
+        Registration registration = registration();
+        User user = user();
+        givenSector(2, 4);
+        when(registrationAdaptor.countSavedBySectorId(1L)).thenReturn(0L);
+        when(userAdaptor.findById(100L)).thenReturn(user);
+        when(registrationAdaptor.save(registration)).thenReturn(registration);
+
+        eventIssuedEventHandler.processQueueData(sector, registration, 100L, 1_234D);
+
+        assertThat(registration.getPosition()).isEqualTo(1);
+        assertThat(registration.getResultStatus()).isEqualTo(UserStatus.SUCCESS);
+        assertThat(registration.getSequence()).isEqualTo(-2);
+        assertThat(registration.getSavedAt()).isEqualTo(1_234L);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.SUCCESS);
+        assertThat(user.getSequence()).isEqualTo(-2);
+        verify(sector).decreaseEventStock();
+        verify(emailOutboxAdaptor).saveRegistrationResultIfAbsent(registration);
+    }
+
+    @Test
+    @DisplayName("정원 초과 예비 정원 이내 position이면 예비 번호로 확정한다")
+    void processQueueDataDecidesPrepare() {
+        Registration registration = registration();
+        User user = user();
+        givenSector(2, 4);
+        when(registrationAdaptor.countSavedBySectorId(1L)).thenReturn(2L);
+        when(userAdaptor.findById(100L)).thenReturn(user);
+        when(registrationAdaptor.save(registration)).thenReturn(registration);
+
+        eventIssuedEventHandler.processQueueData(sector, registration, 100L);
+
+        assertThat(registration.getPosition()).isEqualTo(3);
+        assertThat(registration.getResultStatus()).isEqualTo(UserStatus.PREPARE);
+        assertThat(registration.getSequence()).isEqualTo(1);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.PREPARE);
+        assertThat(user.getSequence()).isEqualTo(1);
+        verify(sector).decreaseEventStock();
+        verify(emailOutboxAdaptor).saveRegistrationResultIfAbsent(registration);
+    }
+
+    @Test
+    @DisplayName("예비 정원까지 초과한 position이면 불합격으로 저장하고 재고는 차감하지 않는다")
+    void processQueueDataDecidesFailWithoutDecreasingStock() {
+        Registration registration = registration();
+        User user = user();
+        givenSector(2, 4);
+        when(registrationAdaptor.countSavedBySectorId(1L)).thenReturn(4L);
+        when(userAdaptor.findById(100L)).thenReturn(user);
+        when(registrationAdaptor.save(registration)).thenReturn(registration);
+
+        eventIssuedEventHandler.processQueueData(sector, registration, 100L);
+
+        assertThat(registration.getPosition()).isEqualTo(5);
+        assertThat(registration.getResultStatus()).isEqualTo(UserStatus.FAIL);
+        assertThat(registration.getSequence()).isEqualTo(-1);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.FAIL);
+        assertThat(user.getSequence()).isEqualTo(-1);
+        verify(sector, never()).decreaseEventStock();
+        verify(emailOutboxAdaptor).saveRegistrationResultIfAbsent(registration);
+    }
+
+    private void givenQueuedRegistrationSector() {
+        when(sectorAdaptor.findByIdForUpdate(2L)).thenReturn(sector);
+        when(sector.getId()).thenReturn(2L);
+        when(sector.getInitSectorCapacity()).thenReturn(1);
+        when(sector.getIssueAmount()).thenReturn(2);
+        when(registrationAdaptor.countSavedBySectorId(2L)).thenReturn(0L);
+    }
+
+    private void givenSector(int initSectorCapacity, int issueAmount) {
+        when(sector.getId()).thenReturn(1L);
+        when(sector.getInitSectorCapacity()).thenReturn(initSectorCapacity);
+        org.mockito.Mockito.lenient().when(sector.getIssueAmount()).thenReturn(issueAmount);
     }
 
     private void beginTransactionSynchronization() {
@@ -133,5 +224,32 @@ class EventIssuedEventHandlerTest {
                 + "\"isSaved\":false,"
                 + "\"isDeleted\":false,"
                 + "\"eventId\":3}";
+    }
+
+    private Registration registration() {
+        Registration registration =
+                Registration.builder()
+                        .email("student@jnu.ac.kr")
+                        .name("학생")
+                        .studentNum("20240001")
+                        .affiliation("공과대학")
+                        .department("컴퓨터공학과")
+                        .carNum("12가3456")
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                        .isSaved(false)
+                        .eventId(10L)
+                        .build();
+        registration.setId(10L);
+        return registration;
+    }
+
+    private User user() {
+        return User.builder()
+                .email("student@jnu.ac.kr")
+                .pwd("encoded-password")
+                .userRole(UserRole.USER)
+                .build();
     }
 }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -1,7 +1,6 @@
 package com.jnu.ticketapi.api.event.handler;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,6 +29,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 @ExtendWith(MockitoExtension.class)
 class EventIssuedEventHandlerTest {
+
+    private static final String EVENT_STREAM_KEY = "쿠폰 발급 스트림:{3}";
 
     @Mock private RegistrationAdaptor registrationAdaptor;
     @Mock private UserAdaptor userAdaptor;
@@ -69,12 +70,12 @@ class EventIssuedEventHandlerTest {
         eventIssuedEventHandler.handle(event);
 
         verify(waitingQueueService, never())
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "1-0");
 
         commitSynchronizations();
 
         verify(waitingQueueService)
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "1-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "1-0");
     }
 
     @Test
@@ -87,7 +88,7 @@ class EventIssuedEventHandlerTest {
                 .isInstanceOf(IllegalStateException.class);
 
         verify(waitingQueueService, never())
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "2-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "2-0");
     }
 
     @Test
@@ -103,7 +104,7 @@ class EventIssuedEventHandlerTest {
         verify(userAdaptor, never()).findById(1L);
         verify(registrationAdaptor, never()).save(org.mockito.ArgumentMatchers.any());
         verify(waitingQueueService)
-                .acknowledgeAndDelete(REDIS_EVENT_ISSUE_STREAM, REDIS_EVENT_ISSUE_GROUP, "3-0");
+                .acknowledgeAndDelete(EVENT_STREAM_KEY, REDIS_EVENT_ISSUE_GROUP, "3-0");
     }
 
     private void beginTransactionSynchronization() {
@@ -118,7 +119,8 @@ class EventIssuedEventHandlerTest {
     }
 
     private EventIssuedEvent event(String recordId, String registration) {
-        return EventIssuedEvent.from(new ChatMessage(registration, 1L, 2L, 3L), recordId);
+        return EventIssuedEvent.from(
+                new ChatMessage(registration, 1L, 2L, 3L), recordId, EVENT_STREAM_KEY);
     }
 
     private String registrationJson() {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/EventIssuedEventHandlerTest.java
@@ -188,7 +188,6 @@ class EventIssuedEventHandlerTest {
         when(sectorAdaptor.findByIdForUpdate(2L)).thenReturn(sector);
         when(sector.getId()).thenReturn(2L);
         when(sector.getInitSectorCapacity()).thenReturn(1);
-        when(sector.getIssueAmount()).thenReturn(2);
         when(registrationAdaptor.countSavedBySectorId(2L)).thenReturn(0L);
     }
 

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/RedisStockSyncWorkerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/handler/RedisStockSyncWorkerTest.java
@@ -1,0 +1,76 @@
+package com.jnu.ticketapi.api.event.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Event;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RedisStockSyncWorkerTest {
+
+    @Mock private SectorAdaptor sectorAdaptor;
+    @Mock private WaitingQueueService waitingQueueService;
+
+    private RedisStockSyncWorker redisStockSyncWorker;
+
+    @BeforeEach
+    void setUp() {
+        redisStockSyncWorker = new RedisStockSyncWorker(sectorAdaptor);
+        ReflectionTestUtils.setField(
+                redisStockSyncWorker, "waitingQueueService", waitingQueueService);
+    }
+
+    @Test
+    @DisplayName("Redis 잔여 재고가 있으면 Sector 재고 필드를 동기화하고 저장한다")
+    void syncSectorUpdatesSectorWhenRedisStockExists() {
+        Sector sector = sector();
+        when(waitingQueueService.findRemainingStock(10L, 20L)).thenReturn(Optional.of(1));
+
+        redisStockSyncWorker.syncSector(sector);
+
+        assertThat(sector.getSectorCapacity()).isZero();
+        assertThat(sector.getReserve()).isEqualTo(1);
+        assertThat(sector.getRemainingAmount()).isEqualTo(1);
+        verify(sectorAdaptor).save(sector);
+    }
+
+    @Test
+    @DisplayName("Redis 잔여 재고가 없으면 Sector를 저장하지 않는다")
+    void syncSectorDoesNothingWhenRedisStockDoesNotExist() {
+        Sector sector = sector();
+        when(waitingQueueService.findRemainingStock(10L, 20L)).thenReturn(Optional.empty());
+
+        redisStockSyncWorker.syncSector(sector);
+
+        verify(sectorAdaptor, never()).save(sector);
+    }
+
+    private Sector sector() {
+        Event event = Event.builder().title("주차권").sector(java.util.List.of()).build();
+        ReflectionTestUtils.setField(event, "id", 10L);
+
+        Sector sector =
+                Sector.builder()
+                        .sectorNumber("1구간")
+                        .name("공과대학")
+                        .sectorCapacity(2)
+                        .reserve(1)
+                        .build();
+        ReflectionTestUtils.setField(sector, "id", 20L);
+        sector.setEvent(event);
+        return sector;
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCaseTest.java
@@ -3,16 +3,16 @@ package com.jnu.ticketapi.api.event.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.jnu.ticketcommon.consts.TicketStatic;
-import com.jnu.ticketcommon.utils.Result;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
+import com.jnu.ticketdomain.domains.events.exception.NotFoundSectorException;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
@@ -29,6 +29,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class EventWithDrawUseCaseTest {
+
+    private static final String EVENT_STREAM_KEY = "쿠폰 발급 스트림:{10}";
 
     @Mock private WaitingQueueService waitingQueueService;
     @Mock private EventAdaptor eventAdaptor;
@@ -52,11 +54,7 @@ class EventWithDrawUseCaseTest {
                 StockReservationResult.reserved(1, UserStatus.SUCCESS, -2, 299);
         givenOpenEvent();
         when(waitingQueueService.reserveAndRegisterQueue(
-                        eq(TicketStatic.REDIS_EVENT_ISSUE_STREAM),
-                        eq(registration),
-                        eq(100L),
-                        eq(sector),
-                        eq(10L)))
+                        eq(EVENT_STREAM_KEY), eq(registration), eq(100L), eq(sector), eq(10L)))
                 .thenReturn(reservationResult);
 
         StockReservationResult result =
@@ -64,8 +62,7 @@ class EventWithDrawUseCaseTest {
 
         assertThat(result).isSameAs(reservationResult);
         verify(waitingQueueService)
-                .reserveAndRegisterQueue(
-                        TicketStatic.REDIS_EVENT_ISSUE_STREAM, registration, 100L, sector, 10L);
+                .reserveAndRegisterQueue(EVENT_STREAM_KEY, registration, 100L, sector, 10L);
     }
 
     @Test
@@ -74,7 +71,7 @@ class EventWithDrawUseCaseTest {
         Registration registration = registration();
         givenOpenEvent();
         when(waitingQueueService.reserveAndRegisterQueue(
-                        TicketStatic.REDIS_EVENT_ISSUE_STREAM, registration, 100L, sector, 10L))
+                        EVENT_STREAM_KEY, registration, 100L, sector, 10L))
                 .thenReturn(StockReservationResult.noStock(0));
 
         assertThatThrownBy(() -> eventWithDrawUseCase.issueEvent(registration, 100L, sector, 10L))
@@ -87,16 +84,41 @@ class EventWithDrawUseCaseTest {
         Registration registration = registration();
         givenOpenEvent();
         when(waitingQueueService.reserveAndRegisterQueue(
-                        TicketStatic.REDIS_EVENT_ISSUE_STREAM, registration, 100L, sector, 10L))
+                        EVENT_STREAM_KEY, registration, 100L, sector, 10L))
                 .thenReturn(StockReservationResult.duplicate(299));
 
         assertThatThrownBy(() -> eventWithDrawUseCase.issueEvent(registration, 100L, sector, 10L))
                 .isSameAs(AlreadyExistRegistrationException.EXCEPTION);
     }
 
-    private void givenOpenEvent() {
-        when(eventAdaptor.findReadyOrOpenEvent()).thenReturn(Result.success(event));
+    @Test
+    @DisplayName("선택한 구간이 요청 이벤트 소속이 아니면 Redis 예약을 거부한다")
+    void issueEventRejectsSectorFromAnotherEvent() throws Exception {
+        Registration registration = registration();
+        Event otherEvent = org.mockito.Mockito.mock(Event.class);
+        when(eventAdaptor.findById(10L)).thenReturn(event);
         when(event.getEventStatus()).thenReturn(EventStatus.OPEN);
+        when(sector.getEvent()).thenReturn(otherEvent);
+        when(otherEvent.getId()).thenReturn(11L);
+
+        assertThatThrownBy(() -> eventWithDrawUseCase.issueEvent(registration, 100L, sector, 10L))
+                .isSameAs(NotFoundSectorException.EXCEPTION);
+
+        verify(waitingQueueService, never())
+                .reserveAndRegisterQueue(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        eq(registration),
+                        eq(100L),
+                        eq(sector),
+                        eq(10L));
+    }
+
+    private void givenOpenEvent() {
+        when(eventAdaptor.findById(10L)).thenReturn(event);
+        when(event.getId()).thenReturn(10L);
+        when(event.getEventStatus()).thenReturn(EventStatus.OPEN);
+        when(sector.getEvent()).thenReturn(event);
+        when(waitingQueueService.eventStreamKey(10L)).thenReturn(EVENT_STREAM_KEY);
     }
 
     private Registration registration() {

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCaseTest.java
@@ -1,0 +1,117 @@
+package com.jnu.ticketapi.api.event.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketcommon.consts.TicketStatic;
+import com.jnu.ticketcommon.utils.Result;
+import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Event;
+import com.jnu.ticketdomain.domains.events.domain.EventStatus;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import com.jnu.ticketinfrastructure.model.StockReservationResult;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EventWithDrawUseCaseTest {
+
+    @Mock private WaitingQueueService waitingQueueService;
+    @Mock private EventAdaptor eventAdaptor;
+    @Mock private Event event;
+    @Mock private Sector sector;
+
+    private EventWithDrawUseCase eventWithDrawUseCase;
+
+    @BeforeEach
+    void setUp() {
+        eventWithDrawUseCase = new EventWithDrawUseCase(eventAdaptor);
+        ReflectionTestUtils.setField(
+                eventWithDrawUseCase, "waitingQueueService", waitingQueueService);
+    }
+
+    @Test
+    @DisplayName("Redis 예약 성공 시 예약 결과를 반환하고 Stream 저장을 위임한다")
+    void issueEventReturnsReservedResult() throws Exception {
+        Registration registration = registration();
+        StockReservationResult reservationResult =
+                StockReservationResult.reserved(1, UserStatus.SUCCESS, -2, 299);
+        givenOpenEvent();
+        when(waitingQueueService.reserveAndRegisterQueue(
+                        eq(TicketStatic.REDIS_EVENT_ISSUE_STREAM),
+                        eq(registration),
+                        eq(100L),
+                        eq(sector),
+                        eq(10L)))
+                .thenReturn(reservationResult);
+
+        StockReservationResult result =
+                eventWithDrawUseCase.issueEvent(registration, 100L, sector, 10L);
+
+        assertThat(result).isSameAs(reservationResult);
+        verify(waitingQueueService)
+                .reserveAndRegisterQueue(
+                        TicketStatic.REDIS_EVENT_ISSUE_STREAM, registration, 100L, sector, 10L);
+    }
+
+    @Test
+    @DisplayName("Redis 예약 결과가 잔여여석 없음이면 기존 잔여여석 예외로 변환한다")
+    void issueEventThrowsNoStockWhenRedisStockIsEmpty() throws Exception {
+        Registration registration = registration();
+        givenOpenEvent();
+        when(waitingQueueService.reserveAndRegisterQueue(
+                        TicketStatic.REDIS_EVENT_ISSUE_STREAM, registration, 100L, sector, 10L))
+                .thenReturn(StockReservationResult.noStock(0));
+
+        assertThatThrownBy(() -> eventWithDrawUseCase.issueEvent(registration, 100L, sector, 10L))
+                .isSameAs(NoEventStockLeftException.EXCEPTION);
+    }
+
+    @Test
+    @DisplayName("Redis 예약 결과가 중복이면 기존 중복 신청 예외로 변환한다")
+    void issueEventThrowsDuplicateWhenRedisReservationIsDuplicate() throws Exception {
+        Registration registration = registration();
+        givenOpenEvent();
+        when(waitingQueueService.reserveAndRegisterQueue(
+                        TicketStatic.REDIS_EVENT_ISSUE_STREAM, registration, 100L, sector, 10L))
+                .thenReturn(StockReservationResult.duplicate(299));
+
+        assertThatThrownBy(() -> eventWithDrawUseCase.issueEvent(registration, 100L, sector, 10L))
+                .isSameAs(AlreadyExistRegistrationException.EXCEPTION);
+    }
+
+    private void givenOpenEvent() {
+        when(eventAdaptor.findReadyOrOpenEvent()).thenReturn(Result.success(event));
+        when(event.getEventStatus()).thenReturn(EventStatus.OPEN);
+    }
+
+    private Registration registration() {
+        return Registration.builder()
+                .email("student@jnu.ac.kr")
+                .name("학생")
+                .studentNum("20240001")
+                .affiliation("공과대학")
+                .department("컴퓨터공학과")
+                .carNum("12가3456")
+                .isLight(false)
+                .phoneNum("010-0000-0000")
+                .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                .isSaved(false)
+                .eventId(10L)
+                .build();
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCaseTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/event/service/EventWithDrawUseCaseTest.java
@@ -13,6 +13,7 @@ import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
 import com.jnu.ticketdomain.domains.events.exception.NotFoundSectorException;
+import com.jnu.ticketdomain.domains.events.exception.NotOpenEventStatusException;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
@@ -89,6 +90,19 @@ class EventWithDrawUseCaseTest {
 
         assertThatThrownBy(() -> eventWithDrawUseCase.issueEvent(registration, 100L, sector, 10L))
                 .isSameAs(AlreadyExistRegistrationException.EXCEPTION);
+    }
+
+    @Test
+    @DisplayName("Redis에서 종료 마커를 확인하면 이벤트 미오픈 예외로 변환한다")
+    void issueEventThrowsNotOpenWhenRedisEventIsClosed() throws Exception {
+        Registration registration = registration();
+        givenOpenEvent();
+        when(waitingQueueService.reserveAndRegisterQueue(
+                        EVENT_STREAM_KEY, registration, 100L, sector, 10L))
+                .thenReturn(StockReservationResult.closed(17));
+
+        assertThatThrownBy(() -> eventWithDrawUseCase.issueEvent(registration, 100L, sector, 10L))
+                .isSameAs(NotOpenEventStatusException.EXCEPTION);
     }
 
     @Test

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
@@ -1,5 +1,6 @@
 package com.jnu.ticketapi.api.registration.handler;
 
+import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -37,21 +38,23 @@ class EmailOutboxWorkerTest {
     @DisplayName("claim에 성공한 outbox 메일 발송이 성공하면 sent_at을 기록한다")
     void sendPendingMarksSentWhenMailSucceeded() {
         givenPendingOutbox();
-        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(true);
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
+                .thenReturn(true);
         when(mailService.sendRegistrationResultMail("student@jnu.ac.kr", "학생", "합격", -2))
                 .thenReturn(true);
 
         emailOutboxWorker.sendPendingRegistrationResultMail();
 
         verify(emailOutboxAdaptor).markSent(1L);
-        verify(emailOutboxAdaptor, never()).releaseAfterFailure(1L);
+        verify(emailOutboxAdaptor, never()).markFailed(1L);
     }
 
     @Test
     @DisplayName("claim에 실패한 outbox는 메일을 보내지 않는다")
     void sendPendingSkipsWhenClaimFailed() {
         givenPendingOutboxWithoutMailPayload();
-        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(false);
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
+                .thenReturn(false);
 
         emailOutboxWorker.sendPendingRegistrationResultMail();
 
@@ -60,16 +63,17 @@ class EmailOutboxWorkerTest {
     }
 
     @Test
-    @DisplayName("메일 발송이 실패하면 outbox claim을 해제하고 재시도 대상으로 남긴다")
-    void sendPendingReleasesClaimWhenMailFailed() {
+    @DisplayName("메일 발송이 실패하면 실패 시각과 재시도 횟수를 기록한다")
+    void sendPendingMarksOutboxFailedWhenMailFailed() {
         givenPendingOutbox();
-        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(true);
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
+                .thenReturn(true);
         when(mailService.sendRegistrationResultMail("student@jnu.ac.kr", "학생", "합격", -2))
                 .thenReturn(false);
 
         emailOutboxWorker.sendPendingRegistrationResultMail();
 
-        verify(emailOutboxAdaptor).releaseAfterFailure(1L);
+        verify(emailOutboxAdaptor).markFailed(1L);
         verify(emailOutboxAdaptor, never()).markSent(1L);
     }
 
@@ -82,7 +86,8 @@ class EmailOutboxWorkerTest {
     }
 
     private void givenPendingOutboxWithoutMailPayload() {
-        when(emailOutboxAdaptor.findPending(eq(20), any(LocalDateTime.class)))
+        when(emailOutboxAdaptor.findPending(
+                        eq(20), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
                 .thenReturn(List.of(outbox));
         when(outbox.getId()).thenReturn(1L);
     }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
@@ -1,0 +1,89 @@
+package com.jnu.ticketapi.api.registration.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import com.jnu.ticketinfrastructure.service.MailService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EmailOutboxWorkerTest {
+
+    @Mock private EmailOutboxAdaptor emailOutboxAdaptor;
+    @Mock private MailService mailService;
+    @Mock private EmailOutbox outbox;
+
+    private EmailOutboxWorker emailOutboxWorker;
+
+    @BeforeEach
+    void setUp() {
+        emailOutboxWorker = new EmailOutboxWorker(emailOutboxAdaptor, mailService);
+    }
+
+    @Test
+    @DisplayName("claim에 성공한 outbox 메일 발송이 성공하면 sent_at을 기록한다")
+    void sendPendingMarksSentWhenMailSucceeded() {
+        givenPendingOutbox();
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(true);
+        when(mailService.sendRegistrationResultMail("student@jnu.ac.kr", "학생", "합격", -2))
+                .thenReturn(true);
+
+        emailOutboxWorker.sendPendingRegistrationResultMail();
+
+        verify(emailOutboxAdaptor).markSent(1L);
+        verify(emailOutboxAdaptor, never()).releaseAfterFailure(1L);
+    }
+
+    @Test
+    @DisplayName("claim에 실패한 outbox는 메일을 보내지 않는다")
+    void sendPendingSkipsWhenClaimFailed() {
+        givenPendingOutboxWithoutMailPayload();
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(false);
+
+        emailOutboxWorker.sendPendingRegistrationResultMail();
+
+        verify(mailService, never()).sendRegistrationResultMail(any(), any(), any(), any());
+        verify(emailOutboxAdaptor, never()).markSent(1L);
+    }
+
+    @Test
+    @DisplayName("메일 발송이 실패하면 outbox claim을 해제하고 재시도 대상으로 남긴다")
+    void sendPendingReleasesClaimWhenMailFailed() {
+        givenPendingOutbox();
+        when(emailOutboxAdaptor.claim(eq(1L), any(LocalDateTime.class))).thenReturn(true);
+        when(mailService.sendRegistrationResultMail("student@jnu.ac.kr", "학생", "합격", -2))
+                .thenReturn(false);
+
+        emailOutboxWorker.sendPendingRegistrationResultMail();
+
+        verify(emailOutboxAdaptor).releaseAfterFailure(1L);
+        verify(emailOutboxAdaptor, never()).markSent(1L);
+    }
+
+    private void givenPendingOutbox() {
+        givenPendingOutboxWithoutMailPayload();
+        when(outbox.getEmail()).thenReturn("student@jnu.ac.kr");
+        when(outbox.getName()).thenReturn("학생");
+        when(outbox.getResultStatus()).thenReturn(UserStatus.SUCCESS);
+        when(outbox.getSequence()).thenReturn(-2);
+    }
+
+    private void givenPendingOutboxWithoutMailPayload() {
+        when(emailOutboxAdaptor.findPending(eq(20), any(LocalDateTime.class)))
+                .thenReturn(List.of(outbox));
+        when(outbox.getId()).thenReturn(1L);
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/api/registration/handler/EmailOutboxWorkerTest.java
@@ -77,6 +77,19 @@ class EmailOutboxWorkerTest {
         verify(emailOutboxAdaptor, never()).markSent(1L);
     }
 
+    @Test
+    @DisplayName("단일 worker는 한 번에 최대 14건의 outbox를 조회한다")
+    void findsAtMostFourteenPendingOutboxesPerRun() {
+        when(emailOutboxAdaptor.findPending(
+                        eq(14), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
+                .thenReturn(List.of());
+
+        emailOutboxWorker.sendPendingRegistrationResultMail();
+
+        verify(emailOutboxAdaptor)
+                .findPending(eq(14), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY));
+    }
+
     private void givenPendingOutbox() {
         givenPendingOutboxWithoutMailPayload();
         when(outbox.getEmail()).thenReturn("student@jnu.ac.kr");
@@ -87,7 +100,7 @@ class EmailOutboxWorkerTest {
 
     private void givenPendingOutboxWithoutMailPayload() {
         when(emailOutboxAdaptor.findPending(
-                        eq(20), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
+                        eq(14), any(LocalDateTime.class), eq(MAX_EMAIL_SEND_RETRY)))
                 .thenReturn(List.of(outbox));
         when(outbox.getId()).thenReturn(1L);
     }

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/config/WebLoggingInterceptorTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/config/WebLoggingInterceptorTest.java
@@ -1,0 +1,95 @@
+package com.jnu.ticketapi.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class WebLoggingInterceptorTest {
+
+    private final Logger logger = (Logger) LoggerFactory.getLogger(WebLoggingInterceptor.class);
+    private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    private Level previousLevel;
+    private boolean previousAdditive;
+
+    @BeforeEach
+    void setUp() {
+        previousLevel = logger.getLevel();
+        previousAdditive = logger.isAdditive();
+        logger.setLevel(Level.INFO);
+        logger.setAdditive(false);
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        logger.detachAppender(appender);
+        logger.setLevel(previousLevel);
+        logger.setAdditive(previousAdditive);
+        appender.stop();
+    }
+
+    @Test
+    @DisplayName("요청 로그는 기존 인증 정보와 HTTP 상태를 사용한다")
+    void logsAuthenticatedUserAndResponseStatus() {
+        WebLoggingInterceptor interceptor = new WebLoggingInterceptor(new WebProperties(List.of()));
+        MockHttpServletRequest request =
+                new MockHttpServletRequest("POST", "/api/v1/registration/3");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(400);
+        response.setContentType("application/json");
+        SecurityContextHolder.getContext()
+                .setAuthentication(
+                        new UsernamePasswordAuthenticationToken("42", "", Collections.emptyList()));
+
+        interceptor.preHandle(request, response, new Object());
+        interceptor.afterCompletion(request, response, new Object(), null);
+
+        assertThat(appender.list)
+                .singleElement()
+                .satisfies(
+                        event -> {
+                            assertThat(event.getLevel()).isEqualTo(Level.INFO);
+                            assertThat(event.getFormattedMessage())
+                                    .contains(
+                                            "Method: POST",
+                                            "URL: /api/v1/registration/3",
+                                            "User: 42",
+                                            "Status: 400");
+                            assertThat(event.getThrowableProxy()).isNull();
+                        });
+    }
+
+    @Test
+    @DisplayName("로그 제외 경로에서도 MDC를 정리한다")
+    void clearsMdcWhenRequestLoggingIsSkipped() {
+        WebLoggingInterceptor interceptor =
+                new WebLoggingInterceptor(new WebProperties(List.of("/api/actuator/*")));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/actuator/health");
+        request.setServletPath("/api/actuator/health");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MDC.put("userId", "42");
+
+        interceptor.preHandle(request, response, new Object());
+        interceptor.afterCompletion(request, response, new Object(), null);
+
+        assertThat(MDC.get("userId")).isNull();
+        assertThat(appender.list).isEmpty();
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/config/response/GlobalExceptionHandlerTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/config/response/GlobalExceptionHandlerTest.java
@@ -1,0 +1,96 @@
+package com.jnu.ticketapi.config.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.jnu.ticketcommon.exception.ErrorResponse;
+import com.jnu.ticketcommon.exception.SecurityContextNotFoundException;
+import com.jnu.ticketdomain.domains.events.exception.NoEventStockLeftException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class GlobalExceptionHandlerTest {
+
+    private final Logger logger = (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    private Level previousLevel;
+    private boolean previousAdditive;
+    private GlobalExceptionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        previousLevel = logger.getLevel();
+        previousAdditive = logger.isAdditive();
+        logger.setLevel(Level.DEBUG);
+        logger.setAdditive(false);
+        appender.start();
+        logger.addAppender(appender);
+        handler = new GlobalExceptionHandler(new MockEnvironment());
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+        logger.setLevel(previousLevel);
+        logger.setAdditive(previousAdditive);
+        appender.stop();
+    }
+
+    @Test
+    @DisplayName("재고 소진은 기존 400 응답을 유지하고 스택 없이 기록한다")
+    void noStockKeepsClientErrorContractWithoutStackTrace() {
+        MockHttpServletRequest request = registrationRequest();
+
+        ResponseEntity<ErrorResponse> response =
+                handler.ticketCodeExceptionHandler(NoEventStockLeftException.EXCEPTION, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo("EVENT_400_2");
+        assertThat(appender.list)
+                .singleElement()
+                .satisfies(
+                        event -> {
+                            assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
+                            assertThat(event.getFormattedMessage())
+                                    .contains(
+                                            "code=EVENT_400_2",
+                                            "method=POST",
+                                            "uri=/api/v1/registration/3");
+                            assertThat(event.getThrowableProxy()).isNull();
+                        });
+    }
+
+    @Test
+    @DisplayName("서버 오류는 ERROR 레벨과 전체 예외 정보를 유지한다")
+    void serverErrorKeepsStackTrace() {
+        MockHttpServletRequest request = registrationRequest();
+
+        ResponseEntity<ErrorResponse> response =
+                handler.ticketCodeExceptionHandler(
+                        SecurityContextNotFoundException.EXCEPTION, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(appender.list)
+                .singleElement()
+                .satisfies(
+                        event -> {
+                            assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+                            assertThat(event.getThrowableProxy()).isNotNull();
+                        });
+    }
+
+    private MockHttpServletRequest registrationRequest() {
+        return new MockHttpServletRequest("POST", "/api/v1/registration/3");
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/redis/RedisStockReservationConcurrencyTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/redis/RedisStockReservationConcurrencyTest.java
@@ -1,0 +1,174 @@
+package com.jnu.ticketapi.redis;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import com.jnu.ticketinfrastructure.model.StockReservationResult;
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class RedisStockReservationConcurrencyTest {
+
+    private static final int REDIS_PORT = 6379;
+
+    @Container
+    private static final GenericContainer<?> REDIS =
+            new GenericContainer<>(DockerImageName.parse("redis:7")).withExposedPorts(REDIS_PORT);
+
+    private LettuceConnectionFactory connectionFactory;
+    private RedisRepository redisRepository;
+
+    @BeforeEach
+    void setUp() {
+        connectionFactory =
+                new LettuceConnectionFactory(REDIS.getHost(), REDIS.getMappedPort(REDIS_PORT));
+        connectionFactory.afterPropertiesSet();
+
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        StringRedisSerializer serializer = new StringRedisSerializer();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(serializer);
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashKeySerializer(serializer);
+        redisTemplate.setHashValueSerializer(serializer);
+        redisTemplate.afterPropertiesSet();
+        redisRepository = new RedisRepository(redisTemplate);
+
+        try (RedisConnection connection = connectionFactory.getConnection()) {
+            connection.serverCommands().flushAll();
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        connectionFactory.destroy();
+    }
+
+    @Test
+    @Timeout(value = 45)
+    @DisplayName("3천 건 동시 예약에서 발급량만 승인하고 position과 결과를 중복 없이 확정한다")
+    void reservesOnlyIssueAmountUnderThreeThousandConcurrentRequests() throws Exception {
+        int requestCount = 3_000;
+        int capacity = 250;
+        int issueAmount = 300;
+        ExecutorService executor = Executors.newFixedThreadPool(64);
+        CountDownLatch startSignal = new CountDownLatch(1);
+
+        try {
+            List<CompletableFuture<StockReservationResult>> futures =
+                    IntStream.range(0, requestCount)
+                            .mapToObj(
+                                    index ->
+                                            CompletableFuture.supplyAsync(
+                                                    () -> {
+                                                        await(startSignal);
+                                                        return reserve(
+                                                                1L,
+                                                                1L,
+                                                                "student" + index + "@jnu.ac.kr",
+                                                                issueAmount,
+                                                                issueAmount,
+                                                                capacity);
+                                                    },
+                                                    executor))
+                            .toList();
+            startSignal.countDown();
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get(40, SECONDS);
+            List<StockReservationResult> results =
+                    futures.stream().map(CompletableFuture::join).toList();
+            List<StockReservationResult> reserved =
+                    results.stream().filter(StockReservationResult::isReserved).toList();
+
+            assertThat(reserved).hasSize(issueAmount);
+            assertThat(results)
+                    .filteredOn(StockReservationResult::isNoStock)
+                    .hasSize(requestCount - issueAmount);
+            assertThat(reserved)
+                    .extracting(StockReservationResult::getPosition)
+                    .containsExactlyInAnyOrderElementsOf(
+                            IntStream.rangeClosed(1, issueAmount).boxed().toList());
+            assertThat(reserved)
+                    .filteredOn(result -> result.getResultStatus() == UserStatus.SUCCESS)
+                    .hasSize(capacity);
+            assertThat(reserved)
+                    .filteredOn(result -> result.getResultStatus() == UserStatus.PREPARE)
+                    .hasSize(issueAmount - capacity)
+                    .extracting(StockReservationResult::getSequence)
+                    .containsExactlyInAnyOrderElementsOf(
+                            IntStream.rangeClosed(1, issueAmount - capacity).boxed().toList());
+            assertThat(redisRepository.getIntegerValue(stockKey(1L, 1L))).contains(0);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("Redis 키가 없으면 DB 잔여여석 다음 position부터 예약하고 이메일 중복은 차감하지 않는다")
+    void initializesFromDatabaseRemainingAmountAndRejectsDuplicateEmail() {
+        StockReservationResult first = reserve(2L, 1L, "student@jnu.ac.kr", 240, 300, 250);
+        StockReservationResult duplicate = reserve(2L, 1L, "student@jnu.ac.kr", 240, 300, 250);
+
+        assertThat(first.isReserved()).isTrue();
+        assertThat(first.getPosition()).isEqualTo(61);
+        assertThat(first.getResultStatus()).isEqualTo(UserStatus.SUCCESS);
+        assertThat(first.getRemainingAmount()).isEqualTo(239);
+        assertThat(duplicate.isDuplicate()).isTrue();
+        assertThat(duplicate.getRemainingAmount()).isEqualTo(239);
+        assertThat(redisRepository.getIntegerValue(stockKey(2L, 1L))).contains(239);
+    }
+
+    private StockReservationResult reserve(
+            Long eventId,
+            Long sectorId,
+            String email,
+            int initialRemainingAmount,
+            int issueAmount,
+            int capacity) {
+        return redisRepository.reserveStockAndAddToStream(
+                stockKey(eventId, sectorId),
+                "parking-ticket:event:{" + eventId + "}:sector:" + sectorId + ":sequence",
+                "parking-ticket:event:{" + eventId + "}:reserved:email",
+                "쿠폰 발급 스트림:{" + eventId + "}",
+                "{\"email\":\"" + email + "\"}",
+                (long) email.hashCode(),
+                sectorId,
+                eventId,
+                email,
+                initialRemainingAmount,
+                issueAmount,
+                capacity);
+    }
+
+    private String stockKey(Long eventId, Long sectorId) {
+        return "parking-ticket:event:{" + eventId + "}:sector:" + sectorId + ":stock";
+    }
+
+    private void await(CountDownLatch startSignal) {
+        try {
+            startSignal.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting to start", e);
+        }
+    }
+}

--- a/Ticket-Api/src/test/java/com/jnu/ticketapi/redis/RedisStockReservationConcurrencyTest.java
+++ b/Ticket-Api/src/test/java/com/jnu/ticketapi/redis/RedisStockReservationConcurrencyTest.java
@@ -137,6 +137,22 @@ class RedisStockReservationConcurrencyTest {
         assertThat(redisRepository.getIntegerValue(stockKey(2L, 1L))).contains(239);
     }
 
+    @Test
+    @DisplayName("이벤트 종료 마커 이후에는 재고와 Stream을 변경하지 않는다")
+    void rejectsReservationAfterEventIsClosed() {
+        StockReservationResult first = reserve(3L, 1L, "first@jnu.ac.kr", 300, 300, 250);
+        redisRepository.set(closedKey(3L), "true", java.time.Duration.ofMinutes(5));
+
+        StockReservationResult closed = reserve(3L, 1L, "late@jnu.ac.kr", 300, 300, 250);
+
+        assertThat(first.isReserved()).isTrue();
+        assertThat(closed.isClosed()).isTrue();
+        assertThat(closed.getRemainingAmount()).isEqualTo(299);
+        assertThat(redisRepository.getIntegerValue(stockKey(3L, 1L))).contains(299);
+        assertThat(redisRepository.xReadGroup(streamKey(3L), "closed-test", "consumer", 10))
+                .hasSize(1);
+    }
+
     private StockReservationResult reserve(
             Long eventId,
             Long sectorId,
@@ -148,7 +164,8 @@ class RedisStockReservationConcurrencyTest {
                 stockKey(eventId, sectorId),
                 "parking-ticket:event:{" + eventId + "}:sector:" + sectorId + ":sequence",
                 "parking-ticket:event:{" + eventId + "}:reserved:email",
-                "쿠폰 발급 스트림:{" + eventId + "}",
+                streamKey(eventId),
+                closedKey(eventId),
                 "{\"email\":\"" + email + "\"}",
                 (long) email.hashCode(),
                 sectorId,
@@ -157,6 +174,14 @@ class RedisStockReservationConcurrencyTest {
                 initialRemainingAmount,
                 issueAmount,
                 capacity);
+    }
+
+    private String closedKey(Long eventId) {
+        return "parking-ticket:event:{" + eventId + "}:closed";
+    }
+
+    private String streamKey(Long eventId) {
+        return "쿠폰 발급 스트림:{" + eventId + "}";
     }
 
     private String stockKey(Long eventId, Long sectorId) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -1,17 +1,18 @@
 package com.jnu.ticketbatch.config;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_CONSUMER;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
-import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
-import java.util.Set;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 
 @Slf4j
 @DisallowConcurrentExecution
@@ -20,20 +21,27 @@ public class ProcessQueueDataJob implements Job {
 
     @Autowired private WaitingQueueService waitingQueueService;
 
+    private static final long READ_COUNT = 100L;
+
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         try {
             // 현재 쓰레드에 ApplicationEventPublisher를 설정
             Events.setPublisher(publisher);
 
-            Set<TypedTuple<Object>> messagesWithScores =
-                    waitingQueueService.findAllWithScore(REDIS_EVENT_ISSUE_STORE);
+            List<StreamQueueMessage> messages =
+                    waitingQueueService.readGroup(
+                            REDIS_EVENT_ISSUE_STREAM,
+                            REDIS_EVENT_ISSUE_GROUP,
+                            REDIS_EVENT_ISSUE_CONSUMER,
+                            READ_COUNT);
 
-            if (!messagesWithScores.isEmpty()) {
-                for (TypedTuple<Object> messageWithScore : messagesWithScores) {
-                    Double score = messageWithScore.getScore();
-                    ChatMessage message = (ChatMessage) messageWithScore.getValue();
-                    Events.raise(EventIssuedEvent.from(message, score));
+            if (!messages.isEmpty()) {
+                for (StreamQueueMessage streamQueueMessage : messages) {
+                    Events.raise(
+                            EventIssuedEvent.from(
+                                    streamQueueMessage.getMessage(),
+                                    streamQueueMessage.getRecordId()));
                 }
             }
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/config/ProcessQueueDataJob.java
@@ -2,7 +2,6 @@ package com.jnu.ticketbatch.config;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_CONSUMER;
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_GROUP;
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketinfrastructure.domainEvent.EventIssuedEvent;
 import com.jnu.ticketinfrastructure.domainEvent.Events;
@@ -28,10 +27,12 @@ public class ProcessQueueDataJob implements Job {
         try {
             // 현재 쓰레드에 ApplicationEventPublisher를 설정
             Events.setPublisher(publisher);
+            Long eventId = context.getMergedJobDataMap().getLong("eventId");
+            String streamKey = waitingQueueService.eventStreamKey(eventId);
 
             List<StreamQueueMessage> messages =
                     waitingQueueService.readGroup(
-                            REDIS_EVENT_ISSUE_STREAM,
+                            streamKey,
                             REDIS_EVENT_ISSUE_GROUP,
                             REDIS_EVENT_ISSUE_CONSUMER,
                             READ_COUNT);
@@ -41,7 +42,8 @@ public class ProcessQueueDataJob implements Job {
                     Events.raise(
                             EventIssuedEvent.from(
                                     streamQueueMessage.getMessage(),
-                                    streamQueueMessage.getRecordId()));
+                                    streamQueueMessage.getRecordId(),
+                                    streamKey));
                 }
             }
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -1,6 +1,6 @@
 package com.jnu.ticketbatch.expired;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STORE;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketdomain.domains.events.EventExpiredEventRaiseGateway;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
@@ -36,7 +36,7 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
-        redisRepository.delete(REDIS_EVENT_ISSUE_STORE);
+        redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 
         JobParameters jobParameters =

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -1,13 +1,11 @@
 package com.jnu.ticketbatch.expired;
 
-import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.jnu.ticketdomain.domains.events.EventExpiredEventRaiseGateway;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
-import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -27,7 +25,6 @@ public class BatchQuartzJob extends QuartzJobBean {
     @Autowired private JobExplorer jobExplorer;
 
     @Autowired EventAdaptor eventAdaptor;
-    @Autowired RedisRepository redisRepository;
     @Autowired RegistrationAdaptor registrationAdaptor;
     @Autowired EventExpiredEventRaiseGateway eventExpiredEventRaiseGateway;
 
@@ -36,7 +33,6 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
-        redisRepository.delete(REDIS_EVENT_ISSUE_STREAM);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 
         JobParameters jobParameters =
@@ -45,7 +41,7 @@ public class BatchQuartzJob extends QuartzJobBean {
                         .addLong("eventId", eventId)
                         .toJobParameters();
         log.info("EventThrow in BatchQuartzJob");
-//        eventExpiredEventRaiseGateway.handle(eventId);
+        //        eventExpiredEventRaiseGateway.handle(eventId);
         try {
             this.jobLauncher.run(this.job, jobParameters);
         } catch (Exception e) {

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -3,10 +3,13 @@ package com.jnu.ticketbatch.expired;
 
 import com.jnu.ticketdomain.domains.events.EventExpiredEventRaiseGateway;
 import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
 import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -21,12 +24,18 @@ import org.springframework.scheduling.quartz.QuartzJobBean;
 @Slf4j
 public class BatchQuartzJob extends QuartzJobBean {
 
+    private static final Duration REDIS_STOCK_DRAIN_TIMEOUT = Duration.ofMinutes(5);
+
     @Autowired private JobLauncher jobLauncher;
     @Autowired private Job job;
     @Autowired private JobExplorer jobExplorer;
 
     @Autowired EventAdaptor eventAdaptor;
-    @Autowired WaitingQueueService waitingQueueService;
+    @Autowired SectorAdaptor sectorAdaptor;
+
+    @Autowired(required = false)
+    WaitingQueueService waitingQueueService;
+
     @Autowired RegistrationAdaptor registrationAdaptor;
     @Autowired EventExpiredEventRaiseGateway eventExpiredEventRaiseGateway;
 
@@ -35,8 +44,8 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
-        waitingQueueService.deleteEventStockKeys(eventId);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
+        syncAndExpireRedisStock(eventId);
 
         JobParameters jobParameters =
                 new JobParametersBuilder(this.jobExplorer)
@@ -51,5 +60,22 @@ public class BatchQuartzJob extends QuartzJobBean {
             log.error("Failed to run batch job", e);
             throw new JobExecutionException(e);
         }
+    }
+
+    void syncAndExpireRedisStock(Long eventId) {
+        if (waitingQueueService == null) {
+            return;
+        }
+        waitingQueueService.markEventStockClosed(eventId, REDIS_STOCK_DRAIN_TIMEOUT);
+        for (Sector sector : sectorAdaptor.findByEventId(eventId)) {
+            waitingQueueService
+                    .findRemainingStock(eventId, sector.getId())
+                    .ifPresent(
+                            remainingAmount -> {
+                                sector.syncRemainingAmount(remainingAmount);
+                                sectorAdaptor.save(sector);
+                            });
+        }
+        waitingQueueService.expireEventStockKeys(eventId, REDIS_STOCK_DRAIN_TIMEOUT);
     }
 }

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/expired/BatchQuartzJob.java
@@ -6,6 +6,7 @@ import com.jnu.ticketdomain.domains.events.adaptor.EventAdaptor;
 import com.jnu.ticketdomain.domains.events.domain.Event;
 import com.jnu.ticketdomain.domains.events.domain.EventStatus;
 import com.jnu.ticketdomain.domains.registration.adaptor.RegistrationAdaptor;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -25,6 +26,7 @@ public class BatchQuartzJob extends QuartzJobBean {
     @Autowired private JobExplorer jobExplorer;
 
     @Autowired EventAdaptor eventAdaptor;
+    @Autowired WaitingQueueService waitingQueueService;
     @Autowired RegistrationAdaptor registrationAdaptor;
     @Autowired EventExpiredEventRaiseGateway eventExpiredEventRaiseGateway;
 
@@ -33,6 +35,7 @@ public class BatchQuartzJob extends QuartzJobBean {
         // JobDataMap에서 eventId를 가져옵니다.
         Long eventId = (Long) context.getJobDetail().getJobDataMap().get("eventId");
         Event event = eventAdaptor.findById(eventId);
+        waitingQueueService.deleteEventStockKeys(eventId);
         eventAdaptor.updateEventStatus(event, EventStatus.CLOSED);
 
         JobParameters jobParameters =

--- a/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
+++ b/Ticket-Batch/src/main/java/com/jnu/ticketbatch/job/EventRegisterJob.java
@@ -38,6 +38,7 @@ public class EventRegisterJob implements Job {
     private static final String GROUP = "group1";
     private static final String ASIA_SEOUL = "Asia/Seoul";
     private static final long OPEN_LEAD_SECONDS = 5L;
+    private static final long QUEUE_DRAIN_GRACE_MINUTES = 5L;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -123,7 +124,11 @@ public class EventRegisterJob implements Job {
                         .build();
 
         Date start = Date.from(startAt.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
-        Date end = Date.from(endAt.atZone(ZoneId.of(ASIA_SEOUL)).toInstant());
+        Date end =
+                Date.from(
+                        endAt.plusMinutes(QUEUE_DRAIN_GRACE_MINUTES)
+                                .atZone(ZoneId.of(ASIA_SEOUL))
+                                .toInstant());
 
         Trigger reserveTrigger =
                 newTrigger()

--- a/Ticket-Batch/src/test/java/com/jnu/ticketbatch/expired/BatchQuartzJobTest.java
+++ b/Ticket-Batch/src/test/java/com/jnu/ticketbatch/expired/BatchQuartzJobTest.java
@@ -1,0 +1,70 @@
+package com.jnu.ticketbatch.expired;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketdomain.domains.events.adaptor.SectorAdaptor;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import com.jnu.ticketinfrastructure.service.WaitingQueueService;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BatchQuartzJobTest {
+
+    @Mock private SectorAdaptor sectorAdaptor;
+    @Mock private WaitingQueueService waitingQueueService;
+    @Mock private Sector sector;
+
+    private BatchQuartzJob batchQuartzJob;
+
+    @BeforeEach
+    void setUp() {
+        batchQuartzJob = new BatchQuartzJob();
+        ReflectionTestUtils.setField(batchQuartzJob, "sectorAdaptor", sectorAdaptor);
+        ReflectionTestUtils.setField(batchQuartzJob, "waitingQueueService", waitingQueueService);
+    }
+
+    @Test
+    @DisplayName("이벤트 종료 시 Redis 잔여재고를 DB에 반영하고 drain 기간 뒤 만료시킨다")
+    void syncAndExpireRedisStockUpdatesDatabaseBeforeExpiration() {
+        when(sectorAdaptor.findByEventId(3L)).thenReturn(List.of(sector));
+        when(sector.getId()).thenReturn(2L);
+        when(waitingQueueService.findRemainingStock(3L, 2L)).thenReturn(Optional.of(0));
+
+        batchQuartzJob.syncAndExpireRedisStock(3L);
+
+        InOrder redisOrder = inOrder(waitingQueueService);
+        redisOrder
+                .verify(waitingQueueService)
+                .markEventStockClosed(3L, Duration.ofMinutes(5));
+        redisOrder.verify(waitingQueueService).findRemainingStock(3L, 2L);
+        redisOrder
+                .verify(waitingQueueService)
+                .expireEventStockKeys(3L, Duration.ofMinutes(5));
+        verify(sector).syncRemainingAmount(0);
+        verify(sectorAdaptor).save(sector);
+        verify(waitingQueueService, never()).deleteEventStockKeys(3L);
+    }
+
+    @Test
+    @DisplayName("Redis가 비활성화된 환경에서는 종료 재고 동기화를 건너뛴다")
+    void syncAndExpireRedisStockSkipsWhenRedisIsDisabled() {
+        ReflectionTestUtils.setField(batchQuartzJob, "waitingQueueService", null);
+
+        batchQuartzJob.syncAndExpireRedisStock(3L);
+
+        verify(sectorAdaptor, never()).findByEventId(3L);
+    }
+}

--- a/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
+++ b/Ticket-Common/src/main/java/com/jnu/ticketcommon/consts/TicketStatic.java
@@ -30,6 +30,9 @@ public class TicketStatic {
 
     public static final String REDIS_EVENT_CHANNEL = "쿠폰 발급 채널";
     public static final String REDIS_EVENT_ISSUE_STORE = "쿠폰 발급 저장소";
+    public static final String REDIS_EVENT_ISSUE_STREAM = "쿠폰 발급 스트림";
+    public static final String REDIS_EVENT_ISSUE_GROUP = "쿠폰 발급 그룹";
+    public static final String REDIS_EVENT_ISSUE_CONSUMER = "쿠폰 발급 소비자";
 
     public static final Integer REGISTRATION_SIZE = 14;
     public static final Integer MAX_EMAIL_SEND_RETRY = 10;

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/adaptor/EmailOutboxAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/adaptor/EmailOutboxAdaptor.java
@@ -23,13 +23,15 @@ public class EmailOutboxAdaptor {
         emailOutboxRepository.save(EmailOutbox.from(registration));
     }
 
-    public List<EmailOutbox> findPending(int size, LocalDateTime staleBefore) {
-        return emailOutboxRepository.findPending(staleBefore, PageRequest.of(0, size));
+    public List<EmailOutbox> findPending(int size, LocalDateTime staleBefore, int maxRetryCount) {
+        return emailOutboxRepository.findPending(
+                staleBefore, maxRetryCount, PageRequest.of(0, size));
     }
 
     @Transactional
-    public boolean claim(Long id, LocalDateTime staleBefore) {
-        return emailOutboxRepository.claim(id, LocalDateTime.now(), staleBefore) == 1;
+    public boolean claim(Long id, LocalDateTime staleBefore, int maxRetryCount) {
+        return emailOutboxRepository.claim(id, LocalDateTime.now(), staleBefore, maxRetryCount)
+                == 1;
     }
 
     @Transactional
@@ -38,7 +40,7 @@ public class EmailOutboxAdaptor {
     }
 
     @Transactional
-    public void releaseAfterFailure(Long id) {
-        emailOutboxRepository.releaseAfterFailure(id);
+    public void markFailed(Long id) {
+        emailOutboxRepository.markFailed(id, LocalDateTime.now());
     }
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/adaptor/EmailOutboxAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/adaptor/EmailOutboxAdaptor.java
@@ -1,0 +1,44 @@
+package com.jnu.ticketdomain.domains.email.adaptor;
+
+
+import com.jnu.ticketcommon.annotation.Adaptor;
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.email.repository.EmailOutboxRepository;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Adaptor
+@RequiredArgsConstructor
+public class EmailOutboxAdaptor {
+    private final EmailOutboxRepository emailOutboxRepository;
+
+    public void saveRegistrationResultIfAbsent(Registration registration) {
+        if (emailOutboxRepository.existsByRegistrationId(registration.getId())) {
+            return;
+        }
+        emailOutboxRepository.save(EmailOutbox.from(registration));
+    }
+
+    public List<EmailOutbox> findPending(int size, LocalDateTime staleBefore) {
+        return emailOutboxRepository.findPending(staleBefore, PageRequest.of(0, size));
+    }
+
+    @Transactional
+    public boolean claim(Long id, LocalDateTime staleBefore) {
+        return emailOutboxRepository.claim(id, LocalDateTime.now(), staleBefore) == 1;
+    }
+
+    @Transactional
+    public void markSent(Long id) {
+        emailOutboxRepository.markSent(id, LocalDateTime.now());
+    }
+
+    @Transactional
+    public void releaseAfterFailure(Long id) {
+        emailOutboxRepository.releaseAfterFailure(id);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/domain/EmailOutbox.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/domain/EmailOutbox.java
@@ -3,8 +3,10 @@ package com.jnu.ticketdomain.domains.email.domain;
 
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import com.jnu.ticketdomain.domains.user.domain.UserStatusConverter;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
@@ -47,6 +49,7 @@ public class EmailOutbox {
     private String name;
 
     @Column(name = "result_status", nullable = false)
+    @Convert(converter = UserStatusConverter.class)
     private UserStatus resultStatus;
 
     @Column(name = "sequence", nullable = false)

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/domain/EmailOutbox.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/domain/EmailOutbox.java
@@ -1,0 +1,100 @@
+package com.jnu.ticketdomain.domains.email.domain;
+
+
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "email_outbox",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_email_outbox_registration_id",
+                    columnNames = "registration_id")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class EmailOutbox {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+    @Column(name = "registration_id", nullable = false)
+    private Long registrationId;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "result_status", nullable = false)
+    private UserStatus resultStatus;
+
+    @Column(name = "sequence", nullable = false)
+    private Integer sequence;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "processing_at")
+    private LocalDateTime processingAt;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Column(name = "retry_count", nullable = false)
+    private Integer retryCount = 0;
+
+    private EmailOutbox(
+            Long eventId,
+            Long registrationId,
+            String email,
+            String name,
+            UserStatus resultStatus,
+            Integer sequence) {
+        this.eventId = eventId;
+        this.registrationId = registrationId;
+        this.email = email;
+        this.name = name;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
+    }
+
+    public static EmailOutbox from(Registration registration) {
+        UserStatus resultStatus =
+                registration.getResultStatus() != null
+                        ? registration.getResultStatus()
+                        : registration.getUser().getStatus();
+        Integer sequence =
+                registration.getSequence() != null
+                        ? registration.getSequence()
+                        : registration.getUser().getSequence();
+        return new EmailOutbox(
+                registration.getEventId(),
+                registration.getId(),
+                registration.getEmail(),
+                registration.getName(),
+                resultStatus,
+                sequence);
+    }
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/repository/EmailOutboxRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/repository/EmailOutboxRepository.java
@@ -1,0 +1,44 @@
+package com.jnu.ticketdomain.domains.email.repository;
+
+
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EmailOutboxRepository extends JpaRepository<EmailOutbox, Long> {
+    boolean existsByRegistrationId(Long registrationId);
+
+    @Query(
+            "select e from EmailOutbox e "
+                    + "where e.sentAt is null "
+                    + "and (e.processingAt is null or e.processingAt < :staleBefore) "
+                    + "order by e.id asc")
+    List<EmailOutbox> findPending(
+            @Param("staleBefore") LocalDateTime staleBefore, Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "update EmailOutbox e set e.processingAt = :now "
+                    + "where e.id = :id "
+                    + "and e.sentAt is null "
+                    + "and (e.processingAt is null or e.processingAt < :staleBefore)")
+    int claim(
+            @Param("id") Long id,
+            @Param("now") LocalDateTime now,
+            @Param("staleBefore") LocalDateTime staleBefore);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update EmailOutbox e set e.sentAt = :sentAt, e.processingAt = null where e.id = :id")
+    int markSent(@Param("id") Long id, @Param("sentAt") LocalDateTime sentAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            "update EmailOutbox e set e.processingAt = null, e.retryCount = e.retryCount + 1 "
+                    + "where e.id = :id")
+    int releaseAfterFailure(@Param("id") Long id);
+}

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/repository/EmailOutboxRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/email/repository/EmailOutboxRepository.java
@@ -16,21 +16,26 @@ public interface EmailOutboxRepository extends JpaRepository<EmailOutbox, Long> 
     @Query(
             "select e from EmailOutbox e "
                     + "where e.sentAt is null "
+                    + "and e.retryCount < :maxRetryCount "
                     + "and (e.processingAt is null or e.processingAt < :staleBefore) "
                     + "order by e.id asc")
     List<EmailOutbox> findPending(
-            @Param("staleBefore") LocalDateTime staleBefore, Pageable pageable);
+            @Param("staleBefore") LocalDateTime staleBefore,
+            @Param("maxRetryCount") int maxRetryCount,
+            Pageable pageable);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
             "update EmailOutbox e set e.processingAt = :now "
                     + "where e.id = :id "
                     + "and e.sentAt is null "
+                    + "and e.retryCount < :maxRetryCount "
                     + "and (e.processingAt is null or e.processingAt < :staleBefore)")
     int claim(
             @Param("id") Long id,
             @Param("now") LocalDateTime now,
-            @Param("staleBefore") LocalDateTime staleBefore);
+            @Param("staleBefore") LocalDateTime staleBefore,
+            @Param("maxRetryCount") int maxRetryCount);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update EmailOutbox e set e.sentAt = :sentAt, e.processingAt = null where e.id = :id")
@@ -38,7 +43,8 @@ public interface EmailOutboxRepository extends JpaRepository<EmailOutbox, Long> 
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
-            "update EmailOutbox e set e.processingAt = null, e.retryCount = e.retryCount + 1 "
-                    + "where e.id = :id")
-    int releaseAfterFailure(@Param("id") Long id);
+            "update EmailOutbox e "
+                    + "set e.processingAt = :failedAt, e.retryCount = e.retryCount + 1 "
+                    + "where e.id = :id and e.sentAt is null")
+    int markFailed(@Param("id") Long id, @Param("failedAt") LocalDateTime failedAt);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/adaptor/SectorAdaptor.java
@@ -27,6 +27,13 @@ public class SectorAdaptor implements SectorRecordPort, SectorLoadPort {
     }
 
     @Override
+    public Sector findByIdForUpdate(Long sectorId) {
+        return sectorRepository
+                .findByIdForUpdate(sectorId)
+                .orElseThrow(() -> NotFoundSectorException.EXCEPTION);
+    }
+
+    @Override
     public List<Sector> findAll() {
         return sectorRepository.findAll();
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/domain/Sector.java
@@ -86,6 +86,17 @@ public class Sector {
         this.reserve = this.initReserve;
     }
 
+    public void syncRemainingAmount(Integer remainingAmount) {
+        int normalizedRemainingAmount = Math.max(0, Math.min(remainingAmount, this.issueAmount));
+        int issuedAmount = this.issueAmount - normalizedRemainingAmount;
+        int issuedCapacityAmount = Math.min(issuedAmount, this.initSectorCapacity);
+        int issuedReserveAmount = Math.max(0, issuedAmount - this.initSectorCapacity);
+
+        this.sectorCapacity = Math.max(0, this.initSectorCapacity - issuedCapacityAmount);
+        this.reserve = Math.max(0, this.initReserve - issuedReserveAmount);
+        this.remainingAmount = normalizedRemainingAmount;
+    }
+
     public void decreaseEventStock() {
         checkEventLeft();
         if (isSectorCapacityRemaining()) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/out/SectorLoadPort.java
@@ -9,6 +9,8 @@ import java.util.List;
 public interface SectorLoadPort {
     Sector findById(Long sectorId);
 
+    Sector findByIdForUpdate(Long sectorId);
+
     List<Sector> findAll();
 
     List<Sector> findByEventId(Long eventId);

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/events/repository/SectorRepository.java
@@ -4,7 +4,9 @@ package com.jnu.ticketdomain.domains.events.repository;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,6 +18,10 @@ public interface SectorRepository extends JpaRepository<Sector, Long> {
 
     @Query("select s from Sector s where s.event.id = :eventId")
     List<Sector> findByEventId(@Param("eventId") Long eventId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Sector s where s.id = :sectorId")
+    Optional<Sector> findByIdForUpdate(@Param("sectorId") Long sectorId);
 
     @Query(
             "select s from Sector s join fetch s.event where s.event.eventStatus = 'OPEN' or s.event.eventStatus = 'READY'")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/adaptor/RegistrationAdaptor.java
@@ -121,6 +121,11 @@ public class RegistrationAdaptor implements RegistrationLoadPort, RegistrationRe
     }
 
     @Override
+    public Long countSavedBySectorId(Long sectorId) {
+        return registrationRepository.countSavedBySectorId(sectorId);
+    }
+
+    @Override
     public List<Registration> findSortedRegistrationsByEventId(Long eventId) {
         return registrationRepository.findSortedRegistrationsByEventId(eventId);
     }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import java.time.LocalDateTime;
 import javax.persistence.*;
 import lombok.*;
@@ -76,6 +77,15 @@ public class Registration {
     @Column(name = "saved_at")
     private Long savedAt;
 
+    @Column(name = "position")
+    private Integer position;
+
+    @Column(name = "result_status")
+    private UserStatus resultStatus;
+
+    @Column(name = "sequence")
+    private Integer sequence;
+
     @JsonBackReference(value = "user-registration")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -102,6 +112,9 @@ public class Registration {
             LocalDateTime createdAt,
             boolean isSaved,
             Long savedAt,
+            Integer position,
+            UserStatus resultStatus,
+            Integer sequence,
             User user,
             Sector sector,
             Long eventId) {
@@ -116,6 +129,9 @@ public class Registration {
         this.createdAt = createdAt;
         this.isSaved = isSaved;
         this.savedAt = savedAt;
+        this.position = position;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
         this.user = user;
         this.sector = sector;
         this.eventId = eventId;
@@ -135,6 +151,9 @@ public class Registration {
             @JsonProperty("isSaved") boolean isSaved,
             @JsonProperty("isDeleted") boolean isDeleted,
             @JsonProperty("savedAt") Long savedAt,
+            @JsonProperty("position") Integer position,
+            @JsonProperty("resultStatus") UserStatus resultStatus,
+            @JsonProperty("sequence") Integer sequence,
             @JsonProperty("user") User user,
             @JsonProperty("sector") Sector sector,
             @JsonProperty("id") Long id,
@@ -151,6 +170,9 @@ public class Registration {
         this.isSaved = isSaved;
         this.isDeleted = isDeleted;
         this.savedAt = savedAt;
+        this.position = position;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
         this.user = user;
         this.sector = sector;
         this.id = id;
@@ -162,6 +184,13 @@ public class Registration {
     public void finalSave() {
         this.isSaved = true;
 //        this.savedAt = System.nanoTime();
+    }
+
+    public void finalSave(Integer position, UserStatus resultStatus, Integer sequence) {
+        this.position = position;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
+        finalSave();
     }
 
     public void updateIsDeleted(boolean isDeleted) {

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/domain/Registration.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.user.domain.User;
 import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import com.jnu.ticketdomain.domains.user.domain.UserStatusConverter;
 import java.time.LocalDateTime;
 import javax.persistence.*;
 import lombok.*;
@@ -81,6 +82,7 @@ public class Registration {
     private Integer position;
 
     @Column(name = "result_status")
+    @Convert(converter = UserStatusConverter.class)
     private UserStatus resultStatus;
 
     @Column(name = "sequence")

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/out/RegistrationLoadPort.java
@@ -30,5 +30,7 @@ public interface RegistrationLoadPort {
 
     Boolean existsByIdAndIsSavedTrue(Long id);
 
+    Long countSavedBySectorId(Long sectorId);
+
     List<Registration> findSortedRegistrationsByEventId(Long eventId);
 }

--- a/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
+++ b/Ticket-Domain/src/main/java/com/jnu/ticketdomain/domains/registration/repository/RegistrationRepository.java
@@ -91,4 +91,7 @@ public interface RegistrationRepository
     Integer findPositionBySavedAt(@Param("id") Long id, @Param("sectorId") Long sectorId);
 
     Boolean existsByIdAndIsSavedTrue(Long id);
+
+    @Query("select count(r) from Registration r where r.isSaved = true and r.sector.id = :sectorId")
+    Long countSavedBySectorId(@Param("sectorId") Long sectorId);
 }

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -87,7 +87,7 @@ spring:
     activate:
       on-profile: test
   datasource:
-    url: jdbc:h2:~/test;DB_CLOSE_DELAY=-1;MODE=MySQL;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
   jpa:
@@ -101,6 +101,8 @@ spring:
   quartz:
     jdbc:
       initialize-schema: always
+      platform: h2
+
 ---
 
 spring:

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -107,6 +107,10 @@ mail:
   outbox:
     enabled: false
 
+redis:
+  stock-sync:
+    enabled: false
+
 ---
 
 spring:

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -103,6 +103,10 @@ spring:
       initialize-schema: always
       platform: h2
 
+mail:
+  outbox:
+    enabled: false
+
 ---
 
 spring:
@@ -227,3 +231,7 @@ thread:
   core-pool-size: 10
   max-pool-size: 20
   queue-capacity: 100
+
+mail:
+  outbox:
+    enabled: false

--- a/Ticket-Domain/src/main/resources/application-domain.yml
+++ b/Ticket-Domain/src/main/resources/application-domain.yml
@@ -239,3 +239,7 @@ thread:
 mail:
   outbox:
     enabled: false
+
+redis:
+  stock-sync:
+    enabled: false

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/AnnounceImage/config/TestDataSourceConfig.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/AnnounceImage/config/TestDataSourceConfig.java
@@ -15,10 +15,9 @@ public class TestDataSourceConfig {
     @Bean
     public DataSource dataSource() {
         DriverManagerDataSource dataSource = new DriverManagerDataSource();
-        dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver");
-        dataSource.setUrl("jdbc:mysql://localhost:3306/ticket");
-        dataSource.setUsername("root");
-        dataSource.setPassword("1234");
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:announce-image-test;MODE=MySQL;DB_CLOSE_DELAY=-1");
+        dataSource.setUsername("sa");
         return dataSource;
     }
 

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxAdaptorTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxAdaptorTest.java
@@ -1,0 +1,71 @@
+package com.jnu.ticketdomain.domains.email;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketdomain.domains.email.adaptor.EmailOutboxAdaptor;
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.email.repository.EmailOutboxRepository;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EmailOutboxAdaptorTest {
+
+    @Mock private EmailOutboxRepository emailOutboxRepository;
+
+    private EmailOutboxAdaptor emailOutboxAdaptor;
+
+    @BeforeEach
+    void setUp() {
+        emailOutboxAdaptor = new EmailOutboxAdaptor(emailOutboxRepository);
+    }
+
+    @Test
+    @DisplayName("이미 outbox가 있는 registration은 중복 저장하지 않는다")
+    void saveRegistrationResultIfAbsentSkipsDuplicateRegistration() {
+        Registration registration = registration();
+        when(emailOutboxRepository.existsByRegistrationId(10L)).thenReturn(true);
+
+        emailOutboxAdaptor.saveRegistrationResultIfAbsent(registration);
+
+        verify(emailOutboxRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("outbox가 없는 registration은 결과 메일 outbox를 저장한다")
+    void saveRegistrationResultIfAbsentSavesNewOutbox() {
+        Registration registration = registration();
+        when(emailOutboxRepository.existsByRegistrationId(10L)).thenReturn(false);
+
+        emailOutboxAdaptor.saveRegistrationResultIfAbsent(registration);
+
+        verify(emailOutboxRepository).save(org.mockito.ArgumentMatchers.any(EmailOutbox.class));
+    }
+
+    private Registration registration() {
+        Registration registration =
+                Registration.builder()
+                        .email("student@jnu.ac.kr")
+                        .name("학생")
+                        .studentNum("20240001")
+                        .carNum("12가3456")
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                        .isSaved(false)
+                        .eventId(10L)
+                        .build();
+        registration.setId(10L);
+        registration.finalSave(1, UserStatus.SUCCESS, -2);
+        return registration;
+    }
+}

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxRepositoryTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxRepositoryTest.java
@@ -1,0 +1,70 @@
+package com.jnu.ticketdomain.domains.email;
+
+import static com.jnu.ticketcommon.consts.TicketStatic.MAX_EMAIL_SEND_RETRY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.email.repository.EmailOutboxRepository;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+class EmailOutboxRepositoryTest {
+
+    @Autowired private EmailOutboxRepository emailOutboxRepository;
+    @Autowired private EntityManager entityManager;
+
+    @Test
+    @DisplayName("재시도 대기 중이거나 최대 재시도에 도달한 outbox는 pending 조회와 claim에서 제외한다")
+    void findPendingExcludesCoolingDownAndExhaustedOutboxes() {
+        LocalDateTime now = LocalDateTime.of(2026, 7, 28, 12, 0);
+        LocalDateTime staleBefore = now.minusMinutes(10);
+        EmailOutbox ready = emailOutboxRepository.saveAndFlush(outbox(1L));
+        EmailOutbox coolingDown = emailOutboxRepository.saveAndFlush(outbox(2L));
+        EmailOutbox exhausted = emailOutboxRepository.saveAndFlush(outbox(3L));
+
+        emailOutboxRepository.markFailed(coolingDown.getId(), now.minusMinutes(1));
+        for (int retry = 0; retry < MAX_EMAIL_SEND_RETRY; retry++) {
+            emailOutboxRepository.markFailed(exhausted.getId(), now.minusMinutes(20));
+        }
+        entityManager.clear();
+
+        List<EmailOutbox> pending =
+                emailOutboxRepository.findPending(
+                        staleBefore, MAX_EMAIL_SEND_RETRY, PageRequest.of(0, 20));
+
+        assertThat(pending)
+                .extracting(EmailOutbox::getRegistrationId)
+                .containsExactly(ready.getRegistrationId());
+        assertThat(
+                        emailOutboxRepository.claim(
+                                exhausted.getId(), now, staleBefore, MAX_EMAIL_SEND_RETRY))
+                .isZero();
+    }
+
+    private EmailOutbox outbox(Long registrationId) {
+        Registration registration =
+                Registration.builder()
+                        .email("student" + registrationId + "@jnu.ac.kr")
+                        .name("학생" + registrationId)
+                        .studentNum("2024" + registrationId)
+                        .carNum("12가" + registrationId)
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 7, 28, 10, 0))
+                        .isSaved(true)
+                        .eventId(10L)
+                        .build();
+        registration.setId(registrationId);
+        registration.finalSave(1, UserStatus.SUCCESS, -2);
+        return EmailOutbox.from(registration);
+    }
+}

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/email/EmailOutboxTest.java
@@ -1,0 +1,67 @@
+package com.jnu.ticketdomain.domains.email;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnu.ticketdomain.domains.email.domain.EmailOutbox;
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.User;
+import com.jnu.ticketdomain.domains.user.domain.UserRole;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EmailOutboxTest {
+
+    @Test
+    @DisplayName("Registration에 확정된 결과가 있으면 해당 결과로 outbox를 생성한다")
+    void fromUsesRegistrationDecision() {
+        Registration registration = registration();
+        registration.finalSave(3, UserStatus.PREPARE, 1);
+
+        EmailOutbox outbox = EmailOutbox.from(registration);
+
+        assertThat(outbox.getEventId()).isEqualTo(10L);
+        assertThat(outbox.getRegistrationId()).isEqualTo(10L);
+        assertThat(outbox.getEmail()).isEqualTo("student@jnu.ac.kr");
+        assertThat(outbox.getName()).isEqualTo("학생");
+        assertThat(outbox.getResultStatus()).isEqualTo(UserStatus.PREPARE);
+        assertThat(outbox.getSequence()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Registration 결과가 비어 있으면 기존 User 결과로 outbox를 생성한다")
+    void fromFallsBackToUserDecision() {
+        User user =
+                User.builder()
+                        .email("student@jnu.ac.kr")
+                        .pwd("encoded-password")
+                        .userRole(UserRole.USER)
+                        .build();
+        user.success();
+        Registration registration = registration();
+        registration.setUser(user);
+
+        EmailOutbox outbox = EmailOutbox.from(registration);
+
+        assertThat(outbox.getResultStatus()).isEqualTo(UserStatus.SUCCESS);
+        assertThat(outbox.getSequence()).isEqualTo(-2);
+    }
+
+    private Registration registration() {
+        Registration registration =
+                Registration.builder()
+                        .email("student@jnu.ac.kr")
+                        .name("학생")
+                        .studentNum("20240001")
+                        .carNum("12가3456")
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                        .isSaved(false)
+                        .eventId(10L)
+                        .build();
+        registration.setId(10L);
+        return registration;
+    }
+}

--- a/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/events/SectorTest.java
+++ b/Ticket-Domain/src/test/java/com/jnu/ticketdomain/domains/events/SectorTest.java
@@ -1,0 +1,70 @@
+package com.jnu.ticketdomain.domains.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jnu.ticketdomain.domains.events.domain.Sector;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SectorTest {
+
+    @Test
+    @DisplayName("Redis 잔여 수량이 정원 구간 안이면 정원만 차감해서 동기화한다")
+    void syncRemainingAmountDecreasesCapacityFirst() {
+        Sector sector =
+                Sector.builder()
+                        .sectorNumber("1구간")
+                        .name("공과대학")
+                        .sectorCapacity(3)
+                        .reserve(2)
+                        .build();
+
+        sector.syncRemainingAmount(4);
+
+        assertThat(sector.getSectorCapacity()).isEqualTo(2);
+        assertThat(sector.getReserve()).isEqualTo(2);
+        assertThat(sector.getRemainingAmount()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("Redis 잔여 수량이 예비 구간이면 정원은 0, 예비는 남은 수량으로 동기화한다")
+    void syncRemainingAmountDecreasesReserveAfterCapacity() {
+        Sector sector =
+                Sector.builder()
+                        .sectorNumber("1구간")
+                        .name("공과대학")
+                        .sectorCapacity(3)
+                        .reserve(2)
+                        .build();
+
+        sector.syncRemainingAmount(1);
+
+        assertThat(sector.getSectorCapacity()).isZero();
+        assertThat(sector.getReserve()).isEqualTo(1);
+        assertThat(sector.getRemainingAmount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Redis 잔여 수량은 0과 issueAmount 사이로 보정해서 동기화한다")
+    void syncRemainingAmountBoundsRemainingAmount() {
+        Sector sector =
+                Sector.builder()
+                        .sectorNumber("1구간")
+                        .name("공과대학")
+                        .sectorCapacity(3)
+                        .reserve(2)
+                        .build();
+
+        sector.syncRemainingAmount(-10);
+
+        assertThat(sector.getSectorCapacity()).isZero();
+        assertThat(sector.getReserve()).isZero();
+        assertThat(sector.getRemainingAmount()).isZero();
+
+        sector.syncRemainingAmount(10);
+
+        assertThat(sector.getSectorCapacity()).isEqualTo(3);
+        assertThat(sector.getReserve()).isEqualTo(2);
+        assertThat(sector.getRemainingAmount()).isEqualTo(5);
+    }
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
@@ -36,6 +36,9 @@ public class RedisConfig {
     @Value("${spring.redis.password}")
     private String redisPassword;
 
+    @Value("${spring.redis.command-timeout-ms:3000}")
+    private long redisCommandTimeoutMs;
+
     @Bean
     @ConditionalOnExpression("${ableRedis:true}")
     public RedisConnectionFactory redisConnectionFactory() {
@@ -47,7 +50,7 @@ public class RedisConfig {
 
         LettuceClientConfiguration clientConfig =
                 LettuceClientConfiguration.builder()
-                        .commandTimeout(Duration.ofSeconds(1))
+                        .commandTimeout(Duration.ofMillis(redisCommandTimeoutMs))
                         .shutdownTimeout(Duration.ZERO)
                         .build();
         return new LettuceConnectionFactory(redisConfig, clientConfig);

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/config/redis/RedisConfig.java
@@ -64,7 +64,7 @@ public class RedisConfig {
                 new Jackson2JsonRedisSerializer<>(ChatMessage.class);
         redisTemplate.setValueSerializer(serializer);
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(serializer);
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
@@ -10,16 +10,26 @@ import lombok.Getter;
 public class EventIssuedEvent extends InfrastructureEvent {
     private ChatMessage message;
     private final Double score;
+    private final String streamRecordId;
 
     public static EventIssuedEvent from(ChatMessage message, Double score) {
         return EventIssuedEvent.builder().message(message).score(score).build();
     }
 
+    public static EventIssuedEvent from(ChatMessage message, String streamRecordId) {
+        return EventIssuedEvent.builder().message(message).streamRecordId(streamRecordId).build();
+    }
+
     @Override
     public String toString() {
-        return "EventIssuedEvent{" +
-                "message=" + message +
-                ", score=" + score +
-                '}';
+        return "EventIssuedEvent{"
+                + "message="
+                + message
+                + ", score="
+                + score
+                + ", streamRecordId='"
+                + streamRecordId
+                + '\''
+                + '}';
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/domainEvent/EventIssuedEvent.java
@@ -11,6 +11,7 @@ public class EventIssuedEvent extends InfrastructureEvent {
     private ChatMessage message;
     private final Double score;
     private final String streamRecordId;
+    private final String streamKey;
 
     public static EventIssuedEvent from(ChatMessage message, Double score) {
         return EventIssuedEvent.builder().message(message).score(score).build();
@@ -18,6 +19,15 @@ public class EventIssuedEvent extends InfrastructureEvent {
 
     public static EventIssuedEvent from(ChatMessage message, String streamRecordId) {
         return EventIssuedEvent.builder().message(message).streamRecordId(streamRecordId).build();
+    }
+
+    public static EventIssuedEvent from(
+            ChatMessage message, String streamRecordId, String streamKey) {
+        return EventIssuedEvent.builder()
+                .message(message)
+                .streamRecordId(streamRecordId)
+                .streamKey(streamKey)
+                .build();
     }
 
     @Override
@@ -29,6 +39,9 @@ public class EventIssuedEvent extends InfrastructureEvent {
                 + score
                 + ", streamRecordId='"
                 + streamRecordId
+                + '\''
+                + ", streamKey='"
+                + streamKey
                 + '\''
                 + '}';
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
@@ -1,20 +1,50 @@
 package com.jnu.ticketinfrastructure.model;
 
 
-import lombok.AllArgsConstructor;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 @Setter
 public class ChatMessage {
     private String registration;
     private Long userId;
     private Long sectorId;
     private Long eventId;
+    private Integer position;
+    private UserStatus resultStatus;
+    private Integer sequence;
+
+    public ChatMessage(String registration, Long userId, Long sectorId, Long eventId) {
+        this.registration = registration;
+        this.userId = userId;
+        this.sectorId = sectorId;
+        this.eventId = eventId;
+    }
+
+    public ChatMessage(
+            String registration,
+            Long userId,
+            Long sectorId,
+            Long eventId,
+            Integer position,
+            UserStatus resultStatus,
+            Integer sequence) {
+        this.registration = registration;
+        this.userId = userId;
+        this.sectorId = sectorId;
+        this.eventId = eventId;
+        this.position = position;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
+    }
+
+    public boolean hasDecision() {
+        return position != null && resultStatus != null && sequence != null;
+    }
 
     @Override
     public String toString() {
@@ -28,6 +58,12 @@ public class ChatMessage {
                 + sectorId
                 + ", eventId="
                 + eventId
+                + ", position="
+                + position
+                + ", resultStatus="
+                + resultStatus
+                + ", sequence="
+                + sequence
                 + '}';
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/ChatMessage.java
@@ -18,11 +18,16 @@ public class ChatMessage {
 
     @Override
     public String toString() {
-        return "ChatMessage{" +
-                "registration='" + registration + '\'' +
-                ", userId=" + userId +
-                ", sectorId=" + sectorId +
-                ", eventId=" + eventId +
-                '}';
+        return "ChatMessage{"
+                + "registration='"
+                + registration
+                + '\''
+                + ", userId="
+                + userId
+                + ", sectorId="
+                + sectorId
+                + ", eventId="
+                + eventId
+                + '}';
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StockReservationResult.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StockReservationResult.java
@@ -1,0 +1,56 @@
+package com.jnu.ticketinfrastructure.model;
+
+
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
+import lombok.Getter;
+
+@Getter
+public class StockReservationResult {
+    private static final String RESERVED = "RESERVED";
+    private static final String DUPLICATE = "DUPLICATE";
+    private static final String NO_STOCK = "NO_STOCK";
+
+    private final boolean reserved;
+    private final String reason;
+    private final Integer position;
+    private final UserStatus resultStatus;
+    private final Integer sequence;
+    private final Integer remainingAmount;
+
+    public StockReservationResult(
+            boolean reserved,
+            String reason,
+            Integer position,
+            UserStatus resultStatus,
+            Integer sequence,
+            Integer remainingAmount) {
+        this.reserved = reserved;
+        this.reason = reason;
+        this.position = position;
+        this.resultStatus = resultStatus;
+        this.sequence = sequence;
+        this.remainingAmount = remainingAmount;
+    }
+
+    public static StockReservationResult reserved(
+            Integer position, UserStatus resultStatus, Integer sequence, Integer remainingAmount) {
+        return new StockReservationResult(
+                true, RESERVED, position, resultStatus, sequence, remainingAmount);
+    }
+
+    public static StockReservationResult duplicate(Integer remainingAmount) {
+        return new StockReservationResult(false, DUPLICATE, null, null, null, remainingAmount);
+    }
+
+    public static StockReservationResult noStock(Integer remainingAmount) {
+        return new StockReservationResult(false, NO_STOCK, null, null, null, remainingAmount);
+    }
+
+    public boolean isDuplicate() {
+        return DUPLICATE.equals(reason);
+    }
+
+    public boolean isNoStock() {
+        return NO_STOCK.equals(reason);
+    }
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StockReservationResult.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StockReservationResult.java
@@ -9,6 +9,7 @@ public class StockReservationResult {
     private static final String RESERVED = "RESERVED";
     private static final String DUPLICATE = "DUPLICATE";
     private static final String NO_STOCK = "NO_STOCK";
+    private static final String CLOSED = "CLOSED";
 
     private final boolean reserved;
     private final String reason;
@@ -46,11 +47,19 @@ public class StockReservationResult {
         return new StockReservationResult(false, NO_STOCK, null, null, null, remainingAmount);
     }
 
+    public static StockReservationResult closed(Integer remainingAmount) {
+        return new StockReservationResult(false, CLOSED, null, null, null, remainingAmount);
+    }
+
     public boolean isDuplicate() {
         return DUPLICATE.equals(reason);
     }
 
     public boolean isNoStock() {
         return NO_STOCK.equals(reason);
+    }
+
+    public boolean isClosed() {
+        return CLOSED.equals(reason);
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StreamQueueMessage.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/model/StreamQueueMessage.java
@@ -1,0 +1,12 @@
+package com.jnu.ticketinfrastructure.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StreamQueueMessage {
+    private final String recordId;
+    private final ChatMessage message;
+}

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -56,10 +56,9 @@ public class RedisRepository {
                     + "  stock = tonumber(stock) "
                     + "end "
                     + "if not redis.call('GET', KEYS[2]) then "
-                    + "  redis.call('SET', KEYS[2], tonumber(ARGV[1]) - stock) "
+                    + "  redis.call('SET', KEYS[2], tonumber(ARGV[2]) - stock) "
                     + "end "
-                    + "if redis.call('SISMEMBER', KEYS[3], ARGV[7]) == 1 "
-                    + "or redis.call('SISMEMBER', KEYS[4], ARGV[8]) == 1 then "
+                    + "if redis.call('SISMEMBER', KEYS[3], ARGV[8]) == 1 then "
                     + "  return {0, 'DUPLICATE', -1, '', -1, stock} "
                     + "end "
                     + "if stock <= 0 then "
@@ -67,19 +66,18 @@ public class RedisRepository {
                     + "end "
                     + "local position = redis.call('INCR', KEYS[2]) "
                     + "local status = 'PREPARE' "
-                    + "local sequence = position - tonumber(ARGV[2]) "
-                    + "if position <= tonumber(ARGV[2]) then "
+                    + "local sequence = position - tonumber(ARGV[3]) "
+                    + "if position <= tonumber(ARGV[3]) then "
                     + "  status = 'SUCCESS' "
                     + "  sequence = -2 "
                     + "end "
                     + "local remaining = redis.call('DECR', KEYS[1]) "
-                    + "redis.call('SADD', KEYS[3], ARGV[7]) "
-                    + "redis.call('SADD', KEYS[4], ARGV[8]) "
-                    + "redis.call('XADD', KEYS[5], '*', "
-                    + "  'registration', ARGV[3], "
-                    + "  'userId', ARGV[4], "
-                    + "  'sectorId', ARGV[5], "
-                    + "  'eventId', ARGV[6], "
+                    + "redis.call('SADD', KEYS[3], ARGV[8]) "
+                    + "redis.call('XADD', KEYS[4], '*', "
+                    + "  'registration', ARGV[4], "
+                    + "  'userId', ARGV[5], "
+                    + "  'sectorId', ARGV[6], "
+                    + "  'eventId', ARGV[7], "
                     + "  'position', tostring(position), "
                     + "  'resultStatus', status, "
                     + "  'sequence', tostring(sequence)) "
@@ -187,14 +185,13 @@ public class RedisRepository {
             String stockKey,
             String sequenceKey,
             String reservedEmailKey,
-            String reservedStudentKey,
             String streamKey,
             String registration,
             Long userId,
             Long sectorId,
             Long eventId,
             String email,
-            String studentNum,
+            Integer initialRemainingAmount,
             Integer issueAmount,
             Integer initSectorCapacity) {
         List<Object> rawResult =
@@ -206,21 +203,21 @@ public class RedisRepository {
                                                         RESERVE_STOCK_SCRIPT.getBytes(
                                                                 StandardCharsets.UTF_8),
                                                         ReturnType.MULTI,
-                                                        5,
+                                                        4,
                                                         redisArgs(
                                                                 stockKey,
                                                                 sequenceKey,
                                                                 reservedEmailKey,
-                                                                reservedStudentKey,
                                                                 streamKey,
+                                                                String.valueOf(
+                                                                        initialRemainingAmount),
                                                                 String.valueOf(issueAmount),
                                                                 String.valueOf(initSectorCapacity),
                                                                 registration,
                                                                 String.valueOf(userId),
                                                                 String.valueOf(sectorId),
                                                                 String.valueOf(eventId),
-                                                                email,
-                                                                studentNum)));
+                                                                email)));
         return toStockReservationResult(rawResult);
     }
 

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -3,12 +3,23 @@ package com.jnu.ticketinfrastructure.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -18,6 +29,7 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 @ConditionalOnExpression("${ableRedis:true}")
 public class RedisRepository {
+    private static final String STREAM_PAYLOAD_KEY = "payload";
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
 
@@ -107,6 +119,53 @@ public class RedisRepository {
         return redisTemplate.opsForZSet().score(key, value);
     }
 
+    public RecordId xAdd(String key, ChatMessage message) {
+        try {
+            Map<String, String> body =
+                    Map.of(STREAM_PAYLOAD_KEY, objectMapper.writeValueAsString(message));
+            return redisTemplate.opsForStream().add(key, body);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to add message to Redis Stream", e);
+        }
+    }
+
+    public void createConsumerGroupIfAbsent(String key, String group) {
+        try {
+            redisTemplate.execute(
+                    (RedisCallback<String>)
+                            connection ->
+                                    connection.xGroupCreate(
+                                            key.getBytes(StandardCharsets.UTF_8),
+                                            group,
+                                            ReadOffset.from("0-0"),
+                                            true));
+        } catch (DataAccessException e) {
+            if (!isAlreadyCreatedGroup(e)) {
+                throw e;
+            }
+        }
+    }
+
+    public List<StreamQueueMessage> xReadGroup(
+            String key, String group, String consumer, long count) {
+        createConsumerGroupIfAbsent(key, group);
+        List<MapRecord<String, Object, Object>> records =
+                redisTemplate
+                        .opsForStream()
+                        .read(
+                                Consumer.from(group, consumer),
+                                StreamReadOptions.empty().count(count),
+                                StreamOffset.create(key, ReadOffset.lastConsumed()));
+        if (records == null || records.isEmpty()) {
+            return List.of();
+        }
+        return records.stream().map(this::toStreamQueueMessage).toList();
+    }
+
+    public Long xAck(String key, String group, String recordId) {
+        return redisTemplate.opsForStream().acknowledge(key, group, recordId);
+    }
+
     public Long remove(String key, Object value) {
         return redisTemplate.opsForZSet().remove(key, value);
     }
@@ -127,5 +186,21 @@ public class RedisRepository {
             // Set is empty, return null or handle accordingly
             return null;
         }
+    }
+
+    private StreamQueueMessage toStreamQueueMessage(MapRecord<String, Object, Object> record) {
+        Object payload = record.getValue().get(STREAM_PAYLOAD_KEY);
+        try {
+            return new StreamQueueMessage(
+                    record.getId().getValue(),
+                    objectMapper.readValue(String.valueOf(payload), ChatMessage.class));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse Redis Stream message", e);
+        }
+    }
+
+    private boolean isAlreadyCreatedGroup(Exception e) {
+        String message = e.getMessage();
+        return message != null && message.contains("BUSYGROUP");
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -5,17 +5,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.ReturnType;
+import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
@@ -162,6 +168,44 @@ public class RedisRepository {
         return records.stream().map(this::toStreamQueueMessage).toList();
     }
 
+    public List<StreamQueueMessage> xClaimStale(
+            String key, String group, String consumer, long count, Duration minIdleTime) {
+        createConsumerGroupIfAbsent(key, group);
+        PendingMessages pendingMessages =
+                redisTemplate.opsForStream().pending(key, group, Range.unbounded(), count);
+        if (pendingMessages == null || pendingMessages.isEmpty()) {
+            return List.of();
+        }
+
+        RecordId[] staleRecordIds =
+                StreamSupport.stream(pendingMessages.spliterator(), false)
+                        .filter(pendingMessage -> isStale(pendingMessage, minIdleTime))
+                        .map(PendingMessage::getId)
+                        .toArray(RecordId[]::new);
+        if (staleRecordIds.length == 0) {
+            return List.of();
+        }
+
+        List<ByteRecord> claimedRecords =
+                redisTemplate.execute(
+                        (RedisCallback<List<ByteRecord>>)
+                                connection ->
+                                        connection.xClaim(
+                                                key.getBytes(StandardCharsets.UTF_8),
+                                                group,
+                                                consumer,
+                                                minIdleTime,
+                                                staleRecordIds));
+        if (claimedRecords == null || claimedRecords.isEmpty()) {
+            return List.of();
+        }
+
+        return claimedRecords.stream()
+                .map(redisTemplate.opsForStream()::deserializeRecord)
+                .map(this::toStreamQueueMessage)
+                .toList();
+    }
+
     public Long xAck(String key, String group, String recordId) {
         return redisTemplate.opsForStream().acknowledge(key, group, recordId);
     }
@@ -206,5 +250,9 @@ public class RedisRepository {
     private boolean isAlreadyCreatedGroup(Exception e) {
         String message = e.getMessage();
         return message != null && message.contains("BUSYGROUP");
+    }
+
+    private boolean isStale(PendingMessage pendingMessage, Duration minIdleTime) {
+        return pendingMessage.getElapsedTimeSinceLastDelivery().compareTo(minIdleTime) >= 0;
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -166,6 +166,10 @@ public class RedisRepository {
         return redisTemplate.opsForStream().acknowledge(key, group, recordId);
     }
 
+    public Long xDelete(String key, String recordId) {
+        return redisTemplate.opsForStream().delete(key, recordId);
+    }
+
     public Long remove(String key, Object value) {
         return redisTemplate.opsForZSet().remove(key, value);
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -2,13 +2,17 @@ package com.jnu.ticketinfrastructure.redis;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StockReservationResult;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.StreamSupport;
@@ -36,6 +40,50 @@ import org.springframework.stereotype.Repository;
 @ConditionalOnExpression("${ableRedis:true}")
 public class RedisRepository {
     private static final String STREAM_PAYLOAD_KEY = "payload";
+    private static final String STREAM_REGISTRATION_KEY = "registration";
+    private static final String STREAM_USER_ID_KEY = "userId";
+    private static final String STREAM_SECTOR_ID_KEY = "sectorId";
+    private static final String STREAM_EVENT_ID_KEY = "eventId";
+    private static final String STREAM_POSITION_KEY = "position";
+    private static final String STREAM_RESULT_STATUS_KEY = "resultStatus";
+    private static final String STREAM_SEQUENCE_KEY = "sequence";
+    private static final String RESERVE_STOCK_SCRIPT =
+            "local stock = redis.call('GET', KEYS[1]) "
+                    + "if not stock then "
+                    + "  stock = tonumber(ARGV[1]) "
+                    + "  redis.call('SET', KEYS[1], stock) "
+                    + "else "
+                    + "  stock = tonumber(stock) "
+                    + "end "
+                    + "if not redis.call('GET', KEYS[2]) then "
+                    + "  redis.call('SET', KEYS[2], tonumber(ARGV[1]) - stock) "
+                    + "end "
+                    + "if redis.call('SISMEMBER', KEYS[3], ARGV[7]) == 1 "
+                    + "or redis.call('SISMEMBER', KEYS[4], ARGV[8]) == 1 then "
+                    + "  return {0, 'DUPLICATE', -1, '', -1, stock} "
+                    + "end "
+                    + "if stock <= 0 then "
+                    + "  return {0, 'NO_STOCK', -1, '', -1, stock} "
+                    + "end "
+                    + "local position = redis.call('INCR', KEYS[2]) "
+                    + "local status = 'PREPARE' "
+                    + "local sequence = position - tonumber(ARGV[2]) "
+                    + "if position <= tonumber(ARGV[2]) then "
+                    + "  status = 'SUCCESS' "
+                    + "  sequence = -2 "
+                    + "end "
+                    + "local remaining = redis.call('DECR', KEYS[1]) "
+                    + "redis.call('SADD', KEYS[3], ARGV[7]) "
+                    + "redis.call('SADD', KEYS[4], ARGV[8]) "
+                    + "redis.call('XADD', KEYS[5], '*', "
+                    + "  'registration', ARGV[3], "
+                    + "  'userId', ARGV[4], "
+                    + "  'sectorId', ARGV[5], "
+                    + "  'eventId', ARGV[6], "
+                    + "  'position', tostring(position), "
+                    + "  'resultStatus', status, "
+                    + "  'sequence', tostring(sequence)) "
+                    + "return {1, 'RESERVED', position, status, sequence, remaining}";
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
 
@@ -135,6 +183,47 @@ public class RedisRepository {
         }
     }
 
+    public StockReservationResult reserveStockAndAddToStream(
+            String stockKey,
+            String sequenceKey,
+            String reservedEmailKey,
+            String reservedStudentKey,
+            String streamKey,
+            String registration,
+            Long userId,
+            Long sectorId,
+            Long eventId,
+            String email,
+            String studentNum,
+            Integer issueAmount,
+            Integer initSectorCapacity) {
+        List<Object> rawResult =
+                redisTemplate.execute(
+                        (RedisCallback<List<Object>>)
+                                connection ->
+                                        (List<Object>)
+                                                connection.eval(
+                                                        RESERVE_STOCK_SCRIPT.getBytes(
+                                                                StandardCharsets.UTF_8),
+                                                        ReturnType.MULTI,
+                                                        5,
+                                                        redisArgs(
+                                                                stockKey,
+                                                                sequenceKey,
+                                                                reservedEmailKey,
+                                                                reservedStudentKey,
+                                                                streamKey,
+                                                                String.valueOf(issueAmount),
+                                                                String.valueOf(initSectorCapacity),
+                                                                registration,
+                                                                String.valueOf(userId),
+                                                                String.valueOf(sectorId),
+                                                                String.valueOf(eventId),
+                                                                email,
+                                                                studentNum)));
+        return toStockReservationResult(rawResult);
+    }
+
     public void createConsumerGroupIfAbsent(String key, String group) {
         try {
             redisTemplate.execute(
@@ -214,6 +303,14 @@ public class RedisRepository {
         return redisTemplate.opsForStream().delete(key, recordId);
     }
 
+    public Optional<Integer> getIntegerValue(String key) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Optional.of(Integer.parseInt(String.valueOf(value)));
+    }
+
     public Long remove(String key, Object value) {
         return redisTemplate.opsForZSet().remove(key, value);
     }
@@ -239,12 +336,108 @@ public class RedisRepository {
     private StreamQueueMessage toStreamQueueMessage(MapRecord<String, Object, Object> record) {
         Object payload = record.getValue().get(STREAM_PAYLOAD_KEY);
         try {
+            if (payload == null) {
+                return new StreamQueueMessage(
+                        record.getId().getValue(), toReservedChatMessage(record));
+            }
             return new StreamQueueMessage(
                     record.getId().getValue(),
                     objectMapper.readValue(String.valueOf(payload), ChatMessage.class));
         } catch (Exception e) {
             throw new IllegalStateException("Failed to parse Redis Stream message", e);
         }
+    }
+
+    private ChatMessage toReservedChatMessage(MapRecord<String, Object, Object> record) {
+        Map<Object, Object> values = record.getValue();
+        return new ChatMessage(
+                value(values, STREAM_REGISTRATION_KEY),
+                longValue(values, STREAM_USER_ID_KEY),
+                longValue(values, STREAM_SECTOR_ID_KEY),
+                longValue(values, STREAM_EVENT_ID_KEY),
+                integerValue(values, STREAM_POSITION_KEY),
+                UserStatus.valueOf(value(values, STREAM_RESULT_STATUS_KEY)),
+                integerValue(values, STREAM_SEQUENCE_KEY));
+    }
+
+    private StockReservationResult toStockReservationResult(List<Object> rawResult) {
+        if (rawResult == null || rawResult.isEmpty()) {
+            throw new IllegalStateException("Failed to reserve Redis stock");
+        }
+        boolean reserved = longValue(rawResult.get(0)) == 1L;
+        String reason = stringValue(rawResult.get(1));
+        Integer position = normalizePositive(integerValue(rawResult.get(2)));
+        String status = stringValue(rawResult.get(3));
+        Integer sequence = normalizeSequence(integerValue(rawResult.get(4)));
+        Integer remainingAmount = integerValue(rawResult.get(5));
+
+        if (reserved) {
+            return StockReservationResult.reserved(
+                    position, UserStatus.valueOf(status), sequence, remainingAmount);
+        }
+        if ("DUPLICATE".equals(reason)) {
+            return StockReservationResult.duplicate(remainingAmount);
+        }
+        if ("NO_STOCK".equals(reason)) {
+            return StockReservationResult.noStock(remainingAmount);
+        }
+        throw new IllegalStateException("Unknown Redis stock reservation result: " + reason);
+    }
+
+    private byte[][] redisArgs(String... values) {
+        List<byte[]> args = new ArrayList<>();
+        for (String value : values) {
+            args.add(value.getBytes(StandardCharsets.UTF_8));
+        }
+        return args.toArray(new byte[0][]);
+    }
+
+    private String value(Map<Object, Object> values, String key) {
+        Object value = values.get(key);
+        if (value == null) {
+            value = values.get(key.getBytes(StandardCharsets.UTF_8));
+        }
+        return stringValue(value);
+    }
+
+    private Long longValue(Map<Object, Object> values, String key) {
+        return Long.parseLong(value(values, key));
+    }
+
+    private Integer integerValue(Map<Object, Object> values, String key) {
+        return Integer.parseInt(value(values, key));
+    }
+
+    private Long longValue(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        return Long.parseLong(stringValue(value));
+    }
+
+    private Integer integerValue(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        return Integer.parseInt(stringValue(value));
+    }
+
+    private String stringValue(Object value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Redis value must not be null");
+        }
+        if (value instanceof byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return String.valueOf(value);
+    }
+
+    private Integer normalizePositive(Integer value) {
+        return value != null && value > 0 ? value : null;
+    }
+
+    private Integer normalizeSequence(Integer value) {
+        return value != null && value != -1 ? value : null;
     }
 
     private boolean isAlreadyCreatedGroup(Exception e) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -48,7 +48,12 @@ public class RedisRepository {
     private static final String STREAM_RESULT_STATUS_KEY = "resultStatus";
     private static final String STREAM_SEQUENCE_KEY = "sequence";
     private static final String RESERVE_STOCK_SCRIPT =
-            "local stock = redis.call('GET', KEYS[1]) "
+            "if redis.call('EXISTS', KEYS[5]) == 1 then "
+                    + "  local closedStock = redis.call('GET', KEYS[1]) "
+                    + "  if not closedStock then closedStock = 0 end "
+                    + "  return {0, 'CLOSED', -1, '', -1, tonumber(closedStock)} "
+                    + "end "
+                    + "local stock = redis.call('GET', KEYS[1]) "
                     + "if not stock then "
                     + "  stock = tonumber(ARGV[1]) "
                     + "  redis.call('SET', KEYS[1], stock) "
@@ -167,6 +172,17 @@ public class RedisRepository {
         }
     }
 
+    public void expireKeysByPrefix(String prefix, Duration timeout) {
+        Set<String> keys = redisTemplate.keys(prefix + "*");
+        if (keys != null) {
+            keys.forEach(key -> redisTemplate.expire(key, timeout));
+        }
+    }
+
+    public void set(String key, Object value, Duration timeout) {
+        redisTemplate.opsForValue().set(key, value, timeout);
+    }
+
     public Double getScore(String key, Object value) {
         return redisTemplate.opsForZSet().score(key, value);
     }
@@ -186,6 +202,7 @@ public class RedisRepository {
             String sequenceKey,
             String reservedEmailKey,
             String streamKey,
+            String closedKey,
             String registration,
             Long userId,
             Long sectorId,
@@ -203,12 +220,13 @@ public class RedisRepository {
                                                         RESERVE_STOCK_SCRIPT.getBytes(
                                                                 StandardCharsets.UTF_8),
                                                         ReturnType.MULTI,
-                                                        4,
+                                                        5,
                                                         redisArgs(
                                                                 stockKey,
                                                                 sequenceKey,
                                                                 reservedEmailKey,
                                                                 streamKey,
+                                                                closedKey,
                                                                 String.valueOf(
                                                                         initialRemainingAmount),
                                                                 String.valueOf(issueAmount),
@@ -380,6 +398,9 @@ public class RedisRepository {
         }
         if ("NO_STOCK".equals(reason)) {
             return StockReservationResult.noStock(remainingAmount);
+        }
+        if ("CLOSED".equals(reason)) {
+            return StockReservationResult.closed(remainingAmount);
         }
         throw new IllegalStateException("Unknown Redis stock reservation result: " + reason);
     }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/redis/RedisRepository.java
@@ -301,11 +301,14 @@ public class RedisRepository {
     }
 
     public Optional<Integer> getIntegerValue(String key) {
-        Object value = redisTemplate.opsForValue().get(key);
+        byte[] value =
+                redisTemplate.execute(
+                        (RedisCallback<byte[]>)
+                                connection -> connection.get(key.getBytes(StandardCharsets.UTF_8)));
         if (value == null) {
             return Optional.empty();
         }
-        return Optional.of(Integer.parseInt(String.valueOf(value)));
+        return Optional.of(Integer.parseInt(new String(value, StandardCharsets.UTF_8)));
     }
 
     public Long remove(String key, Object value) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -1,6 +1,7 @@
 package com.jnu.ticketinfrastructure.service;
 
 import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_CHANNEL;
+import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -144,5 +145,13 @@ public class WaitingQueueService {
             redisRepository.xDelete(key, recordId);
         }
         return acknowledged;
+    }
+
+    public String eventStreamKey(Long eventId) {
+        return REDIS_EVENT_ISSUE_STREAM + ":{" + eventId + "}";
+    }
+
+    public void deleteEventStream(Long eventId) {
+        redisRepository.delete(eventStreamKey(eventId));
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -5,15 +5,18 @@ import static com.jnu.ticketcommon.consts.TicketStatic.REDIS_EVENT_ISSUE_STREAM;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StockReservationResult;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +51,35 @@ public class WaitingQueueService {
         ChatMessage message = new ChatMessage(registrationString, userId, sectorId, eventId);
         redisRepository.xAdd(key, message);
         tracker.info("Added to the stream, score:{}", score);
+    }
+
+    public StockReservationResult reserveAndRegisterQueue(
+            String key, Registration registration, Long userId, Sector sector, Long eventId)
+            throws JsonProcessingException {
+        String registrationString = convertRegistrationJSON(registration);
+        StockReservationResult result =
+                redisRepository.reserveStockAndAddToStream(
+                        stockKey(eventId, sector.getId()),
+                        sequenceKey(eventId, sector.getId()),
+                        reservedEmailKey(eventId),
+                        reservedStudentKey(eventId),
+                        key,
+                        registrationString,
+                        userId,
+                        sector.getId(),
+                        eventId,
+                        registration.getEmail(),
+                        registration.getStudentNum(),
+                        sector.getIssueAmount(),
+                        sector.getInitSectorCapacity());
+        tracker.info(
+                "Reserved Redis stock. sectorId: {}, reserved: {}, position: {}, status: {}, remaining: {}",
+                sector.getId(),
+                result.isReserved(),
+                result.getPosition(),
+                result.getResultStatus(),
+                result.getRemainingAmount());
+        return result;
     }
 
     public String convertRegistrationJSON(Registration registration) {
@@ -153,5 +185,33 @@ public class WaitingQueueService {
 
     public void deleteEventStream(Long eventId) {
         redisRepository.delete(eventStreamKey(eventId));
+    }
+
+    public Optional<Integer> findRemainingStock(Long eventId, Long sectorId) {
+        return redisRepository.getIntegerValue(stockKey(eventId, sectorId));
+    }
+
+    public void deleteEventStockKeys(Long eventId) {
+        redisRepository.deleteKeysByPrefix(eventStockPrefix(eventId));
+    }
+
+    public String eventStockPrefix(Long eventId) {
+        return "parking-ticket:event:{" + eventId + "}:";
+    }
+
+    public String stockKey(Long eventId, Long sectorId) {
+        return eventStockPrefix(eventId) + "sector:" + sectorId + ":stock";
+    }
+
+    public String sequenceKey(Long eventId, Long sectorId) {
+        return eventStockPrefix(eventId) + "sector:" + sectorId + ":sequence";
+    }
+
+    public String reservedEmailKey(Long eventId) {
+        return eventStockPrefix(eventId) + "reserved:email";
+    }
+
+    public String reservedStudentKey(Long eventId) {
+        return eventStockPrefix(eventId) + "reserved:student";
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -9,6 +9,8 @@ import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrat
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Service;
 public class WaitingQueueService {
 
     private static final Logger tracker = LoggerFactory.getLogger("processTracker");
+    private static final Duration STREAM_PENDING_MIN_IDLE_TIME = Duration.ofSeconds(30);
 
     private final RedisRepository redisRepository;
     @Autowired private ObjectMapper objectMapper;
@@ -119,7 +122,16 @@ public class WaitingQueueService {
 
     public List<StreamQueueMessage> readGroup(
             String key, String group, String consumer, long count) {
-        return redisRepository.xReadGroup(key, group, consumer, count);
+        List<StreamQueueMessage> recovered =
+                redisRepository.xClaimStale(
+                        key, group, consumer, count, STREAM_PENDING_MIN_IDLE_TIME);
+        if (recovered.size() >= count) {
+            return recovered;
+        }
+
+        List<StreamQueueMessage> messages = new ArrayList<>(recovered);
+        messages.addAll(redisRepository.xReadGroup(key, group, consumer, count - recovered.size()));
+        return messages;
     }
 
     public Long acknowledge(String key, String group, String recordId) {

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -125,4 +125,12 @@ public class WaitingQueueService {
     public Long acknowledge(String key, String group, String recordId) {
         return redisRepository.xAck(key, group, recordId);
     }
+
+    public Long acknowledgeAndDelete(String key, String group, String recordId) {
+        Long acknowledged = redisRepository.xAck(key, group, recordId);
+        if (acknowledged != null && acknowledged > 0) {
+            redisRepository.xDelete(key, recordId);
+        }
+        return acknowledged;
+    }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -71,6 +71,7 @@ public class WaitingQueueService {
                         sequenceKey(eventId, sector.getId()),
                         reservedEmailKey(eventId),
                         key,
+                        closedKey(eventId),
                         registrationString,
                         userId,
                         sector.getId(),
@@ -202,6 +203,14 @@ public class WaitingQueueService {
         redisRepository.deleteKeysByPrefix(eventStockPrefix(eventId));
     }
 
+    public void expireEventStockKeys(Long eventId, Duration timeout) {
+        redisRepository.expireKeysByPrefix(eventStockPrefix(eventId), timeout);
+    }
+
+    public void markEventStockClosed(Long eventId, Duration timeout) {
+        redisRepository.set(closedKey(eventId), true, timeout);
+    }
+
     public String eventStockPrefix(Long eventId) {
         return "parking-ticket:event:{" + eventId + "}:";
     }
@@ -216,5 +225,9 @@ public class WaitingQueueService {
 
     public String reservedEmailKey(Long eventId) {
         return eventStockPrefix(eventId) + "reserved:email";
+    }
+
+    public String closedKey(Long eventId) {
+        return eventStockPrefix(eventId) + "closed";
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -57,20 +57,27 @@ public class WaitingQueueService {
             String key, Registration registration, Long userId, Sector sector, Long eventId)
             throws JsonProcessingException {
         String registrationString = convertRegistrationJSON(registration);
+        int issueAmount = sector.getIssueAmount();
+        int initialRemainingAmount =
+                Math.max(
+                        0,
+                        Math.min(
+                                Optional.ofNullable(sector.getRemainingAmount())
+                                        .orElse(issueAmount),
+                                issueAmount));
         StockReservationResult result =
                 redisRepository.reserveStockAndAddToStream(
                         stockKey(eventId, sector.getId()),
                         sequenceKey(eventId, sector.getId()),
                         reservedEmailKey(eventId),
-                        reservedStudentKey(eventId),
                         key,
                         registrationString,
                         userId,
                         sector.getId(),
                         eventId,
                         registration.getEmail(),
-                        registration.getStudentNum(),
-                        sector.getIssueAmount(),
+                        initialRemainingAmount,
+                        issueAmount,
                         sector.getInitSectorCapacity());
         tracker.info(
                 "Reserved Redis stock. sectorId: {}, reserved: {}, position: {}, status: {}, remaining: {}",
@@ -209,9 +216,5 @@ public class WaitingQueueService {
 
     public String reservedEmailKey(Long eventId) {
         return eventStockPrefix(eventId) + "reserved:email";
-    }
-
-    public String reservedStudentKey(Long eventId) {
-        return eventStockPrefix(eventId) + "reserved:student";
     }
 }

--- a/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
+++ b/Ticket-Infrastructure/src/main/java/com/jnu/ticketinfrastructure/service/WaitingQueueService.java
@@ -7,8 +7,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketdomain.domains.registration.exception.AlreadyExistRegistrationException;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -40,9 +42,8 @@ public class WaitingQueueService {
         Double score = (double) System.currentTimeMillis();
         String registrationString = convertRegistrationJSON(registration);
         ChatMessage message = new ChatMessage(registrationString, userId, sectorId, eventId);
-        checkDuplicateData(key, message);
-        redisRepository.zAddIfAbsent(key, message, score);
-        tracker.info("Added to the queue, score:{}", score);
+        redisRepository.xAdd(key, message);
+        tracker.info("Added to the stream, score:{}", score);
     }
 
     public String convertRegistrationJSON(Registration registration) {
@@ -114,5 +115,14 @@ public class WaitingQueueService {
 
     public Set<ZSetOperations.TypedTuple<Object>> findAllWithScore(String key) {
         return redisRepository.zRangeWithScores(key, 0L, -1L);
+    }
+
+    public List<StreamQueueMessage> readGroup(
+            String key, String group, String consumer, long count) {
+        return redisRepository.xReadGroup(key, group, consumer, count);
+    }
+
+    public Long acknowledge(String key, String group, String recordId) {
+        return redisRepository.xAck(key, group, recordId);
     }
 }

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -158,14 +158,13 @@ class RedisRepositoryStreamTest {
                         "stock",
                         "sequence",
                         "reserved-email",
-                        "reserved-student",
                         STREAM_KEY,
                         "{\"id\":10}",
                         1L,
                         2L,
                         3L,
                         "student@jnu.ac.kr",
-                        "20240001",
+                        300,
                         300,
                         250);
 
@@ -187,14 +186,13 @@ class RedisRepositoryStreamTest {
                         "stock",
                         "sequence",
                         "reserved-email",
-                        "reserved-student",
                         STREAM_KEY,
                         "{\"id\":10}",
                         1L,
                         2L,
                         3L,
                         "student@jnu.ac.kr",
-                        "20240001",
+                        300,
                         300,
                         250);
 

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -121,4 +121,15 @@ class RedisRepositoryStreamTest {
 
         assertThat(acknowledged).isEqualTo(1L);
     }
+
+    @Test
+    @DisplayName("xDelete는 처리 완료된 Stream record 삭제를 Redis에 위임한다")
+    void xDeleteDelegatesToStreamOperations() {
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.delete(STREAM_KEY, "1-0")).thenReturn(1L);
+
+        Long deleted = redisRepository.xDelete(STREAM_KEY, "1-0");
+
+        assertThat(deleted).isEqualTo(1L);
+    }
 }

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StockReservationResult;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import java.time.Duration;
 import java.util.List;
@@ -101,6 +103,104 @@ class RedisRepositoryStreamTest {
         assertThat(streamQueueMessage.getMessage().getUserId()).isEqualTo(1L);
         assertThat(streamQueueMessage.getMessage().getSectorId()).isEqualTo(2L);
         assertThat(streamQueueMessage.getMessage().getEventId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("xReadGroup은 Redis 예약 script가 저장한 확정 결과 필드를 ChatMessage로 복원한다")
+    void xReadGroupParsesReservedDecisionFields() {
+        MapRecord<String, Object, Object> record =
+                MapRecord.create(
+                                STREAM_KEY,
+                                Map.<Object, Object>of(
+                                        "registration",
+                                        "{\"id\":10}",
+                                        "userId",
+                                        "1",
+                                        "sectorId",
+                                        "2",
+                                        "eventId",
+                                        "3",
+                                        "position",
+                                        "4",
+                                        "resultStatus",
+                                        "PREPARE",
+                                        "sequence",
+                                        "2"))
+                        .withId(RecordId.of("1690000000000-1"));
+        when(redisTemplate.execute(any(RedisCallback.class))).thenReturn("OK");
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.read(
+                        any(Consumer.class), any(StreamReadOptions.class), any(StreamOffset.class)))
+                .thenReturn(List.of(record));
+
+        List<StreamQueueMessage> result =
+                redisRepository.xReadGroup(STREAM_KEY, GROUP, CONSUMER, 100);
+
+        ChatMessage message = result.get(0).getMessage();
+        assertThat(message.getRegistration()).isEqualTo("{\"id\":10}");
+        assertThat(message.getUserId()).isEqualTo(1L);
+        assertThat(message.getSectorId()).isEqualTo(2L);
+        assertThat(message.getEventId()).isEqualTo(3L);
+        assertThat(message.getPosition()).isEqualTo(4);
+        assertThat(message.getResultStatus()).isEqualTo(UserStatus.PREPARE);
+        assertThat(message.getSequence()).isEqualTo(2);
+        assertThat(message.hasDecision()).isTrue();
+    }
+
+    @Test
+    @DisplayName("reserveStockAndAddToStream은 Redis Lua 결과를 예약 성공으로 변환한다")
+    void reserveStockAndAddToStreamParsesReservedResult() {
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenReturn(List.of(1L, "RESERVED", 1L, "SUCCESS", -2L, 299L));
+
+        StockReservationResult result =
+                redisRepository.reserveStockAndAddToStream(
+                        "stock",
+                        "sequence",
+                        "reserved-email",
+                        "reserved-student",
+                        STREAM_KEY,
+                        "{\"id\":10}",
+                        1L,
+                        2L,
+                        3L,
+                        "student@jnu.ac.kr",
+                        "20240001",
+                        300,
+                        250);
+
+        assertThat(result.isReserved()).isTrue();
+        assertThat(result.getPosition()).isEqualTo(1);
+        assertThat(result.getResultStatus()).isEqualTo(UserStatus.SUCCESS);
+        assertThat(result.getSequence()).isEqualTo(-2);
+        assertThat(result.getRemainingAmount()).isEqualTo(299);
+    }
+
+    @Test
+    @DisplayName("reserveStockAndAddToStream은 Redis Lua 결과를 잔여 재고 없음으로 변환한다")
+    void reserveStockAndAddToStreamParsesNoStockResult() {
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenReturn(List.of(0L, "NO_STOCK", -1L, "", -1L, 0L));
+
+        StockReservationResult result =
+                redisRepository.reserveStockAndAddToStream(
+                        "stock",
+                        "sequence",
+                        "reserved-email",
+                        "reserved-student",
+                        STREAM_KEY,
+                        "{\"id\":10}",
+                        1L,
+                        2L,
+                        3L,
+                        "student@jnu.ac.kr",
+                        "20240001",
+                        300,
+                        250);
+
+        assertThat(result.isReserved()).isFalse();
+        assertThat(result.isNoStock()).isTrue();
+        assertThat(result.getRemainingAmount()).isZero();
     }
 
     @Test

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -12,6 +12,7 @@ import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StockReservationResult;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -199,6 +200,15 @@ class RedisRepositoryStreamTest {
         assertThat(result.isReserved()).isFalse();
         assertThat(result.isNoStock()).isTrue();
         assertThat(result.getRemainingAmount()).isZero();
+    }
+
+    @Test
+    @DisplayName("getIntegerValue는 Lua가 저장한 raw 숫자 문자열을 serializer 없이 조회한다")
+    void getIntegerValueReadsRawLuaValue() {
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenReturn("239".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(redisRepository.getIntegerValue("stock")).contains(239);
     }
 
     @Test

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -160,6 +161,7 @@ class RedisRepositoryStreamTest {
                         "sequence",
                         "reserved-email",
                         STREAM_KEY,
+                        "closed",
                         "{\"id\":10}",
                         1L,
                         2L,
@@ -188,6 +190,7 @@ class RedisRepositoryStreamTest {
                         "sequence",
                         "reserved-email",
                         STREAM_KEY,
+                        "closed",
                         "{\"id\":10}",
                         1L,
                         2L,
@@ -203,12 +206,52 @@ class RedisRepositoryStreamTest {
     }
 
     @Test
+    @DisplayName("reserveStockAndAddToStream은 종료 마커 결과를 이벤트 종료로 변환한다")
+    void reserveStockAndAddToStreamParsesClosedResult() {
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenReturn(List.of(0L, "CLOSED", -1L, "", -1L, 17L));
+
+        StockReservationResult result =
+                redisRepository.reserveStockAndAddToStream(
+                        "stock",
+                        "sequence",
+                        "reserved-email",
+                        STREAM_KEY,
+                        "closed",
+                        "{\"id\":10}",
+                        1L,
+                        2L,
+                        3L,
+                        "student@jnu.ac.kr",
+                        300,
+                        300,
+                        250);
+
+        assertThat(result.isReserved()).isFalse();
+        assertThat(result.isClosed()).isTrue();
+        assertThat(result.getRemainingAmount()).isEqualTo(17);
+    }
+
+    @Test
     @DisplayName("getIntegerValue는 Lua가 저장한 raw 숫자 문자열을 serializer 없이 조회한다")
     void getIntegerValueReadsRawLuaValue() {
         when(redisTemplate.execute(any(RedisCallback.class)))
                 .thenReturn("239".getBytes(StandardCharsets.UTF_8));
 
         assertThat(redisRepository.getIntegerValue("stock")).contains(239);
+    }
+
+    @Test
+    @DisplayName("expireKeysByPrefix는 조회된 모든 키에 동일한 TTL을 설정한다")
+    void expireKeysByPrefixExpiresEveryMatchingKey() {
+        Duration timeout = Duration.ofMinutes(5);
+        when(redisTemplate.keys("parking-ticket:event:{3}:*"))
+                .thenReturn(Set.of("stock", "sequence"));
+
+        redisRepository.expireKeysByPrefix("parking-ticket:event:{3}:", timeout);
+
+        verify(redisTemplate).expire("stock", timeout);
+        verify(redisTemplate).expire("sequence", timeout);
     }
 
     @Test

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,8 +21,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.stream.ByteRecord;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
@@ -38,6 +42,7 @@ class RedisRepositoryStreamTest {
 
     @Mock private RedisTemplate<String, Object> redisTemplate;
     @Mock private StreamOperations<String, Object, Object> streamOperations;
+    @Mock private ByteRecord byteRecord;
 
     private RedisRepository redisRepository;
     private ObjectMapper objectMapper;
@@ -109,6 +114,44 @@ class RedisRepositoryStreamTest {
 
         assertThatCode(() -> redisRepository.createConsumerGroupIfAbsent(STREAM_KEY, GROUP))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("xClaimStale은 idle 기준을 넘긴 pending record를 현재 consumer로 가져온다")
+    void xClaimStaleClaimsRecoverablePendingRecord() throws Exception {
+        ChatMessage message = new ChatMessage("{\"id\":10}", 1L, 2L, 3L);
+        MapRecord<String, Object, Object> record =
+                MapRecord.create(
+                                STREAM_KEY,
+                                Map.<Object, Object>of(
+                                        "payload", objectMapper.writeValueAsString(message)))
+                        .withId(RecordId.of("1-0"));
+        PendingMessage pendingMessage =
+                new PendingMessage(
+                        RecordId.of("1-0"),
+                        Consumer.from(GROUP, "stopped-consumer"),
+                        Duration.ofMinutes(1),
+                        2L);
+        PendingMessages pendingMessages = new PendingMessages(GROUP, List.of(pendingMessage));
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenReturn("OK")
+                .thenReturn(List.of(byteRecord));
+        when(streamOperations.pending(
+                        eq(STREAM_KEY),
+                        eq(GROUP),
+                        any(org.springframework.data.domain.Range.class),
+                        eq(10L)))
+                .thenReturn(pendingMessages);
+        when(streamOperations.deserializeRecord(byteRecord)).thenReturn(record);
+
+        List<StreamQueueMessage> result =
+                redisRepository.xClaimStale(
+                        STREAM_KEY, GROUP, CONSUMER, 10L, Duration.ofSeconds(30));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRecordId()).isEqualTo("1-0");
+        assertThat(result.get(0).getMessage().getUserId()).isEqualTo(1L);
     }
 
     @Test

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/redis/RedisRepositoryStreamTest.java
@@ -1,0 +1,124 @@
+package com.jnu.ticketinfrastructure.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisRepositoryStreamTest {
+
+    private static final String STREAM_KEY = "event-issue-stream";
+    private static final String GROUP = "event-issue-group";
+    private static final String CONSUMER = "event-issue-consumer";
+
+    @Mock private RedisTemplate<String, Object> redisTemplate;
+    @Mock private StreamOperations<String, Object, Object> streamOperations;
+
+    private RedisRepository redisRepository;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        redisRepository = new RedisRepository(redisTemplate);
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @DisplayName("xAdd는 ChatMessage를 payload JSON으로 직렬화해서 Stream에 추가한다")
+    void xAddSerializesChatMessageAsPayload() throws Exception {
+        ChatMessage message = new ChatMessage("{\"id\":10}", 1L, 2L, 3L);
+        RecordId recordId = RecordId.of("1-0");
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.add(eq(STREAM_KEY), any(Map.class))).thenReturn(recordId);
+
+        RecordId result = redisRepository.xAdd(STREAM_KEY, message);
+
+        assertThat(result).isEqualTo(recordId);
+        ArgumentCaptor<Map<String, String>> bodyCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(streamOperations).add(eq(STREAM_KEY), bodyCaptor.capture());
+
+        String payload = bodyCaptor.getValue().get("payload");
+        ChatMessage parsed = objectMapper.readValue(payload, ChatMessage.class);
+        assertThat(parsed.getRegistration()).isEqualTo("{\"id\":10}");
+        assertThat(parsed.getUserId()).isEqualTo(1L);
+        assertThat(parsed.getSectorId()).isEqualTo(2L);
+        assertThat(parsed.getEventId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("xReadGroup은 Stream record id와 payload를 StreamQueueMessage로 복원한다")
+    void xReadGroupParsesRecordIdAndPayload() throws Exception {
+        ChatMessage message = new ChatMessage("{\"id\":10}", 1L, 2L, 3L);
+        MapRecord<String, Object, Object> record =
+                MapRecord.create(
+                                STREAM_KEY,
+                                Map.<Object, Object>of(
+                                        "payload", objectMapper.writeValueAsString(message)))
+                        .withId(RecordId.of("1690000000000-0"));
+        when(redisTemplate.execute(any(RedisCallback.class))).thenReturn("OK");
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.read(
+                        any(Consumer.class), any(StreamReadOptions.class), any(StreamOffset.class)))
+                .thenReturn(List.of(record));
+
+        List<StreamQueueMessage> result =
+                redisRepository.xReadGroup(STREAM_KEY, GROUP, CONSUMER, 100);
+
+        assertThat(result).hasSize(1);
+        StreamQueueMessage streamQueueMessage = result.get(0);
+        assertThat(streamQueueMessage.getRecordId()).isEqualTo("1690000000000-0");
+        assertThat(streamQueueMessage.getMessage().getRegistration()).isEqualTo("{\"id\":10}");
+        assertThat(streamQueueMessage.getMessage().getUserId()).isEqualTo(1L);
+        assertThat(streamQueueMessage.getMessage().getSectorId()).isEqualTo(2L);
+        assertThat(streamQueueMessage.getMessage().getEventId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("consumer group이 이미 있으면 BUSYGROUP 예외를 성공으로 처리한다")
+    void createConsumerGroupIgnoresBusyGroup() {
+        when(redisTemplate.execute(any(RedisCallback.class)))
+                .thenThrow(
+                        new RedisSystemException(
+                                "BUSYGROUP Consumer Group name already exists",
+                                new RuntimeException()));
+
+        assertThatCode(() -> redisRepository.createConsumerGroupIfAbsent(STREAM_KEY, GROUP))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("xAck는 Stream record ACK를 Redis에 위임한다")
+    void xAckDelegatesToStreamOperations() {
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.acknowledge(STREAM_KEY, GROUP, "1-0")).thenReturn(1L);
+
+        Long acknowledged = redisRepository.xAck(STREAM_KEY, GROUP, "1-0");
+
+        assertThat(acknowledged).isEqualTo(1L);
+    }
+}

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -1,0 +1,108 @@
+package com.jnu.ticketinfrastructure.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
+import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WaitingQueueServiceTest {
+
+    private static final String STREAM_KEY = "event-issue-stream";
+
+    @Mock private RedisRepository redisRepository;
+
+    private WaitingQueueService waitingQueueService;
+
+    @BeforeEach
+    void setUp() {
+        waitingQueueService = new WaitingQueueService(redisRepository);
+    }
+
+    @Test
+    @DisplayName("신청 대기열 등록은 Redis Stream에 ChatMessage payload로 저장한다")
+    void registerQueueAddsMessageToRedisStream() throws Exception {
+        Registration registration = registration();
+
+        waitingQueueService.registerQueue(STREAM_KEY, registration, 1L, 2L, 3L);
+
+        ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+        verify(redisRepository).xAdd(eq(STREAM_KEY), messageCaptor.capture());
+        verify(redisRepository, never()).zAddIfAbsent(anyString(), any(), anyDouble());
+
+        ChatMessage message = messageCaptor.getValue();
+        assertThat(message.getUserId()).isEqualTo(1L);
+        assertThat(message.getSectorId()).isEqualTo(2L);
+        assertThat(message.getEventId()).isEqualTo(3L);
+
+        JSONObject payload = new JSONObject(message.getRegistration());
+        assertThat(payload.getLong("id")).isEqualTo(10L);
+        assertThat(payload.getString("email")).isEqualTo("student@jnu.ac.kr");
+        assertThat(payload.getString("studentNum")).isEqualTo("20240001");
+        assertThat(payload.getBoolean("isSaved")).isFalse();
+        assertThat(payload.getLong("eventId")).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("consumer group 조회는 Redis Stream readGroup에 위임한다")
+    void readGroupDelegatesToRedisStreamRepository() {
+        List<StreamQueueMessage> messages =
+                List.of(new StreamQueueMessage("1-0", new ChatMessage("{}", 1L, 2L, 3L)));
+        when(redisRepository.xReadGroup(STREAM_KEY, "group", "consumer", 100L))
+                .thenReturn(messages);
+
+        List<StreamQueueMessage> result =
+                waitingQueueService.readGroup(STREAM_KEY, "group", "consumer", 100L);
+
+        assertThat(result).isSameAs(messages);
+    }
+
+    @Test
+    @DisplayName("처리 완료된 Stream record는 acknowledge로 ACK 처리한다")
+    void acknowledgeDelegatesToRedisStreamRepository() {
+        when(redisRepository.xAck(STREAM_KEY, "group", "1-0")).thenReturn(1L);
+
+        Long acknowledged = waitingQueueService.acknowledge(STREAM_KEY, "group", "1-0");
+
+        assertThat(acknowledged).isEqualTo(1L);
+    }
+
+    private Registration registration() {
+        Registration registration =
+                Registration.builder()
+                        .email("student@jnu.ac.kr")
+                        .name("학생")
+                        .studentNum("20240001")
+                        .affiliation("공과대학")
+                        .department("컴퓨터공학과")
+                        .carNum("12가3456")
+                        .isLight(false)
+                        .phoneNum("010-0000-0000")
+                        .createdAt(LocalDateTime.of(2026, 6, 25, 10, 0))
+                        .isSaved(false)
+                        .savedAt(null)
+                        .eventId(3L)
+                        .build();
+        registration.setId(10L);
+        return registration;
+    }
+}

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -9,13 +9,17 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.jnu.ticketdomain.domains.events.domain.Sector;
 import com.jnu.ticketdomain.domains.registration.domain.Registration;
+import com.jnu.ticketdomain.domains.user.domain.UserStatus;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
+import com.jnu.ticketinfrastructure.model.StockReservationResult;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -61,6 +65,58 @@ class WaitingQueueServiceTest {
         assertThat(payload.getString("studentNum")).isEqualTo("20240001");
         assertThat(payload.getBoolean("isSaved")).isFalse();
         assertThat(payload.getLong("eventId")).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("Redis 예약 대기열 등록은 stock/sequence/중복 키와 Stream 저장을 한 번에 위임한다")
+    void reserveAndRegisterQueueDelegatesAtomicStockReservation() throws Exception {
+        Registration registration = registration();
+        Sector sector = org.mockito.Mockito.mock(Sector.class);
+        when(sector.getId()).thenReturn(2L);
+        when(sector.getIssueAmount()).thenReturn(300);
+        when(sector.getInitSectorCapacity()).thenReturn(250);
+        StockReservationResult reservationResult =
+                StockReservationResult.reserved(1, UserStatus.SUCCESS, -2, 299);
+        when(redisRepository.reserveStockAndAddToStream(
+                        eq("parking-ticket:event:{3}:sector:2:stock"),
+                        eq("parking-ticket:event:{3}:sector:2:sequence"),
+                        eq("parking-ticket:event:{3}:reserved:email"),
+                        eq("parking-ticket:event:{3}:reserved:student"),
+                        eq(STREAM_KEY),
+                        anyString(),
+                        eq(1L),
+                        eq(2L),
+                        eq(3L),
+                        eq("student@jnu.ac.kr"),
+                        eq("20240001"),
+                        eq(300),
+                        eq(250)))
+                .thenReturn(reservationResult);
+
+        StockReservationResult result =
+                waitingQueueService.reserveAndRegisterQueue(
+                        STREAM_KEY, registration, 1L, sector, 3L);
+
+        assertThat(result).isSameAs(reservationResult);
+        ArgumentCaptor<String> registrationPayloadCaptor = ArgumentCaptor.forClass(String.class);
+        verify(redisRepository)
+                .reserveStockAndAddToStream(
+                        eq("parking-ticket:event:{3}:sector:2:stock"),
+                        eq("parking-ticket:event:{3}:sector:2:sequence"),
+                        eq("parking-ticket:event:{3}:reserved:email"),
+                        eq("parking-ticket:event:{3}:reserved:student"),
+                        eq(STREAM_KEY),
+                        registrationPayloadCaptor.capture(),
+                        eq(1L),
+                        eq(2L),
+                        eq(3L),
+                        eq("student@jnu.ac.kr"),
+                        eq("20240001"),
+                        eq(300),
+                        eq(250));
+        JSONObject payload = new JSONObject(registrationPayloadCaptor.getValue());
+        assertThat(payload.getString("email")).isEqualTo("student@jnu.ac.kr");
+        assertThat(payload.getString("studentNum")).isEqualTo("20240001");
     }
 
     @Test
@@ -142,6 +198,25 @@ class WaitingQueueServiceTest {
         waitingQueueService.deleteEventStream(3L);
 
         verify(redisRepository).delete("쿠폰 발급 스트림:{3}");
+    }
+
+    @Test
+    @DisplayName("Redis 잔여 재고 조회는 stock key를 사용한다")
+    void findRemainingStockUsesStockKey() {
+        when(redisRepository.getIntegerValue("parking-ticket:event:{3}:sector:2:stock"))
+                .thenReturn(Optional.of(10));
+
+        Optional<Integer> remainingStock = waitingQueueService.findRemainingStock(3L, 2L);
+
+        assertThat(remainingStock).contains(10);
+    }
+
+    @Test
+    @DisplayName("이벤트 종료 시 event 단위 Redis 재고 키 prefix를 삭제한다")
+    void deleteEventStockKeysDeletesEventStockPrefix() {
+        waitingQueueService.deleteEventStockKeys(3L);
+
+        verify(redisRepository).deleteKeysByPrefix("parking-ticket:event:{3}:");
     }
 
     private Registration registration() {

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -13,6 +13,7 @@ import com.jnu.ticketdomain.domains.registration.domain.Registration;
 import com.jnu.ticketinfrastructure.model.ChatMessage;
 import com.jnu.ticketinfrastructure.model.StreamQueueMessage;
 import com.jnu.ticketinfrastructure.redis.RedisRepository;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.json.JSONObject;
@@ -67,13 +68,35 @@ class WaitingQueueServiceTest {
     void readGroupDelegatesToRedisStreamRepository() {
         List<StreamQueueMessage> messages =
                 List.of(new StreamQueueMessage("1-0", new ChatMessage("{}", 1L, 2L, 3L)));
+        when(redisRepository.xClaimStale(
+                        STREAM_KEY, "group", "consumer", 100L, Duration.ofSeconds(30)))
+                .thenReturn(List.of());
         when(redisRepository.xReadGroup(STREAM_KEY, "group", "consumer", 100L))
                 .thenReturn(messages);
 
         List<StreamQueueMessage> result =
                 waitingQueueService.readGroup(STREAM_KEY, "group", "consumer", 100L);
 
-        assertThat(result).isSameAs(messages);
+        assertThat(result).containsExactlyElementsOf(messages);
+    }
+
+    @Test
+    @DisplayName("stale pending record를 먼저 복구하고 남은 수만큼 새 메시지를 읽는다")
+    void readGroupRecoversStalePendingBeforeNewMessages() {
+        StreamQueueMessage recovered =
+                new StreamQueueMessage("1-0", new ChatMessage("{}", 1L, 2L, 3L));
+        StreamQueueMessage newMessage =
+                new StreamQueueMessage("2-0", new ChatMessage("{}", 2L, 2L, 3L));
+        when(redisRepository.xClaimStale(
+                        STREAM_KEY, "group", "consumer", 2L, Duration.ofSeconds(30)))
+                .thenReturn(List.of(recovered));
+        when(redisRepository.xReadGroup(STREAM_KEY, "group", "consumer", 1L))
+                .thenReturn(List.of(newMessage));
+
+        List<StreamQueueMessage> result =
+                waitingQueueService.readGroup(STREAM_KEY, "group", "consumer", 2L);
+
+        assertThat(result).containsExactly(recovered, newMessage);
     }
 
     @Test

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -83,6 +83,7 @@ class WaitingQueueServiceTest {
                         eq("parking-ticket:event:{3}:sector:2:sequence"),
                         eq("parking-ticket:event:{3}:reserved:email"),
                         eq(STREAM_KEY),
+                        eq("parking-ticket:event:{3}:closed"),
                         anyString(),
                         eq(1L),
                         eq(2L),
@@ -105,6 +106,7 @@ class WaitingQueueServiceTest {
                         eq("parking-ticket:event:{3}:sector:2:sequence"),
                         eq("parking-ticket:event:{3}:reserved:email"),
                         eq(STREAM_KEY),
+                        eq("parking-ticket:event:{3}:closed"),
                         registrationPayloadCaptor.capture(),
                         eq(1L),
                         eq(2L),
@@ -216,6 +218,26 @@ class WaitingQueueServiceTest {
         waitingQueueService.deleteEventStockKeys(3L);
 
         verify(redisRepository).deleteKeysByPrefix("parking-ticket:event:{3}:");
+    }
+
+    @Test
+    @DisplayName("이벤트 종료 시 drain 기간 동안 Redis 재고 키 만료를 지연한다")
+    void expireEventStockKeysUsesEventStockPrefix() {
+        Duration timeout = Duration.ofMinutes(5);
+
+        waitingQueueService.expireEventStockKeys(3L, timeout);
+
+        verify(redisRepository).expireKeysByPrefix("parking-ticket:event:{3}:", timeout);
+    }
+
+    @Test
+    @DisplayName("이벤트 종료 마커는 동일한 이벤트 hash slot에 TTL과 함께 저장한다")
+    void markEventStockClosedUsesEventClosedKey() {
+        Duration timeout = Duration.ofMinutes(5);
+
+        waitingQueueService.markEventStockClosed(3L, timeout);
+
+        verify(redisRepository).set("parking-ticket:event:{3}:closed", true, timeout);
     }
 
     private Registration registration() {

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -130,6 +130,20 @@ class WaitingQueueServiceTest {
         verify(redisRepository, never()).xDelete(STREAM_KEY, "1-0");
     }
 
+    @Test
+    @DisplayName("이벤트별 Stream key는 Redis Cluster hash tag에 eventId를 사용한다")
+    void eventStreamKeyUsesEventHashTag() {
+        assertThat(waitingQueueService.eventStreamKey(3L)).isEqualTo("쿠폰 발급 스트림:{3}");
+    }
+
+    @Test
+    @DisplayName("이벤트 삭제는 해당 이벤트의 Stream만 삭제한다")
+    void deleteEventStreamDeletesOnlyEventStreamKey() {
+        waitingQueueService.deleteEventStream(3L);
+
+        verify(redisRepository).delete("쿠폰 발급 스트림:{3}");
+    }
+
     private Registration registration() {
         Registration registration =
                 Registration.builder()

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -86,6 +86,27 @@ class WaitingQueueServiceTest {
         assertThat(acknowledged).isEqualTo(1L);
     }
 
+    @Test
+    @DisplayName("ACK에 성공한 Stream record는 원본 entry도 삭제한다")
+    void acknowledgeAndDeleteRemovesAcknowledgedRecord() {
+        when(redisRepository.xAck(STREAM_KEY, "group", "1-0")).thenReturn(1L);
+
+        Long acknowledged = waitingQueueService.acknowledgeAndDelete(STREAM_KEY, "group", "1-0");
+
+        assertThat(acknowledged).isEqualTo(1L);
+        verify(redisRepository).xDelete(STREAM_KEY, "1-0");
+    }
+
+    @Test
+    @DisplayName("ACK하지 못한 Stream record는 삭제하지 않는다")
+    void acknowledgeAndDeleteKeepsUnacknowledgedRecord() {
+        when(redisRepository.xAck(STREAM_KEY, "group", "1-0")).thenReturn(0L);
+
+        waitingQueueService.acknowledgeAndDelete(STREAM_KEY, "group", "1-0");
+
+        verify(redisRepository, never()).xDelete(STREAM_KEY, "1-0");
+    }
+
     private Registration registration() {
         Registration registration =
                 Registration.builder()

--- a/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
+++ b/Ticket-Infrastructure/src/test/java/com/jnu/ticketinfrastructure/service/WaitingQueueServiceTest.java
@@ -68,11 +68,12 @@ class WaitingQueueServiceTest {
     }
 
     @Test
-    @DisplayName("Redis 예약 대기열 등록은 stock/sequence/중복 키와 Stream 저장을 한 번에 위임한다")
+    @DisplayName("Redis 예약은 DB 잔여여석과 이메일 중복 키, Stream 저장을 한 번에 위임한다")
     void reserveAndRegisterQueueDelegatesAtomicStockReservation() throws Exception {
         Registration registration = registration();
         Sector sector = org.mockito.Mockito.mock(Sector.class);
         when(sector.getId()).thenReturn(2L);
+        when(sector.getRemainingAmount()).thenReturn(240);
         when(sector.getIssueAmount()).thenReturn(300);
         when(sector.getInitSectorCapacity()).thenReturn(250);
         StockReservationResult reservationResult =
@@ -81,14 +82,13 @@ class WaitingQueueServiceTest {
                         eq("parking-ticket:event:{3}:sector:2:stock"),
                         eq("parking-ticket:event:{3}:sector:2:sequence"),
                         eq("parking-ticket:event:{3}:reserved:email"),
-                        eq("parking-ticket:event:{3}:reserved:student"),
                         eq(STREAM_KEY),
                         anyString(),
                         eq(1L),
                         eq(2L),
                         eq(3L),
                         eq("student@jnu.ac.kr"),
-                        eq("20240001"),
+                        eq(240),
                         eq(300),
                         eq(250)))
                 .thenReturn(reservationResult);
@@ -104,14 +104,13 @@ class WaitingQueueServiceTest {
                         eq("parking-ticket:event:{3}:sector:2:stock"),
                         eq("parking-ticket:event:{3}:sector:2:sequence"),
                         eq("parking-ticket:event:{3}:reserved:email"),
-                        eq("parking-ticket:event:{3}:reserved:student"),
                         eq(STREAM_KEY),
                         registrationPayloadCaptor.capture(),
                         eq(1L),
                         eq(2L),
                         eq(3L),
                         eq("student@jnu.ac.kr"),
-                        eq("20240001"),
+                        eq(240),
                         eq(300),
                         eq(250));
         JSONObject payload = new JSONObject(registrationPayloadCaptor.getValue());

--- a/initdb/init.sql
+++ b/initdb/init.sql
@@ -464,6 +464,9 @@ create table registration_tb
     name        varchar(255)     not null,
     phone_num   varchar(255)     not null,
     saved_at    bigint           null,
+    position    int              null,
+    result_status varchar(255)   null,
+    sequence    int              null,
     student_num varchar(255)     not null,
     sector_id   bigint           not null,
     user_id     bigint           null,
@@ -477,3 +480,22 @@ create table registration_tb
         unique (event_id, email, student_num)
 );
 
+create table email_outbox
+(
+    id              bigint auto_increment
+        primary key,
+    event_id        bigint       not null,
+    registration_id bigint       not null,
+    email           varchar(255) not null,
+    name            varchar(255) not null,
+    result_status   varchar(255) not null,
+    sequence        int          not null,
+    created_at      datetime(6)  not null,
+    processing_at   datetime(6)  null,
+    sent_at         datetime(6)  null,
+    retry_count     int          not null,
+    constraint uk_email_outbox_registration_id
+        unique (registration_id),
+    constraint FK_email_outbox_registration
+        foreign key (registration_id) references registration_tb (id)
+);

--- a/test-script/k6_test_registration.js
+++ b/test-script/k6_test_registration.js
@@ -1,0 +1,719 @@
+import http from "k6/http";
+import exec from "k6/execution";
+import { check, fail, sleep } from "k6";
+import { Counter, Gauge, Rate, Trend } from "k6/metrics";
+
+const BASE_URL = (__ENV.BASE_URL || "http://localhost:8080").replace(/\/+$/, "");
+const EVENT_ID = requiredPositiveInteger("EVENT_ID");
+const RUN_ID = requiredRunId();
+const CAPTCHA_ANSWER = requiredEnvironmentValue("CAPTCHA_ANSWER");
+const TARGET_RPS = positiveInteger("TARGET_RPS", 3000);
+const LOAD_DURATION_SECONDS = positiveInteger("LOAD_DURATION_SECONDS", 1);
+const TOTAL_REQUESTS = TARGET_RPS * LOAD_DURATION_SECONDS;
+const BURST_WINDOW_MS = nonNegativeInteger(
+  "BURST_WINDOW_MS",
+  LOAD_DURATION_SECONDS * 1000,
+);
+const REQUESTS_PER_VU = positiveInteger("REQUESTS_PER_VU", 5);
+const LOAD_VUS = Math.ceil(TOTAL_REQUESTS / REQUESTS_PER_VU);
+const PREPARE_VUS_PER_SECOND = positiveInteger("PREPARE_VUS_PER_SECOND", 10);
+const PREPARATION_BUFFER_SECONDS = positiveInteger("PREPARATION_BUFFER_SECONDS", 30);
+const PREPARATION_WINDOW_SECONDS =
+  Math.ceil(LOAD_VUS / PREPARE_VUS_PER_SECOND) + PREPARATION_BUFFER_SECONDS;
+const MIN_EVENT_REMAINING_SECONDS = positiveInteger(
+  "MIN_EVENT_REMAINING_SECONDS",
+  PREPARATION_WINDOW_SECONDS + LOAD_DURATION_SECONDS + 30,
+);
+const MAX_START_DELAY_P95_MS = positiveInteger("MAX_START_DELAY_P95_MS", 500);
+const PASSWORD = __ENV.USER_PASSWORD || "Password!123";
+const INCLUDE_DEPARTMENT = (__ENV.INCLUDE_DEPARTMENT || "true") !== "false";
+const REUSE_HTTP_CONNECTIONS = (__ENV.REUSE_HTTP_CONNECTIONS || "false") === "true";
+const MONITOR_HIKARI = (__ENV.MONITOR_HIKARI || "false") === "true";
+const HIKARI_MONITOR_BEFORE_MS = nonNegativeInteger("HIKARI_MONITOR_BEFORE_MS", 1000);
+const HIKARI_MONITOR_AFTER_MS = positiveInteger("HIKARI_MONITOR_AFTER_MS", 10000);
+const HIKARI_MONITOR_INTERVAL_MS = positiveInteger("HIKARI_MONITOR_INTERVAL_MS", 50);
+const SUMMARY_PATH =
+  __ENV.SUMMARY_PATH || "test-script/registration-load-summary.json";
+const CONFIGURED_SECTOR_IDS = parseSectorIds(__ENV.SECTOR_IDS);
+
+const attempted = new Counter("registration_attempted");
+const accepted = new Counter("registration_accepted");
+const noStock = new Counter("registration_no_stock");
+const unexpected = new Counter("registration_unexpected");
+const transportErrors = new Counter("registration_transport_errors");
+const serverErrors = new Counter("registration_server_errors");
+const unexpectedClientErrors = new Counter("registration_unexpected_client_errors");
+const unexpectedRate = new Rate("registration_unexpected_rate");
+const registrationDuration = new Trend("registration_request_duration", true);
+const registrationAcceptedDuration = new Trend("registration_accepted_duration", true);
+const registrationNoStockDuration = new Trend("registration_no_stock_duration", true);
+const registrationStartDelay = new Trend("registration_start_delay", true);
+const hikariActive = new Gauge("hikari_active_connections");
+const hikariPending = new Gauge("hikari_pending_threads");
+const hikariTimeout = new Gauge("hikari_connection_timeouts");
+let loggedUnexpectedResponse = false;
+
+const scenarios = {
+  registration_burst: {
+    executor: "per-vu-iterations",
+    vus: LOAD_VUS,
+    iterations: 1,
+    maxDuration:
+      __ENV.MAX_DURATION ||
+      `${PREPARATION_WINDOW_SECONDS + LOAD_DURATION_SECONDS + 120}s`,
+  },
+};
+
+if (MONITOR_HIKARI) {
+  scenarios.hikari_monitor = {
+    executor: "shared-iterations",
+    vus: 1,
+    iterations: 1,
+    exec: "monitorHikari",
+    maxDuration: `${PREPARATION_WINDOW_SECONDS + 60}s`,
+  };
+}
+
+export const options = {
+  setupTimeout: __ENV.SETUP_TIMEOUT || "5m",
+  // Prepared users can wait longer than Tomcat's keep-alive timeout before the burst.
+  noConnectionReuse: !REUSE_HTTP_CONNECTIONS,
+  batch: Math.max(REQUESTS_PER_VU, 20),
+  batchPerHost: Math.max(REQUESTS_PER_VU, 20),
+  scenarios,
+  thresholds: {
+    [`http_req_failed{phase:prepare}`]: ["rate==0"],
+    registration_attempted: [`count==${TOTAL_REQUESTS}`],
+    registration_unexpected_rate: ["rate==0"],
+    registration_request_duration: ["p(95)<5000"],
+    registration_start_delay: [`p(95)<${MAX_START_DELAY_P95_MS}`],
+  },
+  summaryTrendStats: ["min", "avg", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export function setup() {
+  const active = readActiveEvent();
+  const sectors = selectSectors(readActiveSectors());
+  validateEventWindow(active.dateTimePeriod);
+
+  const firstUser = loginSingleUser(0);
+  firstUser.captchaCode = requestCaptcha(firstUser.accessToken, 0);
+  const burstAt = Date.now() + PREPARATION_WINDOW_SECONDS * 1000;
+
+  console.log(
+    [
+      `Preparing ${TOTAL_REQUESTS} users for run ${RUN_ID}.`,
+      `eventId=${EVENT_ID}`,
+      `sectorIds=${sectors.map((sector) => sector.id).join(",")}`,
+      `configuredIssueAmount=${sectors.reduce((sum, sector) => sum + sector.issueAmount, 0)}`,
+      `loadVUs=${LOAD_VUS}`,
+      `requestsPerVU=${REQUESTS_PER_VU}`,
+      `reuseHttpConnections=${REUSE_HTTP_CONNECTIONS}`,
+      `burstWindowMs=${BURST_WINDOW_MS}`,
+      `burstStartsIn=${PREPARATION_WINDOW_SECONDS}s`,
+    ].join(" "),
+  );
+
+  return {
+    eventId: EVENT_ID,
+    firstUser,
+    sectorIds: sectors.map((sector) => sector.id),
+    burstAt,
+  };
+}
+
+export default function (data) {
+  const batchIndex = Number(exec.scenario.iterationInTest);
+  const startIndex = batchIndex * REQUESTS_PER_VU;
+  const endIndex = Math.min(startIndex + REQUESTS_PER_VU, TOTAL_REQUESTS);
+  if (startIndex >= TOTAL_REQUESTS) {
+    return;
+  }
+
+  sleep(batchIndex / PREPARE_VUS_PER_SECOND);
+  const users = prepareUsersForBatch(data, startIndex, endIndex);
+
+  const scheduledAt =
+    data.burstAt +
+    Math.floor((startIndex / TOTAL_REQUESTS) * BURST_WINDOW_MS);
+  sleepUntil(scheduledAt);
+  registrationStartDelay.add(Math.max(0, Date.now() - scheduledAt));
+
+  const requests = users.map((user) => {
+    const sectorId = data.sectorIds[user.index % data.sectorIds.length];
+    return {
+      method: "POST",
+      url: `${BASE_URL}/api/v1/registration/${data.eventId}`,
+      body: JSON.stringify(registrationPayload(user.index, sectorId, user.captchaCode)),
+      params: {
+        headers: authorizedJsonHeaders(user.accessToken),
+        tags: {
+          phase: "load",
+          endpoint: "final-registration",
+          sector_id: String(sectorId),
+        },
+        responseCallback: http.expectedStatuses(200, 400),
+      },
+    };
+  });
+
+  const responses = http.batch(requests);
+  responses.forEach((response, offset) => {
+    const user = users[offset];
+    const sectorId = data.sectorIds[user.index % data.sectorIds.length];
+    recordRegistrationResult(response, sectorId);
+  });
+}
+
+export function monitorHikari(data) {
+  sleepUntil(data.burstAt - HIKARI_MONITOR_BEFORE_MS);
+  const monitorUntil = data.burstAt + HIKARI_MONITOR_AFTER_MS;
+
+  while (Date.now() <= monitorUntil) {
+    const names = [
+      "hikaricp.connections.active",
+      "hikaricp.connections.pending",
+      "hikaricp.connections.timeout",
+    ];
+    const responses = http.batch(
+      names.map((name) => ({
+        method: "GET",
+        url: `${BASE_URL}/api/actuator/metrics/${name}`,
+        params: {
+          tags: { phase: "monitor", endpoint: name },
+          responseCallback: http.expectedStatuses(200),
+        },
+      })),
+    );
+
+    hikariActive.add(actuatorMeasurement(responses[0]));
+    hikariPending.add(actuatorMeasurement(responses[1]));
+    hikariTimeout.add(actuatorMeasurement(responses[2]));
+    sleep(HIKARI_MONITOR_INTERVAL_MS / 1000);
+  }
+}
+
+export function teardown(data) {
+  console.log(
+    `HTTP load is complete. Verify async persistence with: RUN_ID=${RUN_ID} EVENT_ID=${data.eventId} test-script/verify_registration_load_test.sh`,
+  );
+}
+
+export function handleSummary(data) {
+  const attemptedCount = metricValue(data, "registration_attempted", "count");
+  const acceptedCount = metricValue(data, "registration_accepted", "count");
+  const noStockCount = metricValue(data, "registration_no_stock", "count");
+  const unexpectedCount = metricValue(data, "registration_unexpected", "count");
+  const transportErrorCount = metricValue(
+    data,
+    "registration_transport_errors",
+    "count",
+  );
+  const serverErrorCount = metricValue(data, "registration_server_errors", "count");
+  const unexpectedClientErrorCount = metricValue(
+    data,
+    "registration_unexpected_client_errors",
+    "count",
+  );
+  const durationP95 = metricValue(data, "registration_request_duration", "p(95)");
+  const durationAvg = metricValue(data, "registration_request_duration", "avg");
+  const durationMedian = metricValue(data, "registration_request_duration", "med");
+  const durationP99 = metricValue(data, "registration_request_duration", "p(99)");
+  const acceptedDurationAvg = metricValue(data, "registration_accepted_duration", "avg");
+  const acceptedDurationP95 = metricValue(
+    data,
+    "registration_accepted_duration",
+    "p(95)",
+  );
+  const noStockDurationAvg = metricValue(
+    data,
+    "registration_no_stock_duration",
+    "avg",
+  );
+  const noStockDurationP95 = metricValue(
+    data,
+    "registration_no_stock_duration",
+    "p(95)",
+  );
+  const startDelayP95 = metricValue(data, "registration_start_delay", "p(95)");
+  const hikariActiveMax = monitoredMetricValue(
+    data,
+    "hikari_active_connections",
+    "max",
+  );
+  const hikariPendingMax = monitoredMetricValue(
+    data,
+    "hikari_pending_threads",
+    "max",
+  );
+  const hikariTimeoutMax = monitoredMetricValue(
+    data,
+    "hikari_connection_timeouts",
+    "max",
+  );
+
+  const report = {
+    metadata: {
+      runId: RUN_ID,
+      eventId: EVENT_ID,
+      baseUrl: BASE_URL,
+      targetRps: TARGET_RPS,
+      loadDurationSeconds: LOAD_DURATION_SECONDS,
+      burstWindowMs: BURST_WINDOW_MS,
+      plannedRequests: TOTAL_REQUESTS,
+      requestsPerVu: REQUESTS_PER_VU,
+      loadVUs: LOAD_VUS,
+      reuseHttpConnections: REUSE_HTTP_CONNECTIONS,
+      monitorHikari: MONITOR_HIKARI,
+      configuredSectorIds: CONFIGURED_SECTOR_IDS,
+    },
+    result: {
+      attempted: attemptedCount,
+      accepted: acceptedCount,
+      noStock: noStockCount,
+      unexpected: unexpectedCount,
+      transportErrors: transportErrorCount,
+      serverErrors: serverErrorCount,
+      unexpectedClientErrors: unexpectedClientErrorCount,
+      registrationDurationAvgMs: durationAvg,
+      registrationDurationMedianMs: durationMedian,
+      registrationDurationP95Ms: durationP95,
+      registrationDurationP99Ms: durationP99,
+      acceptedDurationAvgMs: acceptedDurationAvg,
+      acceptedDurationP95Ms: acceptedDurationP95,
+      noStockDurationAvgMs: noStockDurationAvg,
+      noStockDurationP95Ms: noStockDurationP95,
+      registrationStartDelayP95Ms: startDelayP95,
+      hikariActiveMax,
+      hikariPendingMax,
+      hikariTimeoutMax,
+    },
+    k6: data,
+  };
+
+  const stdout = [
+    "",
+    "Registration load-test result",
+    `  run id:               ${RUN_ID}`,
+    `  planned requests:     ${TOTAL_REQUESTS}`,
+    `  attempted requests:   ${attemptedCount}`,
+    `  accepted (200):       ${acceptedCount}`,
+    `  no stock (400):       ${noStockCount}`,
+    `  unexpected:           ${unexpectedCount}`,
+    `    transport errors:   ${transportErrorCount}`,
+    `    server errors:      ${serverErrorCount}`,
+    `    other responses:    ${unexpectedClientErrorCount}`,
+    `  registration avg ms:  ${durationAvg}`,
+    `  registration p50 ms:  ${durationMedian}`,
+    `  registration p95 ms:  ${durationP95}`,
+    `  registration p99 ms:  ${durationP99}`,
+    `  accepted avg ms:      ${acceptedDurationAvg}`,
+    `  accepted p95 ms:      ${acceptedDurationP95}`,
+    `  no stock avg ms:      ${noStockDurationAvg}`,
+    `  no stock p95 ms:      ${noStockDurationP95}`,
+    `  start delay p95 ms:   ${startDelayP95}`,
+    `  Hikari active max:    ${displayMonitoredMetric(hikariActiveMax)}`,
+    `  Hikari pending max:   ${displayMonitoredMetric(hikariPendingMax)}`,
+    `  Hikari timeout max:   ${displayMonitoredMetric(hikariTimeoutMax)}`,
+    `  summary file:         ${SUMMARY_PATH}`,
+    "",
+  ].join("\n");
+
+  return {
+    stdout,
+    [SUMMARY_PATH]: JSON.stringify(report, null, 2),
+  };
+}
+
+function prepareUsersForBatch(data, startIndex, endIndex) {
+  const users = [];
+  let nextIndex = startIndex;
+
+  if (startIndex === 0) {
+    users.push(data.firstUser);
+    nextIndex = 1;
+  }
+
+  if (nextIndex < endIndex) {
+    const newUsers = loginUserBatch(nextIndex, endIndex);
+    requestCaptchaBatch(newUsers);
+    users.push(...newUsers);
+  }
+
+  return users;
+}
+
+function recordRegistrationResult(response, sectorId) {
+  attempted.add(1, { sector_id: String(sectorId) });
+  registrationDuration.add(response.timings.duration, { sector_id: String(sectorId) });
+
+  const status = Number(response.status || 0);
+  const code = response.status === 400 ? responseErrorCode(response) : null;
+  const isAccepted = status === 200;
+  const isNoStock = status === 400 && code === "EVENT_400_2";
+  const isUnexpected = !isAccepted && !isNoStock;
+  const metricTags = {
+    sector_id: String(sectorId),
+    status: String(status),
+    code: code || response.error_code || "UNKNOWN",
+  };
+
+  if (isAccepted) {
+    accepted.add(1, { sector_id: String(sectorId) });
+    registrationAcceptedDuration.add(response.timings.duration, {
+      sector_id: String(sectorId),
+    });
+  } else if (isNoStock) {
+    noStock.add(1, { sector_id: String(sectorId) });
+    registrationNoStockDuration.add(response.timings.duration, {
+      sector_id: String(sectorId),
+    });
+  } else {
+    unexpected.add(1, metricTags);
+    recordUnexpectedResponse(response, metricTags);
+  }
+
+  unexpectedRate.add(isUnexpected);
+  check(response, {
+    "registration was accepted or rejected because stock was exhausted": () =>
+      !isUnexpected,
+  });
+}
+
+function recordUnexpectedResponse(response, metricTags) {
+  const status = Number(response.status || 0);
+  if (status === 0) {
+    transportErrors.add(1, metricTags);
+  } else if (status >= 500) {
+    serverErrors.add(1, metricTags);
+  } else {
+    unexpectedClientErrors.add(1, metricTags);
+  }
+
+  if (!loggedUnexpectedResponse) {
+    loggedUnexpectedResponse = true;
+    console.warn(
+      [
+        "Unexpected registration response.",
+        `status=${status}`,
+        `errorCode=${response.error_code || "none"}`,
+        `error=${response.error || "none"}`,
+        `body=${String(response.body || "").slice(0, 300)}`,
+      ].join(" "),
+    );
+  }
+}
+
+function readActiveEvent() {
+  const response = http.get(`${BASE_URL}/api/v1/events/period`, {
+    tags: { phase: "prepare", endpoint: "active-event" },
+  });
+  assertResponseStatus(response, 200, "active event lookup");
+
+  const event = responseJson(response, "active event lookup");
+  if (Number(event.eventId) !== EVENT_ID) {
+    fail(`Configured EVENT_ID=${EVENT_ID}, but active published event is ${event.eventId}`);
+  }
+  return event;
+}
+
+function readActiveSectors() {
+  const response = http.get(`${BASE_URL}/api/v1/sectors`, {
+    tags: { phase: "prepare", endpoint: "active-sectors" },
+  });
+  assertResponseStatus(response, 200, "active sector lookup");
+
+  const sectors = responseJson(response, "active sector lookup");
+  if (!Array.isArray(sectors) || sectors.length === 0) {
+    fail("The active published event has no sectors");
+  }
+  return sectors;
+}
+
+function selectSectors(sectors) {
+  const selected = CONFIGURED_SECTOR_IDS
+    ? sectors.filter((sector) => CONFIGURED_SECTOR_IDS.includes(Number(sector.id)))
+    : sectors;
+
+  if (CONFIGURED_SECTOR_IDS && selected.length !== CONFIGURED_SECTOR_IDS.length) {
+    const available = sectors.map((sector) => sector.id).join(",");
+    fail(`SECTOR_IDS contains an inactive sector. Available sector ids: ${available}`);
+  }
+  if (selected.some((sector) => Number(sector.issueAmount) <= 0)) {
+    fail("Every selected sector must have issueAmount greater than zero");
+  }
+
+  return selected.map((sector) => ({
+    id: Number(sector.id),
+    issueAmount: Number(sector.issueAmount),
+  }));
+}
+
+function validateEventWindow(period) {
+  if (!period || !period.startAt || !period.endAt) {
+    fail("The active event response does not contain a valid dateTimePeriod");
+  }
+
+  const now = Date.now();
+  const startAt = parseSeoulDateTime(period.startAt);
+  const endAt = parseSeoulDateTime(period.endAt);
+
+  if (now < startAt) {
+    fail("The event is published but not OPEN yet");
+  }
+  if (now >= endAt) {
+    fail("The event has already ended");
+  }
+
+  const remainingSeconds = Math.floor((endAt - now) / 1000);
+  if (remainingSeconds < MIN_EVENT_REMAINING_SECONDS) {
+    fail(
+      `Only ${remainingSeconds}s remain in the event. At least ${MIN_EVENT_REMAINING_SECONDS}s is required for preparation and load execution`,
+    );
+  }
+}
+
+function loginSingleUser(index) {
+  const email = loadTestEmail(index);
+  const response = http.post(
+    `${BASE_URL}/api/v1/auth/login`,
+    loginPayload(email),
+    jsonParams("prepare", "login"),
+  );
+  assertResponseStatus(response, 200, `login for ${email}`);
+  return preparedUser(index, email, response, `login for ${email}`);
+}
+
+function loginUserBatch(startIndex, endIndex) {
+  const requests = [];
+  const emails = [];
+
+  for (let index = startIndex; index < endIndex; index += 1) {
+    const email = loadTestEmail(index);
+    emails.push(email);
+    requests.push({
+      method: "POST",
+      url: `${BASE_URL}/api/v1/auth/login`,
+      body: loginPayload(email),
+      params: jsonParams("prepare", "login"),
+    });
+  }
+
+  const responses = http.batch(requests);
+  return responses.map((response, offset) => {
+    const index = startIndex + offset;
+    const email = emails[offset];
+    assertResponseStatus(response, 200, `login for ${email}`);
+    return preparedUser(index, email, response, `login for ${email}`);
+  });
+}
+
+function requestCaptcha(accessToken, index) {
+  const response = http.get(`${BASE_URL}/api/v1/captcha`, {
+    headers: authorizedJsonHeaders(accessToken),
+    tags: { phase: "prepare", endpoint: "captcha" },
+  });
+  assertResponseStatus(response, 200, `captcha request for user ${index}`);
+  return captchaCode(response, `captcha request for user ${index}`);
+}
+
+function requestCaptchaBatch(users) {
+  const requests = users.map((user) => ({
+    method: "GET",
+    url: `${BASE_URL}/api/v1/captcha`,
+    params: {
+      headers: authorizedJsonHeaders(user.accessToken),
+      tags: { phase: "prepare", endpoint: "captcha" },
+    },
+  }));
+
+  const responses = http.batch(requests);
+  responses.forEach((response, offset) => {
+    const user = users[offset];
+    assertResponseStatus(response, 200, `captcha request for user ${user.index}`);
+    user.captchaCode = captchaCode(response, `captcha request for user ${user.index}`);
+  });
+}
+
+function preparedUser(index, email, response, label) {
+  const body = responseJson(response, label);
+  if (!body.accessToken) {
+    fail(`${label} did not return accessToken`);
+  }
+  return { index, email, accessToken: body.accessToken, captchaCode: null };
+}
+
+function captchaCode(response, label) {
+  const body = responseJson(response, label);
+  if (!body.captchaCode) {
+    fail(`${label} did not return captchaCode`);
+  }
+  return body.captchaCode;
+}
+
+function registrationPayload(index, sectorId, code) {
+  const serial = String(index % 900000).padStart(6, "0");
+  const phoneSerial = String(index % 100000000).padStart(8, "0");
+  const payload = {
+    name: `load-user-${index}`,
+    studentNum: serial,
+    affiliation: "공과대학",
+    carNum: `12가${String(index % 10000).padStart(4, "0")}`,
+    isLight: index % 2 === 0,
+    phoneNum: `010-${phoneSerial.slice(0, 4)}-${phoneSerial.slice(4)}`,
+    selectSectorId: sectorId,
+    captchaCode: code,
+    captchaAnswer: CAPTCHA_ANSWER,
+  };
+  if (INCLUDE_DEPARTMENT) {
+    payload.department = "컴퓨터정보통신공학과";
+  }
+  return payload;
+}
+
+function loginPayload(email) {
+  return JSON.stringify({ email, pwd: PASSWORD });
+}
+
+function loadTestEmail(index) {
+  return `load-${RUN_ID}-${String(index).padStart(6, "0")}@example.com`;
+}
+
+function authorizedJsonHeaders(accessToken) {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+  };
+}
+
+function jsonParams(phase, endpoint) {
+  return {
+    headers: { "Content-Type": "application/json" },
+    tags: { phase, endpoint },
+  };
+}
+
+function sleepUntil(epochMilliseconds) {
+  const delayMilliseconds = epochMilliseconds - Date.now();
+  if (delayMilliseconds > 0) {
+    sleep(delayMilliseconds / 1000);
+  }
+}
+
+function responseJson(response, label) {
+  try {
+    return response.json();
+  } catch (error) {
+    fail(`${label} returned invalid JSON: ${String(response.body).slice(0, 300)}`);
+  }
+}
+
+function responseErrorCode(response) {
+  try {
+    return response.json().code || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function assertResponseStatus(response, expectedStatus, label) {
+  if (response.status !== expectedStatus) {
+    fail(
+      `${label} failed with HTTP ${response.status}: ${String(response.body).slice(0, 500)}`,
+    );
+  }
+}
+
+function parseSeoulDateTime(value) {
+  const millisecondPrecision = String(value).replace(/(\.\d{3})\d+$/, "$1");
+  const parsed = Date.parse(`${millisecondPrecision}+09:00`);
+  if (Number.isNaN(parsed)) {
+    fail(`Cannot parse event date-time: ${value}`);
+  }
+  return parsed;
+}
+
+function parseSectorIds(raw) {
+  if (!raw) {
+    return null;
+  }
+  const ids = raw.split(",").map((value) => Number(value.trim()));
+  if (ids.some((id) => !Number.isInteger(id) || id <= 0)) {
+    throw new Error("SECTOR_IDS must be a comma-separated list of positive integers");
+  }
+  return [...new Set(ids)];
+}
+
+function requiredEnvironmentValue(name) {
+  const value = __ENV[name];
+  if (!value) {
+    throw new Error(`${name} environment variable is required`);
+  }
+  return value;
+}
+
+function requiredPositiveInteger(name) {
+  const value = Number(requiredEnvironmentValue(name));
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function positiveInteger(name, fallback) {
+  const value = __ENV[name] ? Number(__ENV[name]) : fallback;
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(name, fallback) {
+  const value = __ENV[name] !== undefined ? Number(__ENV[name]) : fallback;
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function requiredRunId() {
+  const runId = __ENV.RUN_ID;
+  if (!runId) {
+    throw new Error(
+      "RUN_ID is required when k6 is called directly. Use test-script/run_registration_load_test.sh to generate it automatically",
+    );
+  }
+  if (!/^[A-Za-z0-9-]+$/.test(runId)) {
+    throw new Error("RUN_ID may contain only letters, numbers, and hyphens");
+  }
+  return runId;
+}
+
+function metricValue(data, metricName, valueName) {
+  const metric = data.metrics[metricName];
+  if (!metric || !metric.values || metric.values[valueName] === undefined) {
+    return 0;
+  }
+  return metric.values[valueName];
+}
+
+function monitoredMetricValue(data, metricName, valueName) {
+  return MONITOR_HIKARI ? metricValue(data, metricName, valueName) : null;
+}
+
+function displayMonitoredMetric(value) {
+  return value === null ? "disabled" : value;
+}
+
+function actuatorMeasurement(response) {
+  if (!response || response.status !== 200) {
+    return 0;
+  }
+  try {
+    const body = response.json();
+    const measurement = body.measurements && body.measurements[0];
+    return measurement ? Number(measurement.value) : 0;
+  } catch (error) {
+    return 0;
+  }
+}

--- a/test-script/run_registration_load_test.sh
+++ b/test-script/run_registration_load_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MYSQL_SERVICE="${MYSQL_SERVICE:-mysql}"
+LOAD_TEST_DB_USER="${LOAD_TEST_DB_USER:-econo}"
+LOAD_TEST_DB_PASSWORD="${LOAD_TEST_DB_PASSWORD:-econo}"
+LOAD_TEST_DB_NAME="${LOAD_TEST_DB_NAME:-ticket}"
+K6_BIN="${K6_BIN:-k6}"
+K6_API_ADDRESS="${K6_API_ADDRESS:-127.0.0.1:0}"
+
+generate_run_id() {
+  local run_date
+  local last_sequence
+  local next_sequence
+
+  run_date="$(date +%Y%m%d)"
+  if ! last_sequence="$(
+    docker compose exec -T "${MYSQL_SERVICE}" \
+      mysql --default-character-set=utf8mb4 \
+      "-u${LOAD_TEST_DB_USER}" "-p${LOAD_TEST_DB_PASSWORD}" \
+      --batch --skip-column-names "${LOAD_TEST_DB_NAME}" \
+      -e "
+        SELECT COALESCE(
+          MAX(CAST(SUBSTRING_INDEX(SUBSTRING_INDEX(email, '-', 3), '-', -1) AS UNSIGNED)),
+          0
+        )
+        FROM user_tb
+        WHERE email REGEXP '^load-${run_date}-[0-9]+-[0-9]{6}@example[.]com$';" \
+      2>/dev/null
+  )"; then
+    echo "Failed to read the next load-test sequence from MySQL." >&2
+    echo "Check Docker Compose and LOAD_TEST_DB_* settings, or provide RUN_ID explicitly." >&2
+    exit 1
+  fi
+
+  if [[ ! "${last_sequence}" =~ ^[0-9]+$ ]]; then
+    echo "MySQL returned an invalid load-test sequence: ${last_sequence}" >&2
+    exit 1
+  fi
+
+  printf -v next_sequence '%02d' "$((10#${last_sequence} + 1))"
+  printf '%s-%s' "${run_date}" "${next_sequence}"
+}
+
+cd "${REPOSITORY_ROOT}"
+
+if [[ -z "${RUN_ID:-}" ]]; then
+  RUN_ID="$(generate_run_id)"
+fi
+
+if [[ ! "${RUN_ID}" =~ ^[A-Za-z0-9-]+$ ]]; then
+  echo "RUN_ID may contain only letters, numbers, and hyphens" >&2
+  exit 2
+fi
+
+export RUN_ID
+echo "Load-test RUN_ID=${RUN_ID}"
+
+exec "${K6_BIN}" run --address "${K6_API_ADDRESS}" "$@" "${SCRIPT_DIR}/k6_test_registration.js"

--- a/test-script/verify_registration_load_test.sh
+++ b/test-script/verify_registration_load_test.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MYSQL_SERVICE="${MYSQL_SERVICE:-mysql}"
+REDIS_SERVICE="${REDIS_SERVICE:-redis}"
+LOAD_TEST_DB_USER="${LOAD_TEST_DB_USER:-econo}"
+LOAD_TEST_DB_PASSWORD="${LOAD_TEST_DB_PASSWORD:-econo}"
+LOAD_TEST_DB_NAME="${LOAD_TEST_DB_NAME:-ticket}"
+SUMMARY_PATH="${SUMMARY_PATH:-test-script/registration-load-summary.json}"
+WAIT_TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-120}"
+summary_event_id=""
+summary_run_id=""
+
+if [[ -f "${SUMMARY_PATH}" ]] && command -v jq >/dev/null 2>&1; then
+  summary_event_id="$(jq -r '.metadata.eventId // empty' "${SUMMARY_PATH}")"
+  summary_run_id="$(jq -r '.metadata.runId // empty' "${SUMMARY_PATH}")"
+fi
+
+EVENT_ID="${EVENT_ID:-${summary_event_id}}"
+RUN_ID="${RUN_ID:-${summary_run_id}}"
+
+if [[ -z "${EVENT_ID}" || -z "${RUN_ID}" ]]; then
+  echo "EVENT_ID and RUN_ID are required." >&2
+  echo "Run the load test first, keep ${SUMMARY_PATH}, or provide both values explicitly." >&2
+  exit 2
+fi
+
+STREAM_KEY="쿠폰 발급 스트림:{${EVENT_ID}}"
+STREAM_GROUP="쿠폰 발급 그룹"
+
+if [[ ! "${EVENT_ID}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "EVENT_ID must be a positive integer" >&2
+  exit 2
+fi
+
+if [[ ! "${RUN_ID}" =~ ^[A-Za-z0-9-]+$ ]]; then
+  echo "RUN_ID may contain only letters, numbers, and hyphens" >&2
+  exit 2
+fi
+
+mysql_query() {
+  docker compose exec -T "${MYSQL_SERVICE}" \
+    mysql --default-character-set=utf8mb4 \
+    "-u${LOAD_TEST_DB_USER}" "-p${LOAD_TEST_DB_PASSWORD}" \
+    --batch --skip-column-names "${LOAD_TEST_DB_NAME}" \
+    -e "$1" 2>/dev/null
+}
+
+redis_command() {
+  docker compose exec -T "${REDIS_SERVICE}" redis-cli --raw "$@" 2>/dev/null
+}
+
+if [[ "$(redis_command PING || true)" != "PONG" ]]; then
+  echo "FAIL: Redis is unavailable; asynchronous state cannot be verified" >&2
+  exit 1
+fi
+
+assert_zero() {
+  local label="$1"
+  local value="$2"
+  if [[ "${value}" != "0" ]]; then
+    echo "FAIL: ${label} (${value})" >&2
+    failures=$((failures + 1))
+  else
+    echo "PASS: ${label}"
+  fi
+}
+
+stream_pending_count() {
+  local result
+  result="$(redis_command XPENDING "${STREAM_KEY}" "${STREAM_GROUP}" | head -n 1 || true)"
+  if [[ "${result}" =~ ^[0-9]+$ ]]; then
+    echo "${result}"
+  else
+    echo "0"
+  fi
+}
+
+echo "Waiting for Redis Stream consumer to commit and ACK all messages..."
+deadline=$((SECONDS + WAIT_TIMEOUT_SECONDS))
+while true; do
+  stream_length="$(redis_command XLEN "${STREAM_KEY}" || echo 0)"
+  pending_count="$(stream_pending_count)"
+  [[ "${stream_length}" =~ ^[0-9]+$ ]] || stream_length=0
+
+  if [[ "${stream_length}" == "0" && "${pending_count}" == "0" ]]; then
+    break
+  fi
+  if (( SECONDS >= deadline )); then
+    echo "FAIL: Redis Stream did not drain within ${WAIT_TIMEOUT_SECONDS}s (length=${stream_length}, pending=${pending_count})" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+expected_accepted="${EXPECTED_ACCEPTED:-}"
+if [[ -z "${expected_accepted}"
+  && "${summary_event_id}" == "${EVENT_ID}"
+  && "${summary_run_id}" == "${RUN_ID}" ]]; then
+  expected_accepted="$(jq -r '.result.accepted // empty' "${SUMMARY_PATH}")"
+fi
+
+email_pattern="load-${RUN_ID}-%@example.com"
+actual_accepted="$(mysql_query "
+  SELECT COUNT(*)
+  FROM registration_tb
+  WHERE event_id = ${EVENT_ID}
+    AND is_saved = 1
+    AND email LIKE '${email_pattern}';")"
+
+failures=0
+echo "Checking registrations for runId=${RUN_ID}, eventId=${EVENT_ID}..."
+
+if [[ "${summary_event_id}" == "${EVENT_ID}" && "${summary_run_id}" == "${RUN_ID}" ]]; then
+  failed_thresholds="$(jq -r '
+    .k6.metrics
+    | to_entries[]
+    | select(.value.thresholds != null)
+    | select([.value.thresholds[]?.ok] | any(. == false))
+    | .key
+  ' "${SUMMARY_PATH}")"
+  if [[ -z "${failed_thresholds}" ]]; then
+    echo "PASS: all k6 load thresholds passed"
+  else
+    while IFS= read -r failed_threshold; do
+      [[ -n "${failed_threshold}" ]] || continue
+      echo "FAIL: k6 threshold crossed (${failed_threshold})" >&2
+      failures=$((failures + 1))
+    done <<< "${failed_thresholds}"
+  fi
+else
+  echo "WARN: matching k6 summary unavailable; load thresholds were not verified" >&2
+fi
+
+if [[ -n "${expected_accepted}" ]]; then
+  if [[ "${actual_accepted}" == "${expected_accepted}" ]]; then
+    echo "PASS: persisted registrations match accepted HTTP responses (${actual_accepted})"
+  else
+    echo "FAIL: accepted HTTP responses=${expected_accepted}, persisted registrations=${actual_accepted}" >&2
+    failures=$((failures + 1))
+  fi
+else
+  echo "WARN: expected accepted count unavailable; set EXPECTED_ACCEPTED or keep ${SUMMARY_PATH}" >&2
+fi
+
+null_decisions="$(mysql_query "
+  SELECT COUNT(*)
+  FROM registration_tb
+  WHERE event_id = ${EVENT_ID}
+    AND email LIKE '${email_pattern}'
+    AND (position IS NULL OR result_status IS NULL OR sequence IS NULL);")"
+assert_zero "all persisted registrations have position, resultStatus, and sequence" "${null_decisions}"
+
+duplicate_positions="$(mysql_query "
+  SELECT COUNT(*)
+  FROM (
+    SELECT sector_id, position
+    FROM registration_tb
+    WHERE event_id = ${EVENT_ID}
+    GROUP BY sector_id, position
+    HAVING COUNT(*) > 1
+  ) duplicated;")"
+assert_zero "positions are unique within each sector" "${duplicate_positions}"
+
+non_contiguous_sectors="$(mysql_query "
+  SELECT COUNT(*)
+  FROM (
+    SELECT sector_id
+    FROM registration_tb
+    WHERE event_id = ${EVENT_ID}
+    GROUP BY sector_id
+    HAVING MIN(position) <> 1
+       OR MAX(position) <> COUNT(*)
+       OR COUNT(DISTINCT position) <> COUNT(*)
+  ) invalid_sector;")"
+assert_zero "positions are contiguous from 1 within each sector" "${non_contiguous_sectors}"
+
+invalid_decisions="$(mysql_query "
+  SELECT COUNT(*)
+  FROM registration_tb registration
+  JOIN sector ON sector.sector_id = registration.sector_id
+  WHERE registration.event_id = ${EVENT_ID}
+    AND registration.email LIKE '${email_pattern}'
+    AND (
+      (registration.position <= sector.init_sector_capacity
+        AND (registration.result_status <> '합격' OR registration.sequence <> -2))
+      OR
+      (registration.position > sector.init_sector_capacity
+        AND registration.position <= sector.issue_amount
+        AND (registration.result_status <> '예비'
+          OR registration.sequence <> registration.position - sector.init_sector_capacity))
+      OR registration.position > sector.issue_amount
+    );")"
+assert_zero "position maps to the intended success/reserve result" "${invalid_decisions}"
+
+invalid_outbox_counts="$(mysql_query "
+  SELECT COUNT(*)
+  FROM (
+    SELECT registration.id
+    FROM registration_tb registration
+    LEFT JOIN email_outbox outbox ON outbox.registration_id = registration.id
+    WHERE registration.event_id = ${EVENT_ID}
+      AND registration.email LIKE '${email_pattern}'
+    GROUP BY registration.id
+    HAVING COUNT(outbox.id) <> 1
+  ) invalid_outbox_count;")"
+assert_zero "every persisted registration has exactly one outbox row" "${invalid_outbox_counts}"
+
+mismatched_outboxes="$(mysql_query "
+  SELECT COUNT(*)
+  FROM registration_tb registration
+  JOIN email_outbox outbox ON outbox.registration_id = registration.id
+  WHERE registration.event_id = ${EVENT_ID}
+    AND registration.email LIKE '${email_pattern}'
+    AND (outbox.event_id <> registration.event_id
+      OR outbox.result_status <> registration.result_status
+      OR outbox.sequence <> registration.sequence);")"
+assert_zero "outbox result data matches registration result data" "${mismatched_outboxes}"
+
+user_result_mismatches="$(mysql_query "
+  SELECT COUNT(*)
+  FROM registration_tb registration
+  JOIN user_tb user ON user.user_id = registration.user_id
+  WHERE registration.event_id = ${EVENT_ID}
+    AND registration.email LIKE '${email_pattern}'
+    AND (user.status <> registration.result_status OR user.sequence <> registration.sequence);")"
+assert_zero "user result matches registration result" "${user_result_mismatches}"
+
+echo "Waiting for the scheduled Redis-to-DB stock sync..."
+deadline=$((SECONDS + WAIT_TIMEOUT_SECONDS))
+while true; do
+  stock_mismatches=0
+  while IFS=$'\t' read -r sector_id db_remaining; do
+    [[ -n "${sector_id}" ]] || continue
+    redis_remaining="$(redis_command GET "parking-ticket:event:{${EVENT_ID}}:sector:${sector_id}:stock" || true)"
+    if [[ -z "${redis_remaining}" || "${redis_remaining}" != "${db_remaining}" ]]; then
+      stock_mismatches=$((stock_mismatches + 1))
+    fi
+  done < <(mysql_query "
+    SELECT sector_id, remaining_amount
+    FROM sector
+    WHERE event_id = ${EVENT_ID} AND is_deleted = 0;")
+
+  if [[ "${stock_mismatches}" == "0" ]]; then
+    echo "PASS: Redis and DB remaining stock match"
+    break
+  fi
+  if (( SECONDS >= deadline )); then
+    echo "FAIL: Redis stock is missing or differs from DB in ${stock_mismatches} sector(s)" >&2
+    failures=$((failures + 1))
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${failures}" != "0" ]]; then
+  echo "Load-test verification failed with ${failures} problem(s)." >&2
+  exit 1
+fi
+
+echo "All asynchronous registration invariants passed (${actual_accepted} persisted registrations)."


### PR DESCRIPTION
## 주요 변경사항

> [!IMPORTANT]
> 이 PR은 `origin/dev` 기준으로 브랜치와 BE 번호 규칙을 다시 정리하면서 닫혔습니다. 같은 Issue #522의 현재 구현과 리뷰는 [PR #528](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/528)에서 진행합니다.

- 이벤트·구간별 Redis stock과 position을 사용합니다.
- Lua script에서 중복 확인, 재고 감소, 순번 증가, 결과 판정, Stream enqueue를 원자적으로 처리합니다.
- `issueAmount`를 합격과 예비를 합친 접수 상한으로 사용하고 재고가 없으면 DB 저장 전에 400 응답으로 차단합니다.
- Stream consumer는 Redis에서 확정된 position, resultStatus, sequence를 Registration과 Email Outbox에 저장합니다.
- 이벤트 종료 시 Redis 잔여여석을 DB와 동기화합니다.
- 3,000건 부하 테스트의 접수 상한, 순번 유일성, 결과 매핑, Outbox, DB/Redis 동기화를 검증합니다.

## 리뷰어에게...

- 이 닫힌 PR의 과거 diff와 설명은 리뷰 기준이 아닙니다.
- 최신 코드, 테스트 결과, Redis 장애 시 fail-closed 경계는 [PR #528](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/528) 본문을 확인해 주세요.

## 관련 이슈

- [Issue #522](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/issues/522)
- [대체 PR #528](https://github.com/JNU-Parking-Ticket-Project/Parking-Ticket-BE/pull/528)

## 체크리스트

- [x] 대체 PR 링크 명시
- [x] 현재 Redis 재고·순번 범위 반영
- [x] 관련 이슈 연결
